### PR TITLE
feat(cache): initial SQLite migration with 10 tables (T-015)

### DIFF
--- a/src-tauri/src/cache/db.rs
+++ b/src-tauri/src/cache/db.rs
@@ -88,4 +88,130 @@ mod tests {
 
         assert!(db_path.exists(), "database file should still exist");
     }
+
+    // ── T-015: Migration schema tests ─────────────────────────────
+
+    /// All 10 application tables must exist after migration.
+    #[tokio::test]
+    async fn test_migration_creates_all_tables() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let pool = init_db(&tmp.path().join("test.db")).await.unwrap();
+
+        let expected_tables = [
+            "repos",
+            "pull_requests",
+            "review_requests",
+            "reviews",
+            "issues",
+            "activity",
+            "workspaces",
+            "workspace_notes",
+            "config",
+            "notification_log",
+        ];
+
+        let rows: Vec<(String,)> = sqlx::query_as(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE '\\__%' ESCAPE '\\' ORDER BY name",
+        )
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+
+        let table_names: Vec<&str> = rows.iter().map(|r| r.0.as_str()).collect();
+
+        assert_eq!(
+            table_names.len(),
+            expected_tables.len(),
+            "expected exactly {} tables, found: {table_names:?}",
+            expected_tables.len()
+        );
+
+        for table in &expected_tables {
+            assert!(
+                table_names.contains(table),
+                "table '{table}' should exist, found: {table_names:?}"
+            );
+        }
+
+        pool.close().await;
+    }
+
+    /// All expected indexes must exist after migration.
+    #[tokio::test]
+    async fn test_migration_creates_all_indexes() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let pool = init_db(&tmp.path().join("test.db")).await.unwrap();
+
+        let expected_indexes = [
+            "idx_activity_created_at",
+            "idx_activity_is_read",
+            "idx_activity_issue_id",
+            "idx_activity_pull_request_id",
+            "idx_activity_repo_id",
+            "idx_issues_repo_id",
+            "idx_issues_state",
+            "idx_pull_requests_repo_id",
+            "idx_pull_requests_state",
+            "idx_review_requests_pull_request_id",
+            "idx_review_requests_reviewer",
+            "idx_reviews_pull_request_id",
+            "idx_workspace_notes_workspace_id",
+            "idx_workspaces_repo_id",
+            "idx_workspaces_state",
+        ];
+
+        let rows: Vec<(String,)> = sqlx::query_as(
+            "SELECT name FROM sqlite_master WHERE type='index' AND name LIKE 'idx_%' ORDER BY name",
+        )
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+
+        let index_names: Vec<&str> = rows.iter().map(|r| r.0.as_str()).collect();
+
+        assert_eq!(
+            index_names.len(),
+            expected_indexes.len(),
+            "expected exactly {} indexes, found: {index_names:?}",
+            expected_indexes.len()
+        );
+
+        for idx in &expected_indexes {
+            assert!(
+                index_names.contains(idx),
+                "index '{idx}' should exist, found: {index_names:?}"
+            );
+        }
+
+        pool.close().await;
+    }
+
+    /// Default config rows must be inserted by the migration.
+    #[tokio::test]
+    async fn test_migration_inserts_default_config() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let pool = init_db(&tmp.path().join("test.db")).await.unwrap();
+
+        let poll: (String,) =
+            sqlx::query_as("SELECT value FROM config WHERE key = 'poll_interval_secs'")
+                .fetch_one(&pool)
+                .await
+                .expect("poll_interval_secs should exist");
+        assert_eq!(poll.0, "300");
+
+        let max_ws: (String,) =
+            sqlx::query_as("SELECT value FROM config WHERE key = 'max_active_workspaces'")
+                .fetch_one(&pool)
+                .await
+                .expect("max_active_workspaces should exist");
+        assert_eq!(max_ws.0, "3");
+
+        let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM config")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(count.0, 2, "config should have exactly 2 default rows");
+
+        pool.close().await;
+    }
 }

--- a/src-tauri/src/cache/migrations/001_initial.sql
+++ b/src-tauri/src/cache/migrations/001_initial.sql
@@ -1,0 +1,156 @@
+-- PRism initial schema: 10 tables, indexes, and default config values.
+-- Applied by sqlx::migrate!() at application startup.
+
+-- ── repos ──────────────────────────────────────────────────────────
+
+CREATE TABLE repos (
+    id            TEXT PRIMARY KEY,
+    org           TEXT NOT NULL,
+    name          TEXT NOT NULL,
+    full_name     TEXT NOT NULL,
+    url           TEXT NOT NULL,
+    default_branch TEXT NOT NULL,
+    is_archived   INTEGER NOT NULL DEFAULT 0,
+    enabled       INTEGER NOT NULL DEFAULT 1,
+    local_path    TEXT,
+    last_sync_at  TEXT,
+    UNIQUE(org, name)
+);
+
+-- ── pull_requests ──────────────────────────────────────────────────
+
+CREATE TABLE pull_requests (
+    id          TEXT PRIMARY KEY,
+    number      INTEGER NOT NULL,
+    title       TEXT NOT NULL,
+    author      TEXT NOT NULL,
+    state       TEXT NOT NULL,
+    ci_status   TEXT NOT NULL,
+    priority    TEXT NOT NULL,
+    repo_id     TEXT NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
+    url         TEXT NOT NULL,
+    labels      TEXT NOT NULL DEFAULT '[]',
+    created_at  TEXT NOT NULL,
+    updated_at  TEXT NOT NULL,
+    UNIQUE(repo_id, number)
+);
+
+CREATE INDEX idx_pull_requests_repo_id ON pull_requests(repo_id);
+CREATE INDEX idx_pull_requests_state   ON pull_requests(state);
+
+-- ── review_requests ────────────────────────────────────────────────
+
+CREATE TABLE review_requests (
+    id               TEXT PRIMARY KEY,
+    pull_request_id  TEXT NOT NULL REFERENCES pull_requests(id) ON DELETE CASCADE,
+    reviewer         TEXT NOT NULL,
+    status           TEXT NOT NULL,
+    requested_at     TEXT NOT NULL
+);
+
+CREATE INDEX idx_review_requests_pull_request_id ON review_requests(pull_request_id);
+CREATE INDEX idx_review_requests_reviewer        ON review_requests(reviewer);
+
+-- ── reviews ────────────────────────────────────────────────────────
+
+CREATE TABLE reviews (
+    id               TEXT PRIMARY KEY,
+    pull_request_id  TEXT NOT NULL REFERENCES pull_requests(id) ON DELETE CASCADE,
+    reviewer         TEXT NOT NULL,
+    status           TEXT NOT NULL,
+    body             TEXT,
+    submitted_at     TEXT NOT NULL
+);
+
+CREATE INDEX idx_reviews_pull_request_id ON reviews(pull_request_id);
+
+-- ── issues ─────────────────────────────────────────────────────────
+
+CREATE TABLE issues (
+    id          TEXT PRIMARY KEY,
+    number      INTEGER NOT NULL,
+    title       TEXT NOT NULL,
+    author      TEXT NOT NULL,
+    state       TEXT NOT NULL,
+    priority    TEXT NOT NULL,
+    repo_id     TEXT NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
+    url         TEXT NOT NULL,
+    labels      TEXT NOT NULL DEFAULT '[]',
+    created_at  TEXT NOT NULL,
+    updated_at  TEXT NOT NULL,
+    UNIQUE(repo_id, number)
+);
+
+CREATE INDEX idx_issues_repo_id ON issues(repo_id);
+CREATE INDEX idx_issues_state   ON issues(state);
+
+-- ── activity ───────────────────────────────────────────────────────
+
+CREATE TABLE activity (
+    id               TEXT PRIMARY KEY,
+    activity_type    TEXT NOT NULL,
+    actor            TEXT NOT NULL,
+    repo_id          TEXT NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
+    pull_request_id  TEXT REFERENCES pull_requests(id) ON DELETE SET NULL,
+    issue_id         TEXT REFERENCES issues(id) ON DELETE SET NULL,
+    message          TEXT NOT NULL,
+    is_read          INTEGER NOT NULL DEFAULT 0,
+    created_at       TEXT NOT NULL
+);
+
+CREATE INDEX idx_activity_repo_id          ON activity(repo_id);
+CREATE INDEX idx_activity_created_at       ON activity(created_at);
+CREATE INDEX idx_activity_is_read          ON activity(is_read);
+CREATE INDEX idx_activity_pull_request_id  ON activity(pull_request_id);
+CREATE INDEX idx_activity_issue_id         ON activity(issue_id);
+
+-- ── workspaces ─────────────────────────────────────────────────────
+
+CREATE TABLE workspaces (
+    id                   TEXT PRIMARY KEY,
+    repo_id              TEXT NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
+    pull_request_number  INTEGER NOT NULL,
+    state                TEXT NOT NULL DEFAULT 'active',
+    worktree_path        TEXT,
+    session_id           TEXT,
+    last_active_at       TEXT,
+    created_at           TEXT NOT NULL,
+    updated_at           TEXT NOT NULL,
+    UNIQUE(repo_id, pull_request_number)
+);
+
+CREATE INDEX idx_workspaces_repo_id ON workspaces(repo_id);
+CREATE INDEX idx_workspaces_state   ON workspaces(state);
+
+-- ── workspace_notes ────────────────────────────────────────────────
+
+CREATE TABLE workspace_notes (
+    id            TEXT PRIMARY KEY,
+    workspace_id  TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    content       TEXT NOT NULL,
+    created_at    TEXT NOT NULL
+);
+
+CREATE INDEX idx_workspace_notes_workspace_id ON workspace_notes(workspace_id);
+
+-- ── config (key-value) ─────────────────────────────────────────────
+
+CREATE TABLE config (
+    key    TEXT PRIMARY KEY,
+    value  TEXT NOT NULL
+);
+
+-- ── notification_log ───────────────────────────────────────────────
+
+CREATE TABLE notification_log (
+    id          TEXT PRIMARY KEY,
+    event_type  TEXT NOT NULL,
+    event_id    TEXT NOT NULL,
+    notified_at TEXT NOT NULL,
+    UNIQUE(event_type, event_id)
+);
+
+-- ── Default configuration ──────────────────────────────────────────
+
+INSERT INTO config (key, value) VALUES ('poll_interval_secs', '300');
+INSERT INTO config (key, value) VALUES ('max_active_workspaces', '3');


### PR DESCRIPTION
## Summary
- Create `001_initial.sql` with the complete PRism SQLite schema (10 tables, 15 indexes, default config)
- Tables: `repos`, `pull_requests`, `review_requests`, `reviews`, `issues`, `activity`, `workspaces`, `workspace_notes`, `config`, `notification_log`
- UNIQUE constraints on natural keys (`repo_id + number` for PRs/issues, `repo_id + pull_request_number` for workspaces, `org + name` for repos)
- CASCADE deletes from `repos`, SET NULL for activity FK references
- Default config: `poll_interval_secs=300`, `max_active_workspaces=3`
- 3 new tests asserting exact table/index counts and default config values (41 total tests passing)

## Test plan
- [x] `test_migration_creates_all_tables` — verifies all 10 tables exist with exact count
- [x] `test_migration_creates_all_indexes` — verifies all 15 indexes exist with exact count
- [x] `test_migration_inserts_default_config` — verifies 2 default config rows with correct values
- [x] Existing T-014 tests still pass (init_db, idempotent, applies_migrations)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration tests validating database initialization: verifies correct table count, index presence, and default configuration rows are properly created.

* **Chores**
  * Implemented initial database schema with tables for managing repositories, pull requests, issues, reviews, workspaces, and activity tracking, along with supporting indexes and constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->