### PR TITLE
feat(cache): implement config + notification_log CRUD (T-022)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2869,7 +2869,6 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "uuid",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2869,6 +2869,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -24,7 +24,6 @@ tauri-plugin-log = "2"
 thiserror = "2.0.18"
 sqlx = { version = "0.8.6", features = ["migrate", "runtime-tokio", "sqlite"] }
 chrono = "0.4.44"
-uuid = { version = "1.22.0", features = ["v4"] }
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -24,6 +24,7 @@ tauri-plugin-log = "2"
 thiserror = "2.0.18"
 sqlx = { version = "0.8.6", features = ["migrate", "runtime-tokio", "sqlite"] }
 chrono = "0.4.44"
+uuid = { version = "1.22.0", features = ["v4"] }
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/src-tauri/src/cache/config.rs
+++ b/src-tauri/src/cache/config.rs
@@ -1,0 +1,201 @@
+use log::warn;
+use sqlx::SqlitePool;
+
+use crate::error::AppError;
+use crate::types::AppConfig;
+
+/// Keys used in the `config` key-value table.
+const KEY_POLL_INTERVAL: &str = "poll_interval_secs";
+const KEY_MAX_WORKSPACES: &str = "max_active_workspaces";
+const KEY_GITHUB_TOKEN: &str = "github_token";
+const KEY_DATA_DIR: &str = "data_dir";
+const KEY_WORKSPACES_DIR: &str = "workspaces_dir";
+
+/// Row from the `config` key-value table.
+#[derive(sqlx::FromRow)]
+struct ConfigRow {
+    key: String,
+    value: String,
+}
+
+/// Read the full application configuration from the `config` table.
+///
+/// Missing keys are filled with [`AppConfig::default()`] values.
+#[allow(dead_code)]
+pub async fn get_config(pool: &SqlitePool) -> Result<AppConfig, AppError> {
+    let rows: Vec<ConfigRow> = sqlx::query_as("SELECT key, value FROM config")
+        .fetch_all(pool)
+        .await?;
+
+    let mut config = AppConfig::default();
+
+    for row in rows {
+        match row.key.as_str() {
+            KEY_POLL_INTERVAL => match row.value.parse::<u64>() {
+                Ok(v) => config.poll_interval_secs = v,
+                Err(_) => warn!(
+                    "ignoring non-parseable config value for '{}': '{}', using default",
+                    KEY_POLL_INTERVAL, row.value
+                ),
+            },
+            KEY_MAX_WORKSPACES => match row.value.parse::<u32>() {
+                Ok(v) => config.max_active_workspaces = v,
+                Err(_) => warn!(
+                    "ignoring non-parseable config value for '{}': '{}', using default",
+                    KEY_MAX_WORKSPACES, row.value
+                ),
+            },
+            KEY_GITHUB_TOKEN => {
+                config.github_token = Some(row.value);
+            }
+            KEY_DATA_DIR => {
+                config.data_dir = Some(row.value);
+            }
+            KEY_WORKSPACES_DIR => {
+                config.workspaces_dir = Some(row.value);
+            }
+            _ => {} // ignore unknown keys for forward-compat
+        }
+    }
+
+    Ok(config)
+}
+
+/// Persist the given configuration to the `config` table.
+///
+/// Every field is upserted. `Option::None` fields are deleted so that
+/// future reads fall back to [`AppConfig::default()`].
+/// Returns the configuration as re-read from DB.
+#[allow(dead_code)]
+pub async fn set_config(pool: &SqlitePool, config: &AppConfig) -> Result<AppConfig, AppError> {
+    upsert_key(
+        pool,
+        KEY_POLL_INTERVAL,
+        &config.poll_interval_secs.to_string(),
+    )
+    .await?;
+    upsert_key(
+        pool,
+        KEY_MAX_WORKSPACES,
+        &config.max_active_workspaces.to_string(),
+    )
+    .await?;
+
+    set_optional_key(pool, KEY_GITHUB_TOKEN, config.github_token.as_deref()).await?;
+    set_optional_key(pool, KEY_DATA_DIR, config.data_dir.as_deref()).await?;
+    set_optional_key(pool, KEY_WORKSPACES_DIR, config.workspaces_dir.as_deref()).await?;
+
+    get_config(pool).await
+}
+
+/// Upsert a single key-value pair.
+async fn upsert_key(pool: &SqlitePool, key: &str, value: &str) -> Result<(), AppError> {
+    sqlx::query(
+        "INSERT INTO config (key, value) VALUES ($1, $2) \
+         ON CONFLICT(key) DO UPDATE SET value = $2",
+    )
+    .bind(key)
+    .bind(value)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Delete a key from the config table.
+async fn delete_key(pool: &SqlitePool, key: &str) -> Result<(), AppError> {
+    sqlx::query("DELETE FROM config WHERE key = $1")
+        .bind(key)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+/// Upsert if `Some`, delete if `None`.
+async fn set_optional_key(
+    pool: &SqlitePool,
+    key: &str,
+    value: Option<&str>,
+) -> Result<(), AppError> {
+    match value {
+        Some(v) => upsert_key(pool, key, v).await,
+        None => delete_key(pool, key).await,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cache::db::init_db;
+
+    async fn test_pool() -> (SqlitePool, tempfile::TempDir) {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let pool = init_db(&tmp.path().join("test.db")).await.unwrap();
+        (pool, tmp)
+    }
+
+    #[tokio::test]
+    async fn test_get_config_defaults() {
+        let (pool, _tmp) = test_pool().await;
+
+        let config = get_config(&pool).await.unwrap();
+
+        // Migration inserts poll_interval_secs=300 and max_active_workspaces=3
+        assert_eq!(config.poll_interval_secs, 300);
+        assert_eq!(config.max_active_workspaces, 3);
+        assert!(config.github_token.is_none());
+        assert!(config.data_dir.is_none());
+        assert!(config.workspaces_dir.is_none());
+
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_set_config_partial() {
+        let (pool, _tmp) = test_pool().await;
+
+        // Read defaults, modify one field
+        let mut config = get_config(&pool).await.unwrap();
+        config.poll_interval_secs = 60;
+
+        let result = set_config(&pool, &config).await.unwrap();
+        assert_eq!(result.poll_interval_secs, 60);
+        // Other fields unchanged
+        assert_eq!(result.max_active_workspaces, 3);
+        assert!(result.github_token.is_none());
+
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_set_config_full() {
+        let (pool, _tmp) = test_pool().await;
+
+        let config = AppConfig {
+            poll_interval_secs: 120,
+            max_active_workspaces: 5,
+            github_token: Some("ghp_test".to_string()),
+            data_dir: Some("/custom/data".to_string()),
+            workspaces_dir: Some("/custom/ws".to_string()),
+        };
+
+        let result = set_config(&pool, &config).await.unwrap();
+        assert_eq!(result.poll_interval_secs, 120);
+        assert_eq!(result.max_active_workspaces, 5);
+        assert_eq!(result.github_token.as_deref(), Some("ghp_test"));
+        assert_eq!(result.data_dir.as_deref(), Some("/custom/data"));
+        assert_eq!(result.workspaces_dir.as_deref(), Some("/custom/ws"));
+
+        // Clear optional fields — they should revert to None
+        let mut cleared = result;
+        cleared.github_token = None;
+        cleared.data_dir = None;
+
+        let after = set_config(&pool, &cleared).await.unwrap();
+        assert!(after.github_token.is_none());
+        assert!(after.data_dir.is_none());
+        // workspaces_dir should remain
+        assert_eq!(after.workspaces_dir.as_deref(), Some("/custom/ws"));
+
+        pool.close().await;
+    }
+}

--- a/src-tauri/src/cache/config.rs
+++ b/src-tauri/src/cache/config.rs
@@ -11,6 +11,9 @@ const KEY_GITHUB_TOKEN: &str = "github_token";
 const KEY_DATA_DIR: &str = "data_dir";
 const KEY_WORKSPACES_DIR: &str = "workspaces_dir";
 
+/// Minimum allowed value for `poll_interval_secs`.
+const MIN_POLL_INTERVAL_SECS: u64 = 30;
+
 /// Row from the `config` key-value table.
 #[derive(sqlx::FromRow)]
 struct ConfigRow {
@@ -63,62 +66,84 @@ pub async fn get_config(pool: &SqlitePool) -> Result<AppConfig, AppError> {
 
 /// Persist the given configuration to the `config` table.
 ///
-/// Every field is upserted. `Option::None` fields are deleted so that
-/// future reads fall back to [`AppConfig::default()`].
-/// Returns the configuration as re-read from DB.
+/// All writes are wrapped in a transaction for atomicity.
+/// `Option::None` fields are deleted so that future reads fall back
+/// to [`AppConfig::default()`]. Values below documented minimums are
+/// clamped with a warning. Returns the configuration as re-read from DB.
 #[allow(dead_code)]
 pub async fn set_config(pool: &SqlitePool, config: &AppConfig) -> Result<AppConfig, AppError> {
+    let poll_interval = if config.poll_interval_secs < MIN_POLL_INTERVAL_SECS {
+        warn!(
+            "poll_interval_secs {} is below the minimum of {}; clamping",
+            config.poll_interval_secs, MIN_POLL_INTERVAL_SECS
+        );
+        MIN_POLL_INTERVAL_SECS
+    } else {
+        config.poll_interval_secs
+    };
+
+    let mut tx = pool.begin().await?;
+
+    upsert_key(&mut *tx, KEY_POLL_INTERVAL, &poll_interval.to_string()).await?;
     upsert_key(
-        pool,
-        KEY_POLL_INTERVAL,
-        &config.poll_interval_secs.to_string(),
-    )
-    .await?;
-    upsert_key(
-        pool,
+        &mut *tx,
         KEY_MAX_WORKSPACES,
         &config.max_active_workspaces.to_string(),
     )
     .await?;
 
-    set_optional_key(pool, KEY_GITHUB_TOKEN, config.github_token.as_deref()).await?;
-    set_optional_key(pool, KEY_DATA_DIR, config.data_dir.as_deref()).await?;
-    set_optional_key(pool, KEY_WORKSPACES_DIR, config.workspaces_dir.as_deref()).await?;
+    set_optional_key(&mut *tx, KEY_GITHUB_TOKEN, config.github_token.as_deref()).await?;
+    set_optional_key(&mut *tx, KEY_DATA_DIR, config.data_dir.as_deref()).await?;
+    set_optional_key(
+        &mut *tx,
+        KEY_WORKSPACES_DIR,
+        config.workspaces_dir.as_deref(),
+    )
+    .await?;
+
+    tx.commit().await?;
 
     get_config(pool).await
 }
 
 /// Upsert a single key-value pair.
-async fn upsert_key(pool: &SqlitePool, key: &str, value: &str) -> Result<(), AppError> {
+async fn upsert_key(
+    conn: impl sqlx::Executor<'_, Database = sqlx::Sqlite>,
+    key: &str,
+    value: &str,
+) -> Result<(), AppError> {
     sqlx::query(
         "INSERT INTO config (key, value) VALUES ($1, $2) \
          ON CONFLICT(key) DO UPDATE SET value = $2",
     )
     .bind(key)
     .bind(value)
-    .execute(pool)
+    .execute(conn)
     .await?;
     Ok(())
 }
 
 /// Delete a key from the config table.
-async fn delete_key(pool: &SqlitePool, key: &str) -> Result<(), AppError> {
+async fn delete_key(
+    conn: impl sqlx::Executor<'_, Database = sqlx::Sqlite>,
+    key: &str,
+) -> Result<(), AppError> {
     sqlx::query("DELETE FROM config WHERE key = $1")
         .bind(key)
-        .execute(pool)
+        .execute(conn)
         .await?;
     Ok(())
 }
 
 /// Upsert if `Some`, delete if `None`.
 async fn set_optional_key(
-    pool: &SqlitePool,
+    conn: impl sqlx::Executor<'_, Database = sqlx::Sqlite>,
     key: &str,
     value: Option<&str>,
 ) -> Result<(), AppError> {
     match value {
-        Some(v) => upsert_key(pool, key, v).await,
-        None => delete_key(pool, key).await,
+        Some(v) => upsert_key(conn, key, v).await,
+        None => delete_key(conn, key).await,
     }
 }
 
@@ -195,6 +220,22 @@ mod tests {
         assert!(after.data_dir.is_none());
         // workspaces_dir should remain
         assert_eq!(after.workspaces_dir.as_deref(), Some("/custom/ws"));
+
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_set_config_clamps_poll_interval() {
+        let (pool, _tmp) = test_pool().await;
+
+        let mut config = get_config(&pool).await.unwrap();
+        config.poll_interval_secs = 5; // below minimum of 30
+
+        let result = set_config(&pool, &config).await.unwrap();
+        assert_eq!(
+            result.poll_interval_secs, MIN_POLL_INTERVAL_SECS,
+            "should clamp to minimum"
+        );
 
         pool.close().await;
     }

--- a/src-tauri/src/cache/config.rs
+++ b/src-tauri/src/cache/config.rs
@@ -13,6 +13,8 @@ const KEY_WORKSPACES_DIR: &str = "workspaces_dir";
 
 /// Minimum allowed value for `poll_interval_secs`.
 const MIN_POLL_INTERVAL_SECS: u64 = 30;
+/// Minimum allowed value for `max_active_workspaces`.
+const MIN_MAX_ACTIVE_WORKSPACES: u32 = 1;
 
 /// Row from the `config` key-value table.
 #[derive(sqlx::FromRow)]
@@ -21,9 +23,34 @@ struct ConfigRow {
     value: String,
 }
 
+/// Clamp `poll_interval_secs` to its minimum, warning on violation.
+fn clamp_poll_interval(value: u64) -> u64 {
+    if value < MIN_POLL_INTERVAL_SECS {
+        warn!(
+            "poll_interval_secs {value} is below the minimum of {MIN_POLL_INTERVAL_SECS}; clamping"
+        );
+        MIN_POLL_INTERVAL_SECS
+    } else {
+        value
+    }
+}
+
+/// Clamp `max_active_workspaces` to its minimum, warning on violation.
+fn clamp_max_workspaces(value: u32) -> u32 {
+    if value < MIN_MAX_ACTIVE_WORKSPACES {
+        warn!(
+            "max_active_workspaces {value} would evict all workspaces; clamping to {MIN_MAX_ACTIVE_WORKSPACES}"
+        );
+        MIN_MAX_ACTIVE_WORKSPACES
+    } else {
+        value
+    }
+}
+
 /// Read the full application configuration from the `config` table.
 ///
 /// Missing keys are filled with [`AppConfig::default()`] values.
+/// Values below documented minimums are clamped with a warning.
 #[allow(dead_code)]
 pub async fn get_config(pool: &SqlitePool) -> Result<AppConfig, AppError> {
     let rows: Vec<ConfigRow> = sqlx::query_as("SELECT key, value FROM config")
@@ -35,14 +62,14 @@ pub async fn get_config(pool: &SqlitePool) -> Result<AppConfig, AppError> {
     for row in rows {
         match row.key.as_str() {
             KEY_POLL_INTERVAL => match row.value.parse::<u64>() {
-                Ok(v) => config.poll_interval_secs = v,
+                Ok(v) => config.poll_interval_secs = clamp_poll_interval(v),
                 Err(_) => warn!(
                     "ignoring non-parseable config value for '{}': '{}', using default",
                     KEY_POLL_INTERVAL, row.value
                 ),
             },
             KEY_MAX_WORKSPACES => match row.value.parse::<u32>() {
-                Ok(v) => config.max_active_workspaces = v,
+                Ok(v) => config.max_active_workspaces = clamp_max_workspaces(v),
                 Err(_) => warn!(
                     "ignoring non-parseable config value for '{}': '{}', using default",
                     KEY_MAX_WORKSPACES, row.value
@@ -69,28 +96,16 @@ pub async fn get_config(pool: &SqlitePool) -> Result<AppConfig, AppError> {
 /// All writes are wrapped in a transaction for atomicity.
 /// `Option::None` fields are deleted so that future reads fall back
 /// to [`AppConfig::default()`]. Values below documented minimums are
-/// clamped with a warning. Returns the configuration as re-read from DB.
+/// clamped with a warning. Returns the clamped config as written.
 #[allow(dead_code)]
 pub async fn set_config(pool: &SqlitePool, config: &AppConfig) -> Result<AppConfig, AppError> {
-    let poll_interval = if config.poll_interval_secs < MIN_POLL_INTERVAL_SECS {
-        warn!(
-            "poll_interval_secs {} is below the minimum of {}; clamping",
-            config.poll_interval_secs, MIN_POLL_INTERVAL_SECS
-        );
-        MIN_POLL_INTERVAL_SECS
-    } else {
-        config.poll_interval_secs
-    };
+    let poll_interval = clamp_poll_interval(config.poll_interval_secs);
+    let max_workspaces = clamp_max_workspaces(config.max_active_workspaces);
 
     let mut tx = pool.begin().await?;
 
     upsert_key(&mut *tx, KEY_POLL_INTERVAL, &poll_interval.to_string()).await?;
-    upsert_key(
-        &mut *tx,
-        KEY_MAX_WORKSPACES,
-        &config.max_active_workspaces.to_string(),
-    )
-    .await?;
+    upsert_key(&mut *tx, KEY_MAX_WORKSPACES, &max_workspaces.to_string()).await?;
 
     set_optional_key(&mut *tx, KEY_GITHUB_TOKEN, config.github_token.as_deref()).await?;
     set_optional_key(&mut *tx, KEY_DATA_DIR, config.data_dir.as_deref()).await?;
@@ -103,7 +118,14 @@ pub async fn set_config(pool: &SqlitePool, config: &AppConfig) -> Result<AppConf
 
     tx.commit().await?;
 
-    get_config(pool).await
+    // Return the config as written — no re-read to avoid TOCTOU races.
+    Ok(AppConfig {
+        poll_interval_secs: poll_interval,
+        max_active_workspaces: max_workspaces,
+        github_token: config.github_token.clone(),
+        data_dir: config.data_dir.clone(),
+        workspaces_dir: config.workspaces_dir.clone(),
+    })
 }
 
 /// Upsert a single key-value pair.
@@ -235,6 +257,22 @@ mod tests {
         assert_eq!(
             result.poll_interval_secs, MIN_POLL_INTERVAL_SECS,
             "should clamp to minimum"
+        );
+
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_set_config_clamps_max_workspaces() {
+        let (pool, _tmp) = test_pool().await;
+
+        let mut config = get_config(&pool).await.unwrap();
+        config.max_active_workspaces = 0;
+
+        let result = set_config(&pool, &config).await.unwrap();
+        assert_eq!(
+            result.max_active_workspaces, MIN_MAX_ACTIVE_WORKSPACES,
+            "should clamp 0 to minimum of 1"
         );
 
         pool.close().await;

--- a/src-tauri/src/cache/mod.rs
+++ b/src-tauri/src/cache/mod.rs
@@ -1,6 +1,8 @@
 pub mod activity;
+pub mod config;
 pub mod db;
 pub mod issues;
+pub mod notifications;
 pub mod pull_requests;
 pub mod repos;
 pub mod reviews;

--- a/src-tauri/src/cache/notifications.rs
+++ b/src-tauri/src/cache/notifications.rs
@@ -1,5 +1,6 @@
 use chrono::Utc;
 use sqlx::SqlitePool;
+use uuid::Uuid;
 
 use crate::error::AppError;
 
@@ -31,8 +32,7 @@ pub async fn mark_notified(
     event_id: &str,
 ) -> Result<(), AppError> {
     let now = Utc::now().to_rfc3339();
-    // Opaque surrogate PK — dedup is enforced by UNIQUE(event_type, event_id).
-    let id = format!("{event_type}\x1F{event_id}");
+    let id = Uuid::new_v4().to_string();
 
     sqlx::query(
         "INSERT OR IGNORE INTO notification_log (id, event_type, event_id, notified_at) \

--- a/src-tauri/src/cache/notifications.rs
+++ b/src-tauri/src/cache/notifications.rs
@@ -1,5 +1,6 @@
 use chrono::Utc;
 use sqlx::SqlitePool;
+use uuid::Uuid;
 
 use crate::error::AppError;
 
@@ -22,23 +23,22 @@ pub async fn has_been_notified(
 
 /// Record that a notification was sent for the given event.
 ///
-/// Uses `INSERT OR IGNORE` for deduplication. Both the deterministic PK
-/// and the `UNIQUE(event_type, event_id)` constraint enforce the invariant
-/// (defense-in-depth). Safe because `event_type` values are controlled enum
-/// strings and `event_id` values are GitHub alphanumeric IDs — neither
-/// contains `/`.
+/// Deduplication is enforced by the `UNIQUE(event_type, event_id)`
+/// constraint via `ON CONFLICT ... DO NOTHING`. The PK is a random
+/// UUID to avoid any separator-collision risk with composite keys.
 #[allow(dead_code)]
 pub async fn mark_notified(
     pool: &SqlitePool,
     event_type: &str,
     event_id: &str,
 ) -> Result<(), AppError> {
+    let id = Uuid::new_v4().to_string();
     let now = Utc::now().to_rfc3339();
-    let id = format!("{event_type}/{event_id}");
 
     sqlx::query(
-        "INSERT OR IGNORE INTO notification_log (id, event_type, event_id, notified_at) \
-         VALUES ($1, $2, $3, $4)",
+        "INSERT INTO notification_log (id, event_type, event_id, notified_at) \
+         VALUES ($1, $2, $3, $4) \
+         ON CONFLICT(event_type, event_id) DO NOTHING",
     )
     .bind(&id)
     .bind(event_type)

--- a/src-tauri/src/cache/notifications.rs
+++ b/src-tauri/src/cache/notifications.rs
@@ -1,6 +1,5 @@
 use chrono::Utc;
 use sqlx::SqlitePool;
-use uuid::Uuid;
 
 use crate::error::AppError;
 
@@ -23,8 +22,11 @@ pub async fn has_been_notified(
 
 /// Record that a notification was sent for the given event.
 ///
-/// Uses `INSERT OR IGNORE` for deduplication via the
-/// `UNIQUE(event_type, event_id)` constraint.
+/// Uses `INSERT OR IGNORE` for deduplication. Both the deterministic PK
+/// and the `UNIQUE(event_type, event_id)` constraint enforce the invariant
+/// (defense-in-depth). Safe because `event_type` values are controlled enum
+/// strings and `event_id` values are GitHub alphanumeric IDs — neither
+/// contains `/`.
 #[allow(dead_code)]
 pub async fn mark_notified(
     pool: &SqlitePool,
@@ -32,7 +34,7 @@ pub async fn mark_notified(
     event_id: &str,
 ) -> Result<(), AppError> {
     let now = Utc::now().to_rfc3339();
-    let id = Uuid::new_v4().to_string();
+    let id = format!("{event_type}/{event_id}");
 
     sqlx::query(
         "INSERT OR IGNORE INTO notification_log (id, event_type, event_id, notified_at) \

--- a/src-tauri/src/cache/notifications.rs
+++ b/src-tauri/src/cache/notifications.rs
@@ -1,0 +1,125 @@
+use chrono::Utc;
+use sqlx::SqlitePool;
+
+use crate::error::AppError;
+
+/// Check whether a notification has already been sent for the given event.
+#[allow(dead_code)]
+pub async fn has_been_notified(
+    pool: &SqlitePool,
+    event_type: &str,
+    event_id: &str,
+) -> Result<bool, AppError> {
+    let row: Option<(i64,)> =
+        sqlx::query_as("SELECT 1 FROM notification_log WHERE event_type = $1 AND event_id = $2")
+            .bind(event_type)
+            .bind(event_id)
+            .fetch_optional(pool)
+            .await?;
+
+    Ok(row.is_some())
+}
+
+/// Record that a notification was sent for the given event.
+///
+/// Uses `INSERT OR IGNORE` for deduplication via the
+/// `UNIQUE(event_type, event_id)` constraint.
+#[allow(dead_code)]
+pub async fn mark_notified(
+    pool: &SqlitePool,
+    event_type: &str,
+    event_id: &str,
+) -> Result<(), AppError> {
+    let now = Utc::now().to_rfc3339();
+    // Opaque surrogate PK — dedup is enforced by UNIQUE(event_type, event_id).
+    let id = format!("{event_type}\x1F{event_id}");
+
+    sqlx::query(
+        "INSERT OR IGNORE INTO notification_log (id, event_type, event_id, notified_at) \
+         VALUES ($1, $2, $3, $4)",
+    )
+    .bind(&id)
+    .bind(event_type)
+    .bind(event_id)
+    .bind(&now)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cache::db::init_db;
+
+    async fn test_pool() -> (SqlitePool, tempfile::TempDir) {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let pool = init_db(&tmp.path().join("test.db")).await.unwrap();
+        (pool, tmp)
+    }
+
+    #[tokio::test]
+    async fn test_has_been_notified_false() {
+        let (pool, _tmp) = test_pool().await;
+
+        let result = has_been_notified(&pool, "review_submitted", "evt-1")
+            .await
+            .unwrap();
+        assert!(!result, "should not be notified for unknown event");
+
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_mark_notified_then_check() {
+        let (pool, _tmp) = test_pool().await;
+
+        mark_notified(&pool, "pr_opened", "pr-42").await.unwrap();
+
+        let result = has_been_notified(&pool, "pr_opened", "pr-42")
+            .await
+            .unwrap();
+        assert!(result, "should be notified after marking");
+
+        // Different event_id → still not notified
+        let other = has_been_notified(&pool, "pr_opened", "pr-99")
+            .await
+            .unwrap();
+        assert!(!other, "different event_id should not match");
+
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_notification_dedup() {
+        let (pool, _tmp) = test_pool().await;
+
+        // Mark the same event twice — should not error
+        mark_notified(&pool, "review_submitted", "rev-1")
+            .await
+            .unwrap();
+        mark_notified(&pool, "review_submitted", "rev-1")
+            .await
+            .unwrap();
+
+        let result = has_been_notified(&pool, "review_submitted", "rev-1")
+            .await
+            .unwrap();
+        assert!(result);
+
+        // Verify only one row exists (dedup via UNIQUE constraint)
+        let count: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM notification_log \
+             WHERE event_type = $1 AND event_id = $2",
+        )
+        .bind("review_submitted")
+        .bind("rev-1")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(count.0, 1, "dedup should prevent duplicate rows");
+
+        pool.close().await;
+    }
+}


### PR DESCRIPTION
## Summary

- **config.rs**: `get_config()` reads all key-value pairs from the `config` table and maps them to `AppConfig` with defaults for missing keys. `set_config()` upserts all fields; `None` optional fields are deleted so future reads fall back to defaults. Warns on corrupt numeric values via `log::warn!`.
- **notifications.rs**: `has_been_notified()` checks the `UNIQUE(event_type, event_id)` constraint. `mark_notified()` uses `INSERT OR IGNORE` for idempotent deduplication.
- Registered both modules in `cache/mod.rs`.
- 6 new tests, 97 total passing, zero clippy warnings.

## Test plan

- [x] `test_get_config_defaults` — migration defaults are read correctly
- [x] `test_set_config_partial` — single field update preserves others
- [x] `test_set_config_full` — all fields round-trip, clear optionals reverts to None
- [x] `test_has_been_notified_false` — unknown event returns false
- [x] `test_mark_notified_then_check` — mark then check returns true, different event_id unaffected
- [x] `test_notification_dedup` — duplicate mark is no-op, only one row exists

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `cache::config` and `cache::notifications` to implement config CRUD and idempotent notification logging for T-022. Reads fill defaults and clamp to minimums (poll ≥30s, max workspaces ≥1); writes are atomic; notifications dedup via `UNIQUE(event_type,event_id)` with a UUID PK.

- **New Features**
  - Config: `get_config()` loads keys with defaults and clamps bad/low values; `set_config()` runs in a transaction, upserts fields, deletes `None` optionals, and returns the clamped config.
  - Notifications: `has_been_notified()` checks `(event_type, event_id)`; `mark_notified()` inserts with UUID PK and `ON CONFLICT(event_type, event_id) DO NOTHING` for dedup.
  - Wiring/tests: modules exported in `cache/mod.rs`; 8 tests cover defaults, partial/full updates, read/write clamping, and dedup.

- **Dependencies**
  - Added `uuid` (v4) for notification IDs.

<sup>Written for commit a14c90fb4e7fb6bf0b0be5d0b7fd9f9ac9b61fe4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent application configuration with atomic save/load and enforced value limits so settings are reliably stored and restored.
  * Notification deduplication to prevent duplicate alerts and keep notifications tidy.

* **Tests**
  * Added unit tests covering defaults, partial/full updates (including clearing optional values), clamping behavior, and notification deduplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->