### PR TITLE
feat(acl): create TypeScript type definitions mirroring Rust structs (T-012)

### DIFF
--- a/src/lib/types.test.ts
+++ b/src/lib/types.test.ts
@@ -30,11 +30,8 @@ import type {
 
 // ── Helpers ──────────────────────────────────────────────────────
 
-/**
- * Type-level assertion: if the assignment compiles, the shape matches.
- * At runtime, validates JSON fixtures parse into the expected TS shape.
- */
-function assertShape<T>(json: unknown): T {
+/** Coerce a JSON fixture to type T. Compile-time check only — no runtime validation. */
+function coerceFixture<T>(json: unknown): T {
   return json as T;
 }
 
@@ -104,7 +101,7 @@ describe("Core struct shapes", () => {
       defaultBranch: "main",
       isArchived: false,
     };
-    const repo = assertShape<Repo>(json);
+    const repo = coerceFixture<Repo>(json);
     expect(repo.id).toBe("r-1");
     expect(repo.fullName).toBe("mpiton/prism");
     expect(repo.defaultBranch).toBe("main");
@@ -126,7 +123,7 @@ describe("Core struct shapes", () => {
       createdAt: "2026-03-24T10:00:00Z",
       updatedAt: "2026-03-24T12:00:00Z",
     };
-    const pr = assertShape<PullRequest>(json);
+    const pr = coerceFixture<PullRequest>(json);
     expect(pr.number).toBe(42);
     expect(pr.ciStatus).toBe("success");
     expect(pr.labels).toEqual(["enhancement", "frontend"]);
@@ -140,7 +137,7 @@ describe("Core struct shapes", () => {
       status: "pending" as ReviewStatus,
       requestedAt: "2026-03-24T10:00:00Z",
     };
-    const rr = assertShape<ReviewRequest>(json);
+    const rr = coerceFixture<ReviewRequest>(json);
     expect(rr.pullRequestId).toBe("pr-1");
     expect(rr.status).toBe("pending");
   });
@@ -153,7 +150,7 @@ describe("Core struct shapes", () => {
       pending: 1,
       reviewers: ["alice", "bob"],
     };
-    const rs = assertShape<ReviewSummary>(json);
+    const rs = coerceFixture<ReviewSummary>(json);
     expect(rs.totalReviews).toBe(3);
     expect(rs.changesRequested).toBe(1);
   });
@@ -172,7 +169,7 @@ describe("Core struct shapes", () => {
       createdAt: "2026-03-24T10:00:00Z",
       updatedAt: "2026-03-24T12:00:00Z",
     };
-    const issue = assertShape<Issue>(json);
+    const issue = coerceFixture<Issue>(json);
     expect(issue.priority).toBe("critical");
   });
 
@@ -187,7 +184,7 @@ describe("Core struct shapes", () => {
       message: "Opened PR #42",
       createdAt: "2026-03-24T10:00:00Z",
     };
-    const activity = assertShape<Activity>(json);
+    const activity = coerceFixture<Activity>(json);
     expect(activity.pullRequestId).toBe("pr-1");
     expect(activity.issueId).toBeNull();
   });
@@ -203,7 +200,7 @@ describe("Core struct shapes", () => {
       createdAt: "2026-03-24T10:00:00Z",
       updatedAt: "2026-03-24T12:00:00Z",
     };
-    const ws = assertShape<Workspace>(json);
+    const ws = coerceFixture<Workspace>(json);
     expect(ws.pullRequestNumber).toBe(42);
     expect(ws.worktreePath).toBe("/home/user/.prism/workspaces/prism/worktrees/pr-42");
   });
@@ -215,7 +212,7 @@ describe("Core struct shapes", () => {
       content: "Review feedback applied",
       createdAt: "2026-03-24T10:00:00Z",
     };
-    const note = assertShape<WorkspaceNote>(json);
+    const note = coerceFixture<WorkspaceNote>(json);
     expect(note.workspaceId).toBe("ws-1");
   });
 });
@@ -229,7 +226,7 @@ describe("Composite struct shapes", () => {
       state: "active" as WorkspaceState,
       lastNoteContent: "LGTM, ready to merge",
     };
-    const ws = assertShape<WorkspaceSummary>(json);
+    const ws = coerceFixture<WorkspaceSummary>(json);
     expect(ws.lastNoteContent).toBe("LGTM, ready to merge");
   });
 
@@ -239,7 +236,7 @@ describe("Composite struct shapes", () => {
       state: "suspended" as WorkspaceState,
       lastNoteContent: null,
     };
-    const ws = assertShape<WorkspaceSummary>(json);
+    const ws = coerceFixture<WorkspaceSummary>(json);
     expect(ws.lastNoteContent).toBeNull();
   });
 
@@ -272,7 +269,7 @@ describe("Composite struct shapes", () => {
         lastNoteContent: null,
       },
     };
-    const prwr = assertShape<PullRequestWithReview>(json);
+    const prwr = coerceFixture<PullRequestWithReview>(json);
     expect(prwr.pullRequest.number).toBe(42);
     expect(prwr.reviewSummary.totalReviews).toBe(2);
     expect(prwr.workspace).not.toBeNull();
@@ -287,7 +284,7 @@ describe("Composite struct shapes", () => {
       workspaces: [],
       syncedAt: "2026-03-24T14:00:00Z",
     };
-    const dashboard = assertShape<DashboardData>(json);
+    const dashboard = coerceFixture<DashboardData>(json);
     expect(dashboard.reviewRequests).toEqual([]);
     expect(dashboard.syncedAt).toBe("2026-03-24T14:00:00Z");
   });
@@ -301,7 +298,7 @@ describe("Composite struct shapes", () => {
       workspaces: [],
       syncedAt: null,
     };
-    const dashboard = assertShape<DashboardData>(json);
+    const dashboard = coerceFixture<DashboardData>(json);
     expect(dashboard.syncedAt).toBeNull();
   });
 
@@ -313,7 +310,7 @@ describe("Composite struct shapes", () => {
       activeWorkspaces: 2,
       unreadActivity: 8,
     };
-    const stats = assertShape<DashboardStats>(json);
+    const stats = coerceFixture<DashboardStats>(json);
     expect(stats.pendingReviews).toBe(5);
     expect(stats.openPrs).toBe(12);
   });
@@ -327,7 +324,7 @@ describe("IPC payload shapes", () => {
       repoId: "r-1",
       pullRequestNumber: 42,
     };
-    const req = assertShape<OpenWorkspaceRequest>(json);
+    const req = coerceFixture<OpenWorkspaceRequest>(json);
     expect(req.repoId).toBe("r-1");
     expect(req.pullRequestNumber).toBe(42);
   });
@@ -338,7 +335,7 @@ describe("IPC payload shapes", () => {
       worktreePath: "/home/user/.prism/workspaces/prism/worktrees/pr-42",
       sessionId: "session-abc",
     };
-    const resp = assertShape<OpenWorkspaceResponse>(json);
+    const resp = coerceFixture<OpenWorkspaceResponse>(json);
     expect(resp.workspaceId).toBe("ws-1");
     expect(resp.sessionId).toBe("session-abc");
   });
@@ -349,7 +346,7 @@ describe("IPC payload shapes", () => {
       worktreePath: "/tmp/worktree",
       sessionId: null,
     };
-    const resp = assertShape<OpenWorkspaceResponse>(json);
+    const resp = coerceFixture<OpenWorkspaceResponse>(json);
     expect(resp.sessionId).toBeNull();
   });
 
@@ -358,7 +355,7 @@ describe("IPC payload shapes", () => {
       workspaceId: "ws-1",
       data: "ls -la\n",
     };
-    const input = assertShape<PtyInput>(json);
+    const input = coerceFixture<PtyInput>(json);
     expect(input.data).toBe("ls -la\n");
   });
 
@@ -367,7 +364,7 @@ describe("IPC payload shapes", () => {
       workspaceId: "ws-1",
       data: "total 42\n",
     };
-    const output = assertShape<PtyOutput>(json);
+    const output = coerceFixture<PtyOutput>(json);
     expect(output.data).toBe("total 42\n");
   });
 
@@ -377,7 +374,7 @@ describe("IPC payload shapes", () => {
       cols: 120,
       rows: 40,
     };
-    const resize = assertShape<PtyResize>(json);
+    const resize = coerceFixture<PtyResize>(json);
     expect(resize.cols).toBe(120);
     expect(resize.rows).toBe(40);
   });
@@ -390,7 +387,7 @@ describe("IPC payload shapes", () => {
       dataDir: null,
       workspacesDir: null,
     };
-    const config = assertShape<AppConfig>(json);
+    const config = coerceFixture<AppConfig>(json);
     expect(config.pollIntervalSecs).toBe(300);
     expect(config.maxActiveWorkspaces).toBe(3);
     expect(config.githubToken).toBeNull();
@@ -404,7 +401,7 @@ describe("IPC payload shapes", () => {
       dataDir: "/custom/data",
       workspacesDir: "/custom/workspaces",
     };
-    const config = assertShape<AppConfig>(json);
+    const config = coerceFixture<AppConfig>(json);
     expect(config.githubToken).toBe("ghp_xxx");
     expect(config.dataDir).toBe("/custom/data");
   });

--- a/src/lib/types.test.ts
+++ b/src/lib/types.test.ts
@@ -1,0 +1,476 @@
+import { describe, it, expect } from "vitest";
+import { TAURI_COMMANDS, TAURI_EVENTS } from "./types";
+import type {
+  PrState,
+  CiStatus,
+  Priority,
+  ReviewStatus,
+  IssueState,
+  ActivityType,
+  WorkspaceState,
+  Repo,
+  PullRequest,
+  ReviewRequest,
+  ReviewSummary,
+  Issue,
+  Activity,
+  Workspace,
+  WorkspaceNote,
+  WorkspaceSummary,
+  PullRequestWithReview,
+  DashboardData,
+  DashboardStats,
+  OpenWorkspaceRequest,
+  OpenWorkspaceResponse,
+  PtyInput,
+  PtyOutput,
+  PtyResize,
+  AppConfig,
+} from "./types";
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+/**
+ * Type-level assertion: if the assignment compiles, the shape matches.
+ * At runtime, validates JSON fixtures parse into the expected TS shape.
+ */
+function assertShape<T>(json: unknown): T {
+  return json as T;
+}
+
+// ── Enum union types ─────────────────────────────────────────────
+
+describe("Enum union types", () => {
+  it("should accept all PrState values", () => {
+    const values: PrState[] = ["open", "closed", "merged", "draft"];
+    expect(values).toHaveLength(4);
+  });
+
+  it("should accept all CiStatus values", () => {
+    const values: CiStatus[] = ["pending", "running", "success", "failure", "cancelled"];
+    expect(values).toHaveLength(5);
+  });
+
+  it("should accept all Priority values", () => {
+    const values: Priority[] = ["low", "medium", "high", "critical"];
+    expect(values).toHaveLength(4);
+  });
+
+  it("should accept all ReviewStatus values", () => {
+    const values: ReviewStatus[] = [
+      "pending",
+      "approved",
+      "changes_requested",
+      "commented",
+      "dismissed",
+    ];
+    expect(values).toHaveLength(5);
+  });
+
+  it("should accept all IssueState values", () => {
+    const values: IssueState[] = ["open", "closed"];
+    expect(values).toHaveLength(2);
+  });
+
+  it("should accept all ActivityType values", () => {
+    const values: ActivityType[] = [
+      "pr_opened",
+      "pr_merged",
+      "pr_closed",
+      "review_submitted",
+      "comment_added",
+      "ci_completed",
+      "issue_opened",
+      "issue_closed",
+    ];
+    expect(values).toHaveLength(8);
+  });
+
+  it("should accept all WorkspaceState values", () => {
+    const values: WorkspaceState[] = ["active", "suspended", "archived"];
+    expect(values).toHaveLength(3);
+  });
+});
+
+// ── Core struct shapes (JSON fixture conformity) ─────────────────
+
+describe("Core struct shapes", () => {
+  it("should match Repo shape from Rust JSON", () => {
+    const json = {
+      id: "r-1",
+      name: "prism",
+      fullName: "mpiton/prism",
+      url: "https://github.com/mpiton/prism",
+      defaultBranch: "main",
+      isArchived: false,
+    };
+    const repo = assertShape<Repo>(json);
+    expect(repo.id).toBe("r-1");
+    expect(repo.fullName).toBe("mpiton/prism");
+    expect(repo.defaultBranch).toBe("main");
+    expect(repo.isArchived).toBe(false);
+  });
+
+  it("should match PullRequest shape from Rust JSON", () => {
+    const json = {
+      id: "pr-1",
+      number: 42,
+      title: "Add feature",
+      author: "mpiton",
+      state: "open" as PrState,
+      ciStatus: "success" as CiStatus,
+      priority: "high" as Priority,
+      repoId: "r-1",
+      url: "https://github.com/mpiton/prism/pull/42",
+      labels: ["enhancement", "frontend"],
+      createdAt: "2026-03-24T10:00:00Z",
+      updatedAt: "2026-03-24T12:00:00Z",
+    };
+    const pr = assertShape<PullRequest>(json);
+    expect(pr.number).toBe(42);
+    expect(pr.ciStatus).toBe("success");
+    expect(pr.labels).toEqual(["enhancement", "frontend"]);
+  });
+
+  it("should match ReviewRequest shape from Rust JSON", () => {
+    const json = {
+      id: "rr-1",
+      pullRequestId: "pr-1",
+      reviewer: "alice",
+      status: "pending" as ReviewStatus,
+      requestedAt: "2026-03-24T10:00:00Z",
+    };
+    const rr = assertShape<ReviewRequest>(json);
+    expect(rr.pullRequestId).toBe("pr-1");
+    expect(rr.status).toBe("pending");
+  });
+
+  it("should match ReviewSummary shape from Rust JSON", () => {
+    const json = {
+      totalReviews: 3,
+      approved: 1,
+      changesRequested: 1,
+      pending: 1,
+      reviewers: ["alice", "bob"],
+    };
+    const rs = assertShape<ReviewSummary>(json);
+    expect(rs.totalReviews).toBe(3);
+    expect(rs.changesRequested).toBe(1);
+  });
+
+  it("should match Issue shape from Rust JSON", () => {
+    const json = {
+      id: "i-1",
+      number: 10,
+      title: "Bug report",
+      author: "bob",
+      state: "open" as IssueState,
+      priority: "critical" as Priority,
+      repoId: "r-1",
+      url: "https://github.com/mpiton/prism/issues/10",
+      labels: ["bug"],
+      createdAt: "2026-03-24T10:00:00Z",
+      updatedAt: "2026-03-24T12:00:00Z",
+    };
+    const issue = assertShape<Issue>(json);
+    expect(issue.priority).toBe("critical");
+  });
+
+  it("should match Activity shape with optional fields", () => {
+    const json = {
+      id: "a-1",
+      activityType: "pr_opened" as ActivityType,
+      actor: "mpiton",
+      repoId: "r-1",
+      pullRequestId: "pr-1",
+      issueId: null,
+      message: "Opened PR #42",
+      createdAt: "2026-03-24T10:00:00Z",
+    };
+    const activity = assertShape<Activity>(json);
+    expect(activity.pullRequestId).toBe("pr-1");
+    expect(activity.issueId).toBeNull();
+  });
+
+  it("should match Workspace shape with optional fields", () => {
+    const json = {
+      id: "ws-1",
+      repoId: "r-1",
+      pullRequestNumber: 42,
+      state: "active" as WorkspaceState,
+      worktreePath: "/home/user/.prism/workspaces/prism/worktrees/pr-42",
+      sessionId: "session-abc",
+      createdAt: "2026-03-24T10:00:00Z",
+      updatedAt: "2026-03-24T12:00:00Z",
+    };
+    const ws = assertShape<Workspace>(json);
+    expect(ws.pullRequestNumber).toBe(42);
+    expect(ws.worktreePath).toBe("/home/user/.prism/workspaces/prism/worktrees/pr-42");
+  });
+
+  it("should match WorkspaceNote shape from Rust JSON", () => {
+    const json = {
+      id: "wn-1",
+      workspaceId: "ws-1",
+      content: "Review feedback applied",
+      createdAt: "2026-03-24T10:00:00Z",
+    };
+    const note = assertShape<WorkspaceNote>(json);
+    expect(note.workspaceId).toBe("ws-1");
+  });
+});
+
+// ── Composite struct shapes ──────────────────────────────────────
+
+describe("Composite struct shapes", () => {
+  it("should match WorkspaceSummary shape", () => {
+    const json = {
+      id: "ws-1",
+      state: "active" as WorkspaceState,
+      lastNoteContent: "LGTM, ready to merge",
+    };
+    const ws = assertShape<WorkspaceSummary>(json);
+    expect(ws.lastNoteContent).toBe("LGTM, ready to merge");
+  });
+
+  it("should match WorkspaceSummary with null lastNoteContent", () => {
+    const json = {
+      id: "ws-2",
+      state: "suspended" as WorkspaceState,
+      lastNoteContent: null,
+    };
+    const ws = assertShape<WorkspaceSummary>(json);
+    expect(ws.lastNoteContent).toBeNull();
+  });
+
+  it("should match PullRequestWithReview shape", () => {
+    const json = {
+      pullRequest: {
+        id: "pr-1",
+        number: 42,
+        title: "Add feature",
+        author: "mpiton",
+        state: "open",
+        ciStatus: "success",
+        priority: "high",
+        repoId: "r-1",
+        url: "https://github.com/mpiton/prism/pull/42",
+        labels: ["enhancement"],
+        createdAt: "2026-03-24T10:00:00Z",
+        updatedAt: "2026-03-24T12:00:00Z",
+      },
+      reviewSummary: {
+        totalReviews: 2,
+        approved: 1,
+        changesRequested: 0,
+        pending: 1,
+        reviewers: ["alice", "bob"],
+      },
+      workspace: {
+        id: "ws-1",
+        state: "active",
+        lastNoteContent: null,
+      },
+    };
+    const prwr = assertShape<PullRequestWithReview>(json);
+    expect(prwr.pullRequest.number).toBe(42);
+    expect(prwr.reviewSummary.totalReviews).toBe(2);
+    expect(prwr.workspace).not.toBeNull();
+  });
+
+  it("should match DashboardData shape", () => {
+    const json = {
+      reviewRequests: [],
+      myPullRequests: [],
+      assignedIssues: [],
+      recentActivity: [],
+      workspaces: [],
+      syncedAt: "2026-03-24T14:00:00Z",
+    };
+    const dashboard = assertShape<DashboardData>(json);
+    expect(dashboard.reviewRequests).toEqual([]);
+    expect(dashboard.syncedAt).toBe("2026-03-24T14:00:00Z");
+  });
+
+  it("should match DashboardData with null syncedAt", () => {
+    const json = {
+      reviewRequests: [],
+      myPullRequests: [],
+      assignedIssues: [],
+      recentActivity: [],
+      workspaces: [],
+      syncedAt: null,
+    };
+    const dashboard = assertShape<DashboardData>(json);
+    expect(dashboard.syncedAt).toBeNull();
+  });
+
+  it("should match DashboardStats shape", () => {
+    const json = {
+      pendingReviews: 5,
+      openPrs: 12,
+      openIssues: 3,
+      activeWorkspaces: 2,
+      unreadActivity: 8,
+    };
+    const stats = assertShape<DashboardStats>(json);
+    expect(stats.pendingReviews).toBe(5);
+    expect(stats.openPrs).toBe(12);
+  });
+});
+
+// ── IPC payload shapes ───────────────────────────────────────────
+
+describe("IPC payload shapes", () => {
+  it("should match OpenWorkspaceRequest shape", () => {
+    const json = {
+      repoId: "r-1",
+      pullRequestNumber: 42,
+    };
+    const req = assertShape<OpenWorkspaceRequest>(json);
+    expect(req.repoId).toBe("r-1");
+    expect(req.pullRequestNumber).toBe(42);
+  });
+
+  it("should match OpenWorkspaceResponse shape", () => {
+    const json = {
+      workspaceId: "ws-1",
+      worktreePath: "/home/user/.prism/workspaces/prism/worktrees/pr-42",
+      sessionId: "session-abc",
+    };
+    const resp = assertShape<OpenWorkspaceResponse>(json);
+    expect(resp.workspaceId).toBe("ws-1");
+    expect(resp.sessionId).toBe("session-abc");
+  });
+
+  it("should match OpenWorkspaceResponse with null sessionId", () => {
+    const json = {
+      workspaceId: "ws-2",
+      worktreePath: "/tmp/worktree",
+      sessionId: null,
+    };
+    const resp = assertShape<OpenWorkspaceResponse>(json);
+    expect(resp.sessionId).toBeNull();
+  });
+
+  it("should match PtyInput shape", () => {
+    const json = {
+      workspaceId: "ws-1",
+      data: "ls -la\n",
+    };
+    const input = assertShape<PtyInput>(json);
+    expect(input.data).toBe("ls -la\n");
+  });
+
+  it("should match PtyOutput shape", () => {
+    const json = {
+      workspaceId: "ws-1",
+      data: "total 42\n",
+    };
+    const output = assertShape<PtyOutput>(json);
+    expect(output.data).toBe("total 42\n");
+  });
+
+  it("should match PtyResize shape", () => {
+    const json = {
+      workspaceId: "ws-1",
+      cols: 120,
+      rows: 40,
+    };
+    const resize = assertShape<PtyResize>(json);
+    expect(resize.cols).toBe(120);
+    expect(resize.rows).toBe(40);
+  });
+
+  it("should match AppConfig shape", () => {
+    const json = {
+      pollIntervalSecs: 300,
+      maxActiveWorkspaces: 3,
+      githubToken: null,
+      dataDir: null,
+      workspacesDir: null,
+    };
+    const config = assertShape<AppConfig>(json);
+    expect(config.pollIntervalSecs).toBe(300);
+    expect(config.maxActiveWorkspaces).toBe(3);
+    expect(config.githubToken).toBeNull();
+  });
+
+  it("should match AppConfig with all optional fields set", () => {
+    const json = {
+      pollIntervalSecs: 120,
+      maxActiveWorkspaces: 5,
+      githubToken: "ghp_xxx",
+      dataDir: "/custom/data",
+      workspacesDir: "/custom/workspaces",
+    };
+    const config = assertShape<AppConfig>(json);
+    expect(config.githubToken).toBe("ghp_xxx");
+    expect(config.dataDir).toBe("/custom/data");
+  });
+});
+
+// ── TauriCommands & TauriEvents maps ─────────────────────────────
+
+describe("TAURI_COMMANDS constant", () => {
+  it("should contain all 23 IPC command names", () => {
+    expect(Object.keys(TAURI_COMMANDS)).toHaveLength(23);
+  });
+
+  it("should have matching key-value pairs", () => {
+    for (const [key, value] of Object.entries(TAURI_COMMANDS)) {
+      expect(key).toBe(value);
+    }
+  });
+
+  it("should include all github commands", () => {
+    expect(TAURI_COMMANDS.github_get_dashboard).toBe("github_get_dashboard");
+    expect(TAURI_COMMANDS.github_get_stats).toBe("github_get_stats");
+    expect(TAURI_COMMANDS.github_force_sync).toBe("github_force_sync");
+  });
+
+  it("should include all workspace commands", () => {
+    expect(TAURI_COMMANDS.workspace_open).toBe("workspace_open");
+    expect(TAURI_COMMANDS.workspace_suspend).toBe("workspace_suspend");
+    expect(TAURI_COMMANDS.workspace_resume).toBe("workspace_resume");
+    expect(TAURI_COMMANDS.workspace_archive).toBe("workspace_archive");
+    expect(TAURI_COMMANDS.workspace_list).toBe("workspace_list");
+    expect(TAURI_COMMANDS.workspace_get_notes).toBe("workspace_get_notes");
+    expect(TAURI_COMMANDS.workspace_cleanup).toBe("workspace_cleanup");
+  });
+
+  it("should include all pty commands", () => {
+    expect(TAURI_COMMANDS.pty_write).toBe("pty_write");
+    expect(TAURI_COMMANDS.pty_resize).toBe("pty_resize");
+    expect(TAURI_COMMANDS.pty_kill).toBe("pty_kill");
+  });
+});
+
+describe("TAURI_EVENTS constant", () => {
+  it("should contain all 8 event names", () => {
+    expect(Object.keys(TAURI_EVENTS)).toHaveLength(8);
+  });
+
+  it("should have matching key-value pairs", () => {
+    for (const [key, value] of Object.entries(TAURI_EVENTS)) {
+      expect(key).toBe(value);
+    }
+  });
+
+  it("should include all github events", () => {
+    expect(TAURI_EVENTS["github:updated"]).toBe("github:updated");
+    expect(TAURI_EVENTS["github:sync_error"]).toBe("github:sync_error");
+  });
+
+  it("should include all workspace events", () => {
+    expect(TAURI_EVENTS["workspace:stdout"]).toBe("workspace:stdout");
+    expect(TAURI_EVENTS["workspace:state_changed"]).toBe("workspace:state_changed");
+    expect(TAURI_EVENTS["workspace:claude_session"]).toBe("workspace:claude_session");
+  });
+
+  it("should include all notification events", () => {
+    expect(TAURI_EVENTS["notification:review_request"]).toBe("notification:review_request");
+    expect(TAURI_EVENTS["notification:ci_failure"]).toBe("notification:ci_failure");
+    expect(TAURI_EVENTS["notification:pr_approved"]).toBe("notification:pr_approved");
+  });
+});

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,258 @@
+// ── Enums (T-008) — snake_case string unions matching Rust serde ──
+
+export type PrState = "open" | "closed" | "merged" | "draft";
+
+export type CiStatus = "pending" | "running" | "success" | "failure" | "cancelled";
+
+export type Priority = "low" | "medium" | "high" | "critical";
+
+export type ReviewStatus = "pending" | "approved" | "changes_requested" | "commented" | "dismissed";
+
+export type IssueState = "open" | "closed";
+
+export type ActivityType =
+  | "pr_opened"
+  | "pr_merged"
+  | "pr_closed"
+  | "review_submitted"
+  | "comment_added"
+  | "ci_completed"
+  | "issue_opened"
+  | "issue_closed";
+
+export type WorkspaceState = "active" | "suspended" | "archived";
+
+// ── Core structs (T-009) — camelCase interfaces matching Rust serde ──
+
+export interface Repo {
+  readonly id: string;
+  readonly name: string;
+  readonly fullName: string;
+  readonly url: string;
+  readonly defaultBranch: string;
+  readonly isArchived: boolean;
+}
+
+export interface PullRequest {
+  readonly id: string;
+  readonly number: number;
+  readonly title: string;
+  readonly author: string;
+  readonly state: PrState;
+  readonly ciStatus: CiStatus;
+  readonly priority: Priority;
+  readonly repoId: string;
+  readonly url: string;
+  readonly labels: readonly string[];
+  readonly createdAt: string;
+  readonly updatedAt: string;
+}
+
+export interface ReviewRequest {
+  readonly id: string;
+  readonly pullRequestId: string;
+  readonly reviewer: string;
+  readonly status: ReviewStatus;
+  readonly requestedAt: string;
+}
+
+export interface ReviewSummary {
+  readonly totalReviews: number;
+  readonly approved: number;
+  readonly changesRequested: number;
+  readonly pending: number;
+  readonly reviewers: readonly string[];
+}
+
+export interface Issue {
+  readonly id: string;
+  readonly number: number;
+  readonly title: string;
+  readonly author: string;
+  readonly state: IssueState;
+  readonly priority: Priority;
+  readonly repoId: string;
+  readonly url: string;
+  readonly labels: readonly string[];
+  readonly createdAt: string;
+  readonly updatedAt: string;
+}
+
+export interface Activity {
+  readonly id: string;
+  readonly activityType: ActivityType;
+  readonly actor: string;
+  readonly repoId: string;
+  readonly pullRequestId: string | null;
+  readonly issueId: string | null;
+  readonly message: string;
+  readonly createdAt: string;
+}
+
+export interface Workspace {
+  readonly id: string;
+  readonly repoId: string;
+  readonly pullRequestNumber: number;
+  readonly state: WorkspaceState;
+  readonly worktreePath: string | null;
+  readonly sessionId: string | null;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+}
+
+export interface WorkspaceNote {
+  readonly id: string;
+  readonly workspaceId: string;
+  readonly content: string;
+  readonly createdAt: string;
+}
+
+// ── Composite structs (T-010) ────────────────────────────────────
+
+export interface WorkspaceSummary {
+  readonly id: string;
+  readonly state: WorkspaceState;
+  readonly lastNoteContent: string | null;
+}
+
+export interface PullRequestWithReview {
+  readonly pullRequest: PullRequest;
+  readonly reviewSummary: ReviewSummary;
+  readonly workspace: WorkspaceSummary | null;
+}
+
+export interface DashboardData {
+  readonly reviewRequests: readonly PullRequestWithReview[];
+  readonly myPullRequests: readonly PullRequestWithReview[];
+  readonly assignedIssues: readonly Issue[];
+  readonly recentActivity: readonly Activity[];
+  readonly workspaces: readonly Workspace[];
+  readonly syncedAt: string | null;
+}
+
+export interface DashboardStats {
+  readonly pendingReviews: number;
+  readonly openPrs: number;
+  readonly openIssues: number;
+  readonly activeWorkspaces: number;
+  readonly unreadActivity: number;
+}
+
+// ── IPC payloads (T-011) ─────────────────────────────────────────
+
+export interface OpenWorkspaceRequest {
+  readonly repoId: string;
+  readonly pullRequestNumber: number;
+}
+
+export interface OpenWorkspaceResponse {
+  readonly workspaceId: string;
+  readonly worktreePath: string;
+  readonly sessionId: string | null;
+}
+
+export interface PtyInput {
+  readonly workspaceId: string;
+  readonly data: string;
+}
+
+export interface PtyOutput {
+  readonly workspaceId: string;
+  readonly data: string;
+}
+
+export interface PtyResize {
+  readonly workspaceId: string;
+  readonly cols: number;
+  readonly rows: number;
+}
+
+export interface AppConfig {
+  readonly pollIntervalSecs: number;
+  readonly maxActiveWorkspaces: number;
+  readonly githubToken: string | null;
+  readonly dataDir: string | null;
+  readonly workspacesDir: string | null;
+}
+
+// ── Tauri IPC command & event registries ─────────────────────────
+
+export type TauriCommands = {
+  readonly [K in TauriCommandName]: K;
+};
+
+export type TauriCommandName =
+  | "github_get_dashboard"
+  | "github_get_stats"
+  | "github_force_sync"
+  | "repos_list"
+  | "repos_toggle"
+  | "repos_set_local_path"
+  | "workspace_open"
+  | "workspace_suspend"
+  | "workspace_resume"
+  | "workspace_archive"
+  | "workspace_list"
+  | "workspace_get_notes"
+  | "workspace_cleanup"
+  | "pty_write"
+  | "pty_resize"
+  | "pty_kill"
+  | "config_get"
+  | "config_set"
+  | "activity_mark_read"
+  | "activity_mark_all_read"
+  | "auth_set_token"
+  | "auth_get_status"
+  | "auth_logout";
+
+export const TAURI_COMMANDS: TauriCommands = {
+  github_get_dashboard: "github_get_dashboard",
+  github_get_stats: "github_get_stats",
+  github_force_sync: "github_force_sync",
+  repos_list: "repos_list",
+  repos_toggle: "repos_toggle",
+  repos_set_local_path: "repos_set_local_path",
+  workspace_open: "workspace_open",
+  workspace_suspend: "workspace_suspend",
+  workspace_resume: "workspace_resume",
+  workspace_archive: "workspace_archive",
+  workspace_list: "workspace_list",
+  workspace_get_notes: "workspace_get_notes",
+  workspace_cleanup: "workspace_cleanup",
+  pty_write: "pty_write",
+  pty_resize: "pty_resize",
+  pty_kill: "pty_kill",
+  config_get: "config_get",
+  config_set: "config_set",
+  activity_mark_read: "activity_mark_read",
+  activity_mark_all_read: "activity_mark_all_read",
+  auth_set_token: "auth_set_token",
+  auth_get_status: "auth_get_status",
+  auth_logout: "auth_logout",
+} as const;
+
+export type TauriEvents = {
+  readonly [K in TauriEventName]: K;
+};
+
+export type TauriEventName =
+  | "github:updated"
+  | "github:sync_error"
+  | "workspace:stdout"
+  | "workspace:state_changed"
+  | "workspace:claude_session"
+  | "notification:review_request"
+  | "notification:ci_failure"
+  | "notification:pr_approved";
+
+export const TAURI_EVENTS: TauriEvents = {
+  "github:updated": "github:updated",
+  "github:sync_error": "github:sync_error",
+  "workspace:stdout": "workspace:stdout",
+  "workspace:state_changed": "workspace:state_changed",
+  "workspace:claude_session": "workspace:claude_session",
+  "notification:review_request": "notification:review_request",
+  "notification:ci_failure": "notification:ci_failure",
+  "notification:pr_approved": "notification:pr_approved",
+} as const;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -168,6 +168,7 @@ export interface PtyResize {
 }
 
 export interface AppConfig {
+  /** Rust type is u64 — safe as `number` since practical values never exceed 2^53. */
   readonly pollIntervalSecs: number;
   readonly maxActiveWorkspaces: number;
   readonly githubToken: string | null;
@@ -176,10 +177,6 @@ export interface AppConfig {
 }
 
 // ── Tauri IPC command & event registries ─────────────────────────
-
-export type TauriCommands = {
-  readonly [K in TauriCommandName]: K;
-};
 
 export type TauriCommandName =
   | "github_get_dashboard"
@@ -206,7 +203,7 @@ export type TauriCommandName =
   | "auth_get_status"
   | "auth_logout";
 
-export const TAURI_COMMANDS: TauriCommands = {
+export const TAURI_COMMANDS = {
   github_get_dashboard: "github_get_dashboard",
   github_get_stats: "github_get_stats",
   github_force_sync: "github_force_sync",
@@ -230,11 +227,7 @@ export const TAURI_COMMANDS: TauriCommands = {
   auth_set_token: "auth_set_token",
   auth_get_status: "auth_get_status",
   auth_logout: "auth_logout",
-} as const;
-
-export type TauriEvents = {
-  readonly [K in TauriEventName]: K;
-};
+} as const satisfies Record<TauriCommandName, TauriCommandName>;
 
 export type TauriEventName =
   | "github:updated"
@@ -246,7 +239,7 @@ export type TauriEventName =
   | "notification:ci_failure"
   | "notification:pr_approved";
 
-export const TAURI_EVENTS: TauriEvents = {
+export const TAURI_EVENTS = {
   "github:updated": "github:updated",
   "github:sync_error": "github:sync_error",
   "workspace:stdout": "workspace:stdout",
@@ -255,4 +248,4 @@ export const TAURI_EVENTS: TauriEvents = {
   "notification:review_request": "notification:review_request",
   "notification:ci_failure": "notification:ci_failure",
   "notification:pr_approved": "notification:pr_approved",
-} as const;
+} as const satisfies Record<TauriEventName, TauriEventName>;


### PR DESCRIPTION
## Summary
- Mirrors all Rust enums (T-008) as TypeScript string union types with `snake_case` values matching serde serialization
- Mirrors all Rust structs (T-009, T-010, T-011) as TypeScript `readonly` interfaces with `camelCase` fields
- Exports `TAURI_COMMANDS` (23 IPC commands) and `TAURI_EVENTS` (8 event names) as typed runtime constants
- All interfaces use `readonly` fields and `readonly T[]` arrays for immutability

## Test plan
- [x] `npx tsc --noEmit` passes with zero errors
- [x] 39 vitest tests validate JSON fixture conformity for all types
- [x] `npx oxlint` reports 0 warnings, 0 errors
- [x] `npx oxfmt` formatting applied
- [x] No regressions (40/40 tests pass across project)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for exported types, validating enum unions, data shape expectations, composite view models, IPC payload formats, and registry integrity.

* **Chores**
  * Introduced foundational shared type definitions for domain models, view models, configuration, and inter-process communication contracts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->