### PR TITLE
feat(auth): add AuthSetup UI component (T-027)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@fontsource/ibm-plex-mono": "^5.2.7",
         "@fontsource/ibm-plex-sans": "^5.2.8",
+        "@tanstack/react-query": "^5.95.2",
         "@tauri-apps/api": "^2.10.1",
         "react": "^19.2.4",
         "react-dom": "^19.2.4"
@@ -20,6 +21,7 @@
         "@tauri-apps/cli": "^2.10.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
@@ -1848,6 +1850,32 @@
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.95.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.95.2.tgz",
+      "integrity": "sha512-o4T8vZHZET4Bib3jZ/tCW9/7080urD4c+0/AUaYVpIqOsr7y0reBc1oX3ttNaSW5mYyvZHctiQ/UOP2PfdmFEQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.95.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.95.2.tgz",
+      "integrity": "sha512-/wGkvLj/st5Ud1Q76KF1uFxScV7WeqN1slQx5280ycwAyYkIPGaRZAEgHxe3bjirSd5Zpwkj6zNcR4cqYni/ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.95.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
     "node_modules/@tauri-apps/api": {
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.10.1.tgz",
@@ -2149,6 +2177,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@fontsource/ibm-plex-mono": "^5.2.7",
     "@fontsource/ibm-plex-sans": "^5.2.8",
+    "@tanstack/react-query": "^5.95.2",
     "@tauri-apps/api": "^2.10.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
@@ -38,6 +39,7 @@
     "@tauri-apps/cli": "^2.10.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",

--- a/src/components/AuthSetup/AuthSetup.test.tsx
+++ b/src/components/AuthSetup/AuthSetup.test.tsx
@@ -100,7 +100,7 @@ describe("AuthSetup", () => {
       expect(screen.getByLabelText(/token/i)).toBeInTheDocument();
     });
 
-    await user.type(screen.getByLabelText(/token/i), "ghp_validtoken123");
+    await user.type(screen.getByLabelText(/token/i), "  ghp_validtoken123  ");
     await user.click(screen.getByRole("button", { name: /connect/i }));
 
     await waitFor(() => {

--- a/src/components/AuthSetup/AuthSetup.test.tsx
+++ b/src/components/AuthSetup/AuthSetup.test.tsx
@@ -1,0 +1,185 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { AuthSetup } from "./AuthSetup";
+
+// Mock the tauri IPC wrappers
+vi.mock("../../lib/tauri", () => ({
+  authSetToken: vi.fn(),
+  authGetStatus: vi.fn(),
+  authLogout: vi.fn(),
+}));
+
+import { authSetToken, authGetStatus, authLogout } from "../../lib/tauri";
+
+const mockedAuthSetToken = vi.mocked(authSetToken);
+const mockedAuthGetStatus = vi.mocked(authGetStatus);
+const mockedAuthLogout = vi.mocked(authLogout);
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe("AuthSetup", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("should show token input when disconnected", async () => {
+    mockedAuthGetStatus.mockResolvedValue({
+      connected: false,
+      username: null,
+      error: null,
+    });
+
+    render(<AuthSetup />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/token/i)).toBeInTheDocument();
+    });
+    expect(screen.getByRole("button", { name: /connect/i })).toBeInTheDocument();
+  });
+
+  it("should show username when connected", async () => {
+    mockedAuthGetStatus.mockResolvedValue({
+      connected: true,
+      username: "octocat",
+      error: null,
+    });
+
+    render(<AuthSetup />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByText("octocat")).toBeInTheDocument();
+    });
+    expect(screen.getByRole("button", { name: /disconnect/i })).toBeInTheDocument();
+    expect(screen.queryByLabelText(/token/i)).not.toBeInTheDocument();
+  });
+
+  it("should display error on invalid token", async () => {
+    mockedAuthGetStatus.mockResolvedValue({
+      connected: false,
+      username: null,
+      error: null,
+    });
+    mockedAuthSetToken.mockRejectedValue(new Error("invalid or expired token"));
+
+    const user = userEvent.setup();
+    render(<AuthSetup />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/token/i)).toBeInTheDocument();
+    });
+
+    await user.type(screen.getByLabelText(/token/i), "ghp_invalid123");
+    await user.click(screen.getByRole("button", { name: /connect/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(/invalid or expired token/i);
+    });
+  });
+
+  it("should call auth_set_token on submit", async () => {
+    mockedAuthGetStatus.mockResolvedValue({
+      connected: false,
+      username: null,
+      error: null,
+    });
+    mockedAuthSetToken.mockResolvedValue("octocat");
+
+    const user = userEvent.setup();
+    render(<AuthSetup />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/token/i)).toBeInTheDocument();
+    });
+
+    await user.type(screen.getByLabelText(/token/i), "ghp_validtoken123");
+    await user.click(screen.getByRole("button", { name: /connect/i }));
+
+    await waitFor(() => {
+      expect(mockedAuthSetToken).toHaveBeenCalled();
+      expect(mockedAuthSetToken.mock.calls[0]?.[0]).toBe("ghp_validtoken123");
+    });
+  });
+
+  it("should call auth_logout on disconnect", async () => {
+    mockedAuthGetStatus.mockResolvedValue({
+      connected: true,
+      username: "octocat",
+      error: null,
+    });
+    mockedAuthLogout.mockResolvedValue(undefined);
+
+    const user = userEvent.setup();
+    render(<AuthSetup />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /disconnect/i })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /disconnect/i }));
+
+    await waitFor(() => {
+      expect(mockedAuthLogout).toHaveBeenCalledOnce();
+    });
+  });
+
+  it("should disable submit button when token is empty", async () => {
+    mockedAuthGetStatus.mockResolvedValue({
+      connected: false,
+      username: null,
+      error: null,
+    });
+
+    render(<AuthSetup />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /connect/i })).toBeDisabled();
+    });
+  });
+
+  it("should show loading state during submission", async () => {
+    mockedAuthGetStatus.mockResolvedValue({
+      connected: false,
+      username: null,
+      error: null,
+    });
+    // Never resolves — keeps loading state
+    mockedAuthSetToken.mockReturnValue(new Promise(() => {}));
+
+    const user = userEvent.setup();
+    render(<AuthSetup />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/token/i)).toBeInTheDocument();
+    });
+
+    await user.type(screen.getByLabelText(/token/i), "ghp_token123");
+    await user.click(screen.getByRole("button", { name: /connect/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /connect/i })).toBeDisabled();
+    });
+  });
+
+  it("should display transient error from status", async () => {
+    mockedAuthGetStatus.mockResolvedValue({
+      connected: false,
+      username: null,
+      error: "GitHub API error: request failed: timeout",
+    });
+
+    render(<AuthSetup />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(/timeout/i);
+    });
+  });
+});

--- a/src/components/AuthSetup/AuthSetup.test.tsx
+++ b/src/components/AuthSetup/AuthSetup.test.tsx
@@ -68,7 +68,7 @@ describe("AuthSetup", () => {
       username: null,
       error: null,
     });
-    mockedAuthSetToken.mockRejectedValue(new Error("invalid or expired token"));
+    mockedAuthSetToken.mockRejectedValue("invalid or expired token");
 
     const user = userEvent.setup();
     render(<AuthSetup />, { wrapper: createWrapper() });
@@ -85,7 +85,7 @@ describe("AuthSetup", () => {
     });
   });
 
-  it("should call auth_set_token on submit", async () => {
+  it("should call auth_set_token on submit with trimmed token", async () => {
     mockedAuthGetStatus.mockResolvedValue({
       connected: false,
       username: null,
@@ -105,7 +105,8 @@ describe("AuthSetup", () => {
 
     await waitFor(() => {
       expect(mockedAuthSetToken).toHaveBeenCalled();
-      expect(mockedAuthSetToken.mock.calls[0]?.[0]).toBe("ghp_validtoken123");
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- guarded by toHaveBeenCalled above
+      expect(mockedAuthSetToken.mock.calls[0]![0]).toBe("ghp_validtoken123");
     });
   });
 
@@ -180,6 +181,39 @@ describe("AuthSetup", () => {
 
     await waitFor(() => {
       expect(screen.getByRole("alert")).toHaveTextContent(/timeout/i);
+    });
+  });
+
+  it("should show error state when status query fails", async () => {
+    mockedAuthGetStatus.mockRejectedValue("IPC connection failed");
+
+    render(<AuthSetup />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(/IPC connection failed/i);
+    });
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+
+  it("should display logout error when disconnect fails", async () => {
+    mockedAuthGetStatus.mockResolvedValue({
+      connected: true,
+      username: "octocat",
+      error: null,
+    });
+    mockedAuthLogout.mockRejectedValue("keyring access denied");
+
+    const user = userEvent.setup();
+    render(<AuthSetup />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /disconnect/i })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /disconnect/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(/keyring access denied/i);
     });
   });
 });

--- a/src/components/AuthSetup/AuthSetup.tsx
+++ b/src/components/AuthSetup/AuthSetup.tsx
@@ -1,0 +1,103 @@
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { authSetToken, authGetStatus, authLogout } from "../../lib/tauri";
+
+export function AuthSetup() {
+  const [token, setToken] = useState("");
+  const queryClient = useQueryClient();
+
+  const statusQuery = useQuery({
+    queryKey: ["auth", "status"],
+    queryFn: authGetStatus,
+    staleTime: 60_000,
+  });
+
+  const setTokenMutation = useMutation({
+    mutationFn: authSetToken,
+    onSuccess: () => {
+      setToken("");
+      queryClient.invalidateQueries({ queryKey: ["auth", "status"] });
+    },
+  });
+
+  const logoutMutation = useMutation({
+    mutationFn: authLogout,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["auth", "status"] });
+    },
+  });
+
+  const status = statusQuery.data;
+  const isConnected = status?.connected === true;
+  const transientError = status?.error ?? null;
+  const mutationError = setTokenMutation.error
+    ? String(setTokenMutation.error.message ?? setTokenMutation.error)
+    : null;
+  const displayError = mutationError ?? transientError;
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (token.trim()) {
+      setTokenMutation.mutate(token);
+    }
+  }
+
+  if (statusQuery.isLoading) {
+    return (
+      <div className="flex items-center justify-center p-6">
+        <p className="text-sm text-muted">Checking authentication…</p>
+      </div>
+    );
+  }
+
+  if (isConnected) {
+    return (
+      <div className="flex flex-col items-center gap-4 rounded-lg border border-border bg-surface p-6">
+        <p className="text-sm text-muted">Connected as</p>
+        <p className="text-lg font-semibold text-accent">{status?.username}</p>
+        <button
+          type="button"
+          onClick={() => logoutMutation.mutate()}
+          disabled={logoutMutation.isPending}
+          className="rounded-md border border-border bg-bg px-4 py-2 text-sm text-fg transition-colors hover:bg-surface disabled:opacity-50"
+        >
+          Disconnect
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="flex flex-col gap-4 rounded-lg border border-border bg-surface p-6"
+    >
+      <label htmlFor="auth-token" className="text-sm font-medium text-fg">
+        GitHub Token
+      </label>
+      <input
+        id="auth-token"
+        type="password"
+        value={token}
+        onChange={(e) => setToken(e.target.value)}
+        placeholder="ghp_..."
+        autoComplete="off"
+        className="rounded-md border border-border bg-bg px-3 py-2 font-mono text-sm text-fg placeholder:text-muted focus:border-accent focus:outline-none"
+      />
+
+      {displayError && (
+        <p role="alert" className="text-sm text-red">
+          {displayError}
+        </p>
+      )}
+
+      <button
+        type="submit"
+        disabled={!token.trim() || setTokenMutation.isPending}
+        className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-bg transition-colors hover:opacity-90 disabled:opacity-50"
+      >
+        Connect
+      </button>
+    </form>
+  );
+}

--- a/src/components/AuthSetup/AuthSetup.tsx
+++ b/src/components/AuthSetup/AuthSetup.tsx
@@ -31,7 +31,7 @@ export function AuthSetup() {
   const isConnected = status?.connected === true;
   const transientError = status?.error ?? null;
   const mutationError = setTokenMutation.error
-    ? String(setTokenMutation.error.message ?? setTokenMutation.error)
+    ? setTokenMutation.error.message
     : null;
   const displayError = mutationError ?? transientError;
 
@@ -54,7 +54,7 @@ export function AuthSetup() {
     return (
       <div className="flex flex-col items-center gap-4 rounded-lg border border-border bg-surface p-6">
         <p className="text-sm text-muted">Connected as</p>
-        <p className="text-lg font-semibold text-accent">{status?.username}</p>
+        <p className="text-lg font-semibold text-accent">{status.username ?? "unknown"}</p>
         <button
           type="button"
           onClick={() => logoutMutation.mutate()}

--- a/src/components/AuthSetup/AuthSetup.tsx
+++ b/src/components/AuthSetup/AuthSetup.tsx
@@ -2,6 +2,11 @@ import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { authSetToken, authGetStatus, authLogout } from "../../lib/tauri";
 
+function extractErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}
+
 export function AuthSetup() {
   const [token, setToken] = useState("");
   const queryClient = useQueryClient();
@@ -30,15 +35,15 @@ export function AuthSetup() {
   const status = statusQuery.data;
   const isConnected = status?.connected === true;
   const transientError = status?.error ?? null;
-  const mutationError = setTokenMutation.error
-    ? setTokenMutation.error.message
-    : null;
-  const displayError = mutationError ?? transientError;
+  const mutationError = setTokenMutation.error ? extractErrorMessage(setTokenMutation.error) : null;
+  const logoutError = logoutMutation.error ? extractErrorMessage(logoutMutation.error) : null;
+  const displayError = mutationError ?? logoutError ?? transientError;
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    if (token.trim()) {
-      setTokenMutation.mutate(token);
+    const trimmed = token.trim();
+    if (trimmed) {
+      setTokenMutation.mutate(trimmed);
     }
   }
 
@@ -46,6 +51,23 @@ export function AuthSetup() {
     return (
       <div className="flex items-center justify-center p-6">
         <p className="text-sm text-muted">Checking authentication…</p>
+      </div>
+    );
+  }
+
+  if (statusQuery.isError) {
+    return (
+      <div className="flex flex-col items-center gap-4 rounded-lg border border-border bg-surface p-6">
+        <p role="alert" className="text-sm text-red">
+          {extractErrorMessage(statusQuery.error)}
+        </p>
+        <button
+          type="button"
+          onClick={() => statusQuery.refetch()}
+          className="rounded-md border border-border bg-bg px-4 py-2 text-sm text-fg transition-colors hover:bg-surface"
+        >
+          Retry
+        </button>
       </div>
     );
   }
@@ -63,6 +85,11 @@ export function AuthSetup() {
         >
           Disconnect
         </button>
+        {logoutError && (
+          <p role="alert" className="text-sm text-red">
+            {logoutError}
+          </p>
+        )}
       </div>
     );
   }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1,0 +1,14 @@
+import { invoke } from "@tauri-apps/api/core";
+import type { AuthStatus } from "./types";
+
+export async function authSetToken(token: string): Promise<string> {
+  return invoke<string>("auth_set_token", { token });
+}
+
+export async function authGetStatus(): Promise<AuthStatus> {
+  return invoke<AuthStatus>("auth_get_status");
+}
+
+export async function authLogout(): Promise<void> {
+  return invoke<void>("auth_logout");
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1,14 +1,15 @@
 import { invoke } from "@tauri-apps/api/core";
+import { TAURI_COMMANDS } from "./types";
 import type { AuthStatus } from "./types";
 
 export async function authSetToken(token: string): Promise<string> {
-  return invoke<string>("auth_set_token", { token });
+  return invoke<string>(TAURI_COMMANDS.auth_set_token, { token });
 }
 
 export async function authGetStatus(): Promise<AuthStatus> {
-  return invoke<AuthStatus>("auth_get_status");
+  return invoke<AuthStatus>(TAURI_COMMANDS.auth_get_status);
 }
 
 export async function authLogout(): Promise<void> {
-  return invoke<void>("auth_logout");
+  return invoke<void>(TAURI_COMMANDS.auth_logout);
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -142,6 +142,14 @@ export interface DashboardStats {
   readonly unreadActivity: number;
 }
 
+// ── Auth (T-027) ─────────────────────────────────────────────────
+
+export interface AuthStatus {
+  readonly connected: boolean;
+  readonly username: string | null;
+  readonly error: string | null;
+}
+
 // ── IPC payloads (T-011) ─────────────────────────────────────────
 
 export interface OpenWorkspaceRequest {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,15 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import "./index.css";
 import App from "./App";
 
+const queryClient = new QueryClient();
+
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
   </React.StrictMode>,
 );


### PR DESCRIPTION
## Summary

- Add `AuthSetup` React component for GitHub token management (input/validate/disconnect)
- Add typed Tauri IPC wrappers (`authSetToken`, `authGetStatus`, `authLogout`) in `src/lib/tauri.ts`
- Add `AuthStatus` interface to `src/lib/types.ts` mirroring Rust struct
- Install `@tanstack/react-query` and `@testing-library/user-event`
- Uses `useQuery` for status polling and `useMutation` for token operations

## Test plan

- [x] 8 unit tests covering all acceptance criteria
- [x] Token input visible when disconnected
- [x] Username displayed when connected
- [x] Error displayed on invalid token
- [x] `auth_set_token` called on form submit
- [x] `auth_logout` called on disconnect
- [x] Button disabled when token empty
- [x] Loading state during submission
- [x] Transient error from status displayed
- [x] All 48 TS tests pass (`npx vitest run`)
- [x] TypeScript strict mode clean (`tsc --noEmit`)
- [x] oxlint + oxfmt clean

Depends on: T-026 (merged), T-012 (merged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an authentication setup UI: enter token to connect, view authenticated username, disconnect, with loading, retry and error handling.

* **Tests**
  * Added comprehensive UI tests covering connect/disconnect flows, error states, retries, and disabled/button states.

* **Chores**
  * Added runtime and testing dependencies to support the new auth UI and tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->