### PR TITLE
feat(cache): configure sqlx SQLite pool with compile-time migrations (T-014)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -923,6 +923,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "etcetera"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2059,9 +2069,16 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -2846,7 +2863,9 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-log",
+ "tempfile",
  "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]
@@ -3259,6 +3278,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4372,6 +4404,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "tendril"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4501,7 +4546,19 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,7 +22,7 @@ log = "0.4"
 tauri = { version = "2.10.3" }
 tauri-plugin-log = "2"
 thiserror = "2.0.18"
-sqlx = { version = "0.8.6", features = ["runtime-tokio"] }
+sqlx = { version = "0.8.6", features = ["migrate", "runtime-tokio", "sqlite"] }
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }
@@ -49,3 +49,7 @@ lto = "thin"
 codegen-units = 1
 strip = "symbols"
 panic = "abort"
+
+[dev-dependencies]
+tempfile = "3.27.0"
+tokio = { version = "1.50.0", features = ["macros", "rt"] }

--- a/src-tauri/src/cache/db.rs
+++ b/src-tauri/src/cache/db.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use sqlx::SqlitePool;
-use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions};
 
 use crate::error::AppError;
 
@@ -25,7 +25,8 @@ pub async fn init_db(db_path: &Path) -> Result<SqlitePool, AppError> {
 
     let options = SqliteConnectOptions::new()
         .filename(db_path)
-        .create_if_missing(true);
+        .create_if_missing(true)
+        .journal_mode(SqliteJournalMode::Wal);
 
     let pool = SqlitePoolOptions::new()
         .max_connections(5)

--- a/src-tauri/src/cache/db.rs
+++ b/src-tauri/src/cache/db.rs
@@ -1,0 +1,90 @@
+use std::path::Path;
+
+use sqlx::SqlitePool;
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+
+use crate::error::AppError;
+
+/// Initialize the `SQLite` database pool at the given path.
+///
+/// Creates the parent directory and file if missing, runs all
+/// compile-time embedded migrations, and returns a reusable pool.
+#[allow(dead_code)] // Will be called from Tauri setup in a later task
+pub async fn init_db(db_path: &Path) -> Result<SqlitePool, AppError> {
+    if let Some(parent) = db_path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| {
+            AppError::Io(std::io::Error::new(
+                e.kind(),
+                format!(
+                    "failed to create database directory '{}': {e}",
+                    parent.display()
+                ),
+            ))
+        })?;
+    }
+
+    let options = SqliteConnectOptions::new()
+        .filename(db_path)
+        .create_if_missing(true);
+
+    let pool = SqlitePoolOptions::new()
+        .max_connections(5)
+        .connect_with(options)
+        .await?;
+
+    sqlx::migrate!("src/cache/migrations").run(&pool).await?;
+
+    Ok(pool)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_init_db_creates_file() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let db_path = tmp.path().join("prism_test.db");
+
+        let pool = init_db(&db_path).await.unwrap();
+
+        assert!(db_path.exists(), "database file should be created");
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_init_db_applies_migrations() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let db_path = tmp.path().join("prism_test.db");
+
+        let pool = init_db(&db_path).await.unwrap();
+
+        // sqlx creates the _sqlx_migrations tracking table when the
+        // migrator runs, even if no migration files exist yet.
+        let row: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='_sqlx_migrations'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("query should succeed");
+
+        assert_eq!(row.0, 1, "_sqlx_migrations table should exist");
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_init_db_idempotent() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let db_path = tmp.path().join("prism_test.db");
+
+        // First call — creates the database
+        let pool1 = init_db(&db_path).await.unwrap();
+        pool1.close().await;
+
+        // Second call — should succeed without errors on existing DB
+        let pool2 = init_db(&db_path).await.unwrap();
+        pool2.close().await;
+
+        assert!(db_path.exists(), "database file should still exist");
+    }
+}

--- a/src-tauri/src/cache/mod.rs
+++ b/src-tauri/src/cache/mod.rs
@@ -1,1 +1,1 @@
-
+pub mod db;

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -29,6 +29,9 @@ pub enum AppError {
     #[error("git error: {0}")]
     Git(String),
 
+    #[error("migration error: {0}")]
+    Migrate(#[from] sqlx::migrate::MigrateError),
+
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
 
@@ -132,5 +135,15 @@ mod tests {
         for (err, expected) in cases {
             assert_eq!(err.to_string(), expected);
         }
+    }
+
+    #[test]
+    fn test_app_error_display_migrate() {
+        let err = AppError::Migrate(sqlx::migrate::MigrateError::VersionMissing(1));
+        let msg = err.to_string();
+        assert!(
+            msg.contains("migration error"),
+            "expected 'migration error' in '{msg}'"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Add `sqlite` and `migrate` features to sqlx dependency
- Create `init_db()` function in `src-tauri/src/cache/db.rs` that initializes a SQLite connection pool with:
  - Automatic parent directory and DB file creation
  - Bounded connection pool (`max_connections = 5`)
  - Compile-time embedded migrations via `sqlx::migrate!()`
- Add `AppError::Migrate` variant with `#[from] sqlx::migrate::MigrateError` for typed error handling
- Add `tokio` (dev, macros+rt) and `tempfile` (dev) dependencies for async tests

## Test plan

- [x] `test_init_db_creates_file` — verifies DB file is created at the given path
- [x] `test_init_db_applies_migrations` — verifies `_sqlx_migrations` table exists after init
- [x] `test_init_db_idempotent` — verifies calling init_db twice on same file succeeds
- [x] `test_app_error_display_migrate` — verifies Migrate variant Display output
- [x] All 38 tests passing, clippy clean (`-D warnings`), rustfmt clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added database initialization with SQLite persistence and automated schema migrations.

* **Improvements**
  * Improved error reporting for migration failures and added a migration-related error variant.

* **Tests**
  * Added tests ensuring DB file creation, migrations applied, and idempotent initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->