### PR TITLE
feat(auth): add Tauri IPC commands for authentication (T-026)

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,6 +27,7 @@ chrono = "0.4.44"
 uuid = { version = "1.22.0", features = ["v4"] }
 keyring = "3.6.3"
 reqwest = { version = "0.13.2", features = ["json"] }
+tokio = { version = "1.50.0", features = ["rt"] }
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -13,13 +13,37 @@ pub struct AuthStatus {
     pub error: Option<String>,
 }
 
+/// Maps a token validation result to an [`AuthStatus`].
+///
+/// - `Ok(username)` → connected with username
+/// - `Err(AppError::Auth(_))` → disconnected (invalid/expired token)
+/// - `Err(other)` → disconnected with error detail (transient failure)
+fn status_from_validation(result: Result<String, AppError>) -> AuthStatus {
+    match result {
+        Ok(username) => AuthStatus {
+            connected: true,
+            username: Some(username),
+            error: None,
+        },
+        Err(AppError::Auth(_)) => AuthStatus {
+            connected: false,
+            username: None,
+            error: None,
+        },
+        Err(e) => AuthStatus {
+            connected: false,
+            username: None,
+            error: Some(e.to_string()),
+        },
+    }
+}
+
 /// Validates and stores a GitHub token. Returns the authenticated username.
 #[tauri::command]
 pub async fn auth_set_token(token: String) -> Result<String, String> {
     let token = token.trim().to_string();
     let username = auth::validate_token(&token).await.map_err(String::from)?;
-    let token_clone = token.clone();
-    tokio::task::spawn_blocking(move || auth::store_token(&token_clone))
+    tokio::task::spawn_blocking(move || auth::store_token(&token))
         .await
         .map_err(|e| format!("task join error: {e}"))?
         .map_err(String::from)?;
@@ -40,23 +64,7 @@ pub async fn auth_get_status() -> Result<AuthStatus, String> {
         .map_err(|e| format!("task join error: {e}"))?
         .map_err(String::from)?;
     match token {
-        Some(ref t) => match auth::validate_token(t).await {
-            Ok(username) => Ok(AuthStatus {
-                connected: true,
-                username: Some(username),
-                error: None,
-            }),
-            Err(AppError::Auth(_)) => Ok(AuthStatus {
-                connected: false,
-                username: None,
-                error: None,
-            }),
-            Err(e) => Ok(AuthStatus {
-                connected: false,
-                username: None,
-                error: Some(e.to_string()),
-            }),
-        },
+        Some(ref t) => Ok(status_from_validation(auth::validate_token(t).await)),
         None => Ok(AuthStatus {
             connected: false,
             username: None,
@@ -129,16 +137,49 @@ mod tests {
         assert!(result.unwrap_err().contains("empty"));
     }
 
+    // -- status_from_validation tests cover auth_get_status branching logic --
+
     #[test]
-    fn test_auth_status_debug_impl() {
-        let status = AuthStatus {
-            connected: true,
-            username: Some("user".into()),
-            error: None,
-        };
-        let debug = format!("{status:?}");
-        assert!(debug.contains("AuthStatus"));
-        assert!(debug.contains("true"));
-        assert!(debug.contains("user"));
+    fn test_status_from_validation_success() {
+        let status = status_from_validation(Ok("octocat".into()));
+        assert!(status.connected);
+        assert_eq!(status.username.as_deref(), Some("octocat"));
+        assert!(status.error.is_none());
+    }
+
+    #[test]
+    fn test_status_from_validation_auth_error() {
+        let status =
+            status_from_validation(Err(AppError::Auth("invalid or expired token".into())));
+        assert!(!status.connected);
+        assert!(status.username.is_none());
+        assert!(status.error.is_none());
+    }
+
+    #[test]
+    fn test_status_from_validation_transient_error() {
+        let status =
+            status_from_validation(Err(AppError::GitHub("request failed: timeout".into())));
+        assert!(!status.connected);
+        assert!(status.username.is_none());
+        let err = status.error.unwrap();
+        assert!(
+            err.contains("timeout"),
+            "expected 'timeout' in '{err}'"
+        );
+    }
+
+    #[test]
+    fn test_status_from_validation_rate_limit() {
+        let status = status_from_validation(Err(AppError::RateLimit {
+            reset_at: "2026-03-25T19:00:00Z".into(),
+        }));
+        assert!(!status.connected);
+        assert!(status.username.is_none());
+        let err = status.error.unwrap();
+        assert!(
+            err.contains("rate limited"),
+            "expected 'rate limited' in '{err}'"
+        );
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -52,17 +52,33 @@ pub async fn auth_set_token(token: String) -> Result<String, String> {
 
 /// Returns the current authentication status.
 ///
-/// If a token is stored, validates it against GitHub to confirm it is still
-/// active and returns `connected: true` with the username.
+/// **Note:** this command performs a live HTTP request to the GitHub API
+/// to validate the stored token. Callers should debounce or cache results
+/// (e.g. via `TanStack Query` `staleTime`) to avoid excessive API usage.
+///
 /// Auth errors (invalid/expired token) return `connected: false`.
-/// Transient errors (network, rate-limit) return `connected: false` with an
-/// `error` field so the frontend can distinguish offline from logged-out.
+/// Transient errors (network, rate-limit, keychain) return `connected: false`
+/// with an `error` field so the frontend can distinguish offline from
+/// logged-out.
 #[tauri::command]
 pub async fn auth_get_status() -> Result<AuthStatus, String> {
-    let token: Option<String> = tokio::task::spawn_blocking(auth::get_token)
-        .await
-        .map_err(|e| format!("task join error: {e}"))?
-        .map_err(String::from)?;
+    let token: Option<String> = match tokio::task::spawn_blocking(auth::get_token).await {
+        Ok(Ok(t)) => t,
+        Ok(Err(e)) => {
+            return Ok(AuthStatus {
+                connected: false,
+                username: None,
+                error: Some(e.to_string()),
+            });
+        }
+        Err(e) => {
+            return Ok(AuthStatus {
+                connected: false,
+                username: None,
+                error: Some(format!("task join error: {e}")),
+            });
+        }
+    };
     match token {
         Some(ref t) => Ok(status_from_validation(auth::validate_token(t).await)),
         None => Ok(AuthStatus {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -149,8 +149,7 @@ mod tests {
 
     #[test]
     fn test_status_from_validation_auth_error() {
-        let status =
-            status_from_validation(Err(AppError::Auth("invalid or expired token".into())));
+        let status = status_from_validation(Err(AppError::Auth("invalid or expired token".into())));
         assert!(!status.connected);
         assert!(status.username.is_none());
         assert!(status.error.is_none());
@@ -163,10 +162,7 @@ mod tests {
         assert!(!status.connected);
         assert!(status.username.is_none());
         let err = status.error.unwrap();
-        assert!(
-            err.contains("timeout"),
-            "expected 'timeout' in '{err}'"
-        );
+        assert!(err.contains("timeout"), "expected 'timeout' in '{err}'");
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,1 +1,126 @@
+use serde::Serialize;
 
+use crate::github::auth;
+
+/// Authentication status returned by [`auth_get_status`].
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AuthStatus {
+    pub connected: bool,
+    pub username: Option<String>,
+}
+
+/// Validates and stores a GitHub token. Returns the authenticated username.
+#[tauri::command]
+pub async fn auth_set_token(token: String) -> Result<String, String> {
+    let token = token.trim();
+    let username = auth::validate_token(token).await.map_err(String::from)?;
+    auth::store_token(token).map_err(String::from)?;
+    Ok(username)
+}
+
+/// Returns the current authentication status.
+///
+/// If a token is stored, validates it against GitHub to confirm it is still
+/// active and returns `connected: true` with the username.
+/// If no token or validation fails, returns `connected: false`.
+#[tauri::command]
+pub async fn auth_get_status() -> Result<AuthStatus, String> {
+    let token = auth::get_token().map_err(String::from)?;
+    match token {
+        Some(t) => match auth::validate_token(&t).await {
+            Ok(username) => Ok(AuthStatus {
+                connected: true,
+                username: Some(username),
+            }),
+            Err(_) => Ok(AuthStatus {
+                connected: false,
+                username: None,
+            }),
+        },
+        None => Ok(AuthStatus {
+            connected: false,
+            username: None,
+        }),
+    }
+}
+
+/// Deletes the stored GitHub token (logout).
+/// Synchronous: keyring deletion is a blocking syscall with no async I/O.
+#[tauri::command]
+pub fn auth_logout() -> Result<(), String> {
+    auth::delete_token().map_err(String::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_auth_status_serializes_connected() {
+        let status = AuthStatus {
+            connected: true,
+            username: Some("testuser".into()),
+        };
+        let json = serde_json::to_value(&status).unwrap();
+        assert_eq!(json["connected"], true);
+        assert_eq!(json["username"], "testuser");
+    }
+
+    #[test]
+    fn test_auth_status_serializes_disconnected() {
+        let status = AuthStatus {
+            connected: false,
+            username: None,
+        };
+        let json = serde_json::to_value(&status).unwrap();
+        assert_eq!(json["connected"], false);
+        assert!(json["username"].is_null());
+    }
+
+    #[test]
+    fn test_auth_status_uses_camel_case() {
+        let status = AuthStatus {
+            connected: true,
+            username: Some("user".into()),
+        };
+        let json = serde_json::to_string(&status).unwrap();
+        assert!(json.contains("connected"));
+        assert!(json.contains("username"));
+        // Verify camelCase — no snake_case keys
+        assert!(!json.contains("user_name"));
+    }
+
+    #[tokio::test]
+    async fn test_auth_set_token_rejects_empty() {
+        let result = auth_set_token("".into()).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("empty"));
+    }
+
+    #[tokio::test]
+    async fn test_auth_set_token_rejects_whitespace() {
+        let result = auth_set_token("   ".into()).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("empty"));
+    }
+
+    #[test]
+    fn test_auth_logout_returns_ok_type() {
+        // Verify the function signature compiles — actual keyring
+        // interaction tested in integration tests
+        let _: fn() -> Result<(), String> = auth_logout;
+    }
+
+    #[test]
+    fn test_auth_status_debug_impl() {
+        let status = AuthStatus {
+            connected: true,
+            username: Some("user".into()),
+        };
+        let debug = format!("{status:?}");
+        assert!(debug.contains("AuthStatus"));
+        assert!(debug.contains("true"));
+        assert!(debug.contains("user"));
+    }
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,5 +1,6 @@
 use serde::Serialize;
 
+use crate::error::AppError;
 use crate::github::auth;
 
 /// Authentication status returned by [`auth_get_status`].
@@ -8,14 +9,20 @@ use crate::github::auth;
 pub struct AuthStatus {
     pub connected: bool,
     pub username: Option<String>,
+    /// Non-null when a transient error (network, rate-limit) prevents validation.
+    pub error: Option<String>,
 }
 
 /// Validates and stores a GitHub token. Returns the authenticated username.
 #[tauri::command]
 pub async fn auth_set_token(token: String) -> Result<String, String> {
-    let token = token.trim();
-    let username = auth::validate_token(token).await.map_err(String::from)?;
-    auth::store_token(token).map_err(String::from)?;
+    let token = token.trim().to_string();
+    let username = auth::validate_token(&token).await.map_err(String::from)?;
+    let token_clone = token.clone();
+    tokio::task::spawn_blocking(move || auth::store_token(&token_clone))
+        .await
+        .map_err(|e| format!("task join error: {e}"))?
+        .map_err(String::from)?;
     Ok(username)
 }
 
@@ -23,33 +30,48 @@ pub async fn auth_set_token(token: String) -> Result<String, String> {
 ///
 /// If a token is stored, validates it against GitHub to confirm it is still
 /// active and returns `connected: true` with the username.
-/// If no token or validation fails, returns `connected: false`.
+/// Auth errors (invalid/expired token) return `connected: false`.
+/// Transient errors (network, rate-limit) return `connected: false` with an
+/// `error` field so the frontend can distinguish offline from logged-out.
 #[tauri::command]
 pub async fn auth_get_status() -> Result<AuthStatus, String> {
-    let token = auth::get_token().map_err(String::from)?;
+    let token: Option<String> = tokio::task::spawn_blocking(auth::get_token)
+        .await
+        .map_err(|e| format!("task join error: {e}"))?
+        .map_err(String::from)?;
     match token {
-        Some(t) => match auth::validate_token(&t).await {
+        Some(ref t) => match auth::validate_token(t).await {
             Ok(username) => Ok(AuthStatus {
                 connected: true,
                 username: Some(username),
+                error: None,
             }),
-            Err(_) => Ok(AuthStatus {
+            Err(AppError::Auth(_)) => Ok(AuthStatus {
                 connected: false,
                 username: None,
+                error: None,
+            }),
+            Err(e) => Ok(AuthStatus {
+                connected: false,
+                username: None,
+                error: Some(e.to_string()),
             }),
         },
         None => Ok(AuthStatus {
             connected: false,
             username: None,
+            error: None,
         }),
     }
 }
 
 /// Deletes the stored GitHub token (logout).
-/// Synchronous: keyring deletion is a blocking syscall with no async I/O.
 #[tauri::command]
-pub fn auth_logout() -> Result<(), String> {
-    auth::delete_token().map_err(String::from)
+pub async fn auth_logout() -> Result<(), String> {
+    tokio::task::spawn_blocking(auth::delete_token)
+        .await
+        .map_err(|e| format!("task join error: {e}"))?
+        .map_err(String::from)
 }
 
 #[cfg(test)]
@@ -61,10 +83,12 @@ mod tests {
         let status = AuthStatus {
             connected: true,
             username: Some("testuser".into()),
+            error: None,
         };
         let json = serde_json::to_value(&status).unwrap();
         assert_eq!(json["connected"], true);
         assert_eq!(json["username"], "testuser");
+        assert!(json["error"].is_null());
     }
 
     #[test]
@@ -72,6 +96,7 @@ mod tests {
         let status = AuthStatus {
             connected: false,
             username: None,
+            error: None,
         };
         let json = serde_json::to_value(&status).unwrap();
         assert_eq!(json["connected"], false);
@@ -79,16 +104,15 @@ mod tests {
     }
 
     #[test]
-    fn test_auth_status_uses_camel_case() {
+    fn test_auth_status_serializes_with_error() {
         let status = AuthStatus {
-            connected: true,
-            username: Some("user".into()),
+            connected: false,
+            username: None,
+            error: Some("GitHub API error: request failed: timeout".into()),
         };
-        let json = serde_json::to_string(&status).unwrap();
-        assert!(json.contains("connected"));
-        assert!(json.contains("username"));
-        // Verify camelCase — no snake_case keys
-        assert!(!json.contains("user_name"));
+        let json = serde_json::to_value(&status).unwrap();
+        assert_eq!(json["connected"], false);
+        assert!(json["error"].as_str().unwrap().contains("timeout"));
     }
 
     #[tokio::test]
@@ -106,17 +130,11 @@ mod tests {
     }
 
     #[test]
-    fn test_auth_logout_returns_ok_type() {
-        // Verify the function signature compiles — actual keyring
-        // interaction tested in integration tests
-        let _: fn() -> Result<(), String> = auth_logout;
-    }
-
-    #[test]
     fn test_auth_status_debug_impl() {
         let status = AuthStatus {
             connected: true,
             username: Some("user".into()),
+            error: None,
         };
         let debug = format!("{status:?}");
         assert!(debug.contains("AuthStatus"));

--- a/src-tauri/src/github/auth.rs
+++ b/src-tauri/src/github/auth.rs
@@ -5,7 +5,6 @@ use crate::error::AppError;
 
 const SERVICE_NAME: &str = "prism-github";
 const ACCOUNT_NAME: &str = "default";
-#[allow(dead_code)] // Used by validate_token, called from T-026 Tauri commands
 const GITHUB_API_URL: &str = "https://api.github.com";
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -70,7 +69,6 @@ impl TokenStore for KeyringTokenStore {
 
 /// Stores a GitHub token in the system keychain.
 /// Rejects empty or whitespace-only tokens.
-#[allow(dead_code)] // Called from T-026 Tauri commands
 pub fn store_token(token: &str) -> Result<(), AppError> {
     let token = token.trim();
     if token.is_empty() {
@@ -81,20 +79,17 @@ pub fn store_token(token: &str) -> Result<(), AppError> {
 
 /// Retrieves the GitHub token from the system keychain.
 /// Returns `Ok(None)` if no token is stored. Propagates keychain errors.
-#[allow(dead_code)] // Called from T-026 Tauri commands
 pub fn get_token() -> Result<Option<String>, AppError> {
     KeyringTokenStore.get_token()
 }
 
 /// Deletes the GitHub token from the system keychain.
-#[allow(dead_code)] // Called from T-026 Tauri commands
 pub fn delete_token() -> Result<(), AppError> {
     KeyringTokenStore.delete_token()
 }
 
 /// Validates a GitHub token by calling GET /user on the GitHub API.
 /// Returns the authenticated username on success.
-#[allow(dead_code)] // Called from T-026 Tauri commands
 pub async fn validate_token(token: &str) -> Result<String, AppError> {
     let token = token.trim();
     if token.is_empty() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -20,6 +20,11 @@ pub fn run() {
             }
             Ok(())
         })
+        .invoke_handler(tauri::generate_handler![
+            commands::auth_set_token,
+            commands::auth_get_status,
+            commands::auth_logout,
+        ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }


### PR DESCRIPTION
## Summary

- Add 3 Tauri IPC commands: `auth_set_token`, `auth_get_status`, `auth_logout` wrapping the keyring auth module (T-025)
- Add `AuthStatus` struct with camelCase serialization for frontend consumption
- Register commands in `lib.rs` invoke_handler
- Remove `#[allow(dead_code)]` annotations from `auth.rs` (functions now called from commands)

## Test plan

- [x] 7 unit tests covering serialization, empty/whitespace rejection, type signatures
- [x] 123 total tests passing (full suite)
- [x] Zero clippy warnings
- [x] Verify commands are accessible from frontend via `invoke("auth_set_token", ...)`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds three Tauri IPC commands for GitHub auth with clear status reporting and non-blocking keychain access. Implements T-026 on top of T-025 keyring auth and improves testability.

- **New Features**
  - `auth_set_token(token: string) -> string`: trims input, validates with GitHub, stores in keyring, returns the username.
  - `auth_get_status() -> { connected: boolean, username?: string, error?: string }`: camelCase `AuthStatus`.
  - `auth_logout() -> void`: deletes the stored token.

- **Refactors**
  - Use `tokio::spawn_blocking` for keychain I/O (adds `tokio` dep); distinguish auth errors from transient errors in `auth_get_status`.
  - Removed token clone; extracted `status_from_validation`; added tests for success, auth error, transient error, and rate-limit.

<sup>Written for commit d30d6923273ed287c959e8c1a6e53ae4868e7232. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub authentication: set/store tokens, check auth status (connected, username, error), and logout to clear credentials
  * Token input is trimmed, asynchronously validated, persisted, and rejects empty/whitespace inputs; transient validation errors are surfaced
  * Auth actions exposed to the app UI via IPC/command handlers

* **Tests**
  * Unit tests for auth-status serialization, token validation/rejection, and status branching for success, auth failure, transient and rate-limit errors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->