### PR TITLE
feat(acl): configure cargo test + clippy with compilation profiles (T-005)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,12 @@
     "format:check": "oxfmt --check .",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:rust": "cargo test --manifest-path src-tauri/Cargo.toml",
+    "lint:rust": "cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings",
+    "format:rust": "cargo fmt --manifest-path src-tauri/Cargo.toml",
+    "format:rust:check": "cargo fmt --manifest-path src-tauri/Cargo.toml --check",
+    "check": "npm run format:check && npm run format:rust:check && npm run lint && npm run lint:rust && npm run test && npm run test:rust"
   },
   "dependencies": {
     "@fontsource/ibm-plex-mono": "^5.2.7",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -8,8 +8,6 @@ repository = "https://github.com/mpiton/prism"
 edition = "2024"
 rust-version = "1.94"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [lib]
 name = "prism_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
@@ -23,3 +21,29 @@ serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
 tauri = { version = "2.10.3" }
 tauri-plugin-log = "2"
+
+[lints.clippy]
+pedantic = { level = "warn", priority = -1 }
+suspicious = { level = "warn", priority = -1 }
+perf = { level = "warn", priority = -1 }
+# Tauri commands often have many params; complex types are common in event-driven apps
+too_many_arguments = "allow"
+type_complexity = "allow"
+# Tauri generates code that triggers these
+module_name_repetitions = "allow"
+must_use_candidate = "allow"
+# Entry point run() uses .expect() intentionally — fatal if Tauri fails to start
+missing_panics_doc = "allow"
+
+[profile.dev]
+incremental = true
+opt-level = 0
+
+[profile.dev.package."*"]
+opt-level = 2
+
+[profile.release]
+lto = "thin"
+codegen-units = 1
+strip = "symbols"
+panic = "abort"

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-  tauri_build::build()
+    tauri_build::build();
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,16 +1,24 @@
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-  tauri::Builder::default()
-    .setup(|app| {
-      if cfg!(debug_assertions) {
-        app.handle().plugin(
-          tauri_plugin_log::Builder::default()
-            .level(log::LevelFilter::Info)
-            .build(),
-        )?;
-      }
-      Ok(())
-    })
-    .run(tauri::generate_context!())
-    .expect("error while running tauri application");
+    tauri::Builder::default()
+        .setup(|app| {
+            if cfg!(debug_assertions) {
+                app.handle().plugin(
+                    tauri_plugin_log::Builder::default()
+                        .level(log::LevelFilter::Info)
+                        .build(),
+                )?;
+            }
+            Ok(())
+        })
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_harness_runs_successfully() {
+        assert_eq!(1 + 1, 2, "Test harness is functional");
+    }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,5 +2,5 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
-  prism_lib::run();
+    prism_lib::run();
 }


### PR DESCRIPTION
## Summary

- Configure `cargo clippy` with **pedantic**, **suspicious**, and **perf** lint groups, with Tauri-specific exceptions (too_many_arguments, type_complexity, module_name_repetitions, must_use_candidate, missing_panics_doc)
- Add Cargo compilation profiles: **dev** (incremental, opt-level 2 for dependencies) and **release** (thin LTO, codegen-units 1, strip symbols, panic abort)
- Add smoke test in `src-tauri/src/lib.rs` to verify the Rust test harness runs
- Fix `rustfmt` formatting across all Rust files (2-space → 4-space indent standard)
- Add npm scripts for Rust toolchain: `test:rust`, `lint:rust`, `format:rust`, `format:rust:check`, and unified `check` script

## Design Decisions

| Decision | Rationale |
|----------|-----------|
| Thin LTO over Fat LTO | ~90% optimization gains for ~50% build time — good tradeoff for solo dev |
| `panic = "abort"` in release | Reduces binary size, eliminates unwind tables — appropriate for Tauri desktop |
| `[profile.dev.package."*"] opt-level = 2` | Optimizes heavy deps (serde, tauri) while keeping local code at opt-level 0 for fast iteration |
| Clippy `priority = -1` on groups | Allows individual lint exceptions to override group-level settings |
| `missing_panics_doc = "allow"` | Tauri entry point `run()` uses `.expect()` intentionally — panic is fatal and expected |

## Test Plan

- [x] `cargo test` — 1 test passing (smoke test)
- [x] `cargo clippy -- -D warnings` — 0 warnings, 0 errors
- [x] `cargo fmt --check` — all files formatted
- [x] `npm run test:rust` — passes from project root
- [x] `npm run lint:rust` — passes from project root
- [x] `npm run format:rust:check` — passes from project root

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Rust toolchain integration with new scripts for testing, linting, and formatting
  * Enhanced build optimization through new profile configurations
  * Updated the comprehensive check command to validate both JavaScript and Rust ecosystems

* **Tests**
  * Added unit test coverage for core harness functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->