### PR TITLE
feat(github): configure graphql_client and generate types (T-028)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1513,6 +1513,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "graphql-introspection-query"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e063446242093b0acecc78a2313801e6c4faafa3501277b409a2b1972eff5d85"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "graphql-parser"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a818c0d883d7c0801df27be910917750932be279c7bc82dc541b8769425f409"
+dependencies = [
+ "combine",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "graphql_client"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f04840854efa7b06377d86fab117f598f5f5c95727067463417ccaf8aa7635"
+dependencies = [
+ "graphql_query_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "graphql_client_codegen"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa0141e66c8d0302f8a586df12ad5d0cf87c0fa8c391f2f5b5dc296312dce569"
+dependencies = [
+ "graphql-introspection-query",
+ "graphql-parser",
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "graphql_query_derive"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16ecf9bb87a6760cf5227f66cbe48bad7b89505aeb002aa9439ea090e6038a3"
+dependencies = [
+ "graphql_client_codegen",
+ "proc-macro2",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "gtk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3042,6 +3099,7 @@ name = "prism"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "graphql_client",
  "keyring",
  "log",
  "mockito",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,6 +28,7 @@ uuid = { version = "1.22.0", features = ["v4"] }
 keyring = "3.6.3"
 reqwest = { version = "0.13.2", features = ["json"] }
 tokio = { version = "1.50.0", features = ["rt"] }
+graphql_client = { version = "0.16.0", features = ["graphql_query_derive"] }
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/src-tauri/src/github/graphql/dashboard.graphql
+++ b/src-tauri/src/github/graphql/dashboard.graphql
@@ -1,0 +1,93 @@
+fragment PrFields on PullRequest {
+  id
+  number
+  title
+  author { __typename login }
+  state
+  isDraft
+  url
+  createdAt
+  updatedAt
+  additions
+  deletions
+  headRefName
+  repository { nameWithOwner }
+  labels(first: 10) { nodes { name } }
+  reviewRequests(first: 10) {
+    totalCount
+    nodes {
+      requestedReviewer {
+        __typename
+        ... on User { login }
+        ... on Team { name }
+      }
+    }
+  }
+  reviews(first: 20) {
+    nodes {
+      author { __typename login }
+      state
+      createdAt
+    }
+  }
+  commits(last: 1) {
+    nodes {
+      commit {
+        statusCheckRollup { state }
+      }
+    }
+  }
+}
+
+fragment IssueFields on Issue {
+  id
+  number
+  title
+  author { __typename login }
+  state
+  url
+  createdAt
+  updatedAt
+  repository { nameWithOwner }
+  labels(first: 10) { nodes { name } }
+}
+
+query DashboardData(
+  $reviewQuery: String!
+  $myPrsQuery: String!
+  $issuesQuery: String!
+  $first: Int!
+) {
+  reviewRequests: search(query: $reviewQuery, type: ISSUE, first: $first) {
+    nodes {
+      __typename
+      ... on PullRequest { ...PrFields }
+    }
+    pageInfo { endCursor hasNextPage }
+  }
+  myPullRequests: search(query: $myPrsQuery, type: ISSUE, first: $first) {
+    nodes {
+      __typename
+      ... on PullRequest { ...PrFields }
+    }
+    pageInfo { endCursor hasNextPage }
+  }
+  assignedIssues: search(query: $issuesQuery, type: ISSUE, first: $first) {
+    nodes {
+      __typename
+      ... on Issue { ...IssueFields }
+    }
+    pageInfo { endCursor hasNextPage }
+  }
+}
+
+query RecentActivity($activityQuery: String!, $first: Int!) {
+  search(query: $activityQuery, type: ISSUE, first: $first) {
+    nodes {
+      __typename
+      ... on PullRequest { ...PrFields }
+      ... on Issue { ...IssueFields }
+    }
+    pageInfo { endCursor hasNextPage }
+  }
+}

--- a/src-tauri/src/github/graphql/dashboard.graphql
+++ b/src-tauri/src/github/graphql/dashboard.graphql
@@ -23,7 +23,7 @@ fragment PrFields on PullRequest {
       }
     }
   }
-  reviews(first: 20) {
+  reviews(first: 50) {
     nodes {
       author { __typename login }
       state
@@ -58,26 +58,25 @@ query DashboardData(
   $issuesQuery: String!
   $first: Int!
 ) {
+  # NOTE: Pagination (after/endCursor) intentionally deferred to a future task.
+  # The schema supports `after: String` on search(); add $after variables here when needed.
   reviewRequests: search(query: $reviewQuery, type: ISSUE, first: $first) {
     nodes {
       __typename
       ... on PullRequest { ...PrFields }
     }
-    pageInfo { endCursor hasNextPage }
   }
   myPullRequests: search(query: $myPrsQuery, type: ISSUE, first: $first) {
     nodes {
       __typename
       ... on PullRequest { ...PrFields }
     }
-    pageInfo { endCursor hasNextPage }
   }
   assignedIssues: search(query: $issuesQuery, type: ISSUE, first: $first) {
     nodes {
       __typename
       ... on Issue { ...IssueFields }
     }
-    pageInfo { endCursor hasNextPage }
   }
 }
 
@@ -88,6 +87,5 @@ query RecentActivity($activityQuery: String!, $first: Int!) {
       ... on PullRequest { ...PrFields }
       ... on Issue { ...IssueFields }
     }
-    pageInfo { endCursor hasNextPage }
   }
 }

--- a/src-tauri/src/github/graphql/pull_request_detail.graphql
+++ b/src-tauri/src/github/graphql/pull_request_detail.graphql
@@ -1,0 +1,45 @@
+query PullRequestDetail($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      id
+      number
+      title
+      author { __typename login }
+      state
+      isDraft
+      url
+      createdAt
+      updatedAt
+      additions
+      deletions
+      headRefName
+      baseRefName
+      repository { nameWithOwner }
+      labels(first: 20) { nodes { name } }
+      reviewRequests(first: 20) {
+        totalCount
+        nodes {
+          requestedReviewer {
+            __typename
+            ... on User { login }
+            ... on Team { name }
+          }
+        }
+      }
+      reviews(first: 50) {
+        nodes {
+          author { __typename login }
+          state
+          createdAt
+        }
+      }
+      commits(last: 1) {
+        nodes {
+          commit {
+            statusCheckRollup { state }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src-tauri/src/github/graphql/schema.graphql
+++ b/src-tauri/src/github/graphql/schema.graphql
@@ -1,0 +1,232 @@
+# Minimal GitHub GraphQL schema for PRism queries.
+# Covers only the types used by dashboard.graphql and pull_request_detail.graphql.
+
+scalar DateTime
+scalar URI
+
+type Query {
+  search(query: String!, type: SearchType!, first: Int, after: String): SearchResultItemConnection!
+  repository(owner: String!, name: String!): Repository
+  viewer: User!
+}
+
+enum SearchType {
+  ISSUE
+  REPOSITORY
+  USER
+  DISCUSSION
+}
+
+interface Node {
+  id: ID!
+}
+
+type SearchResultItemConnection {
+  nodes: [SearchResultItem]
+  pageInfo: PageInfo!
+  issueCount: Int!
+}
+
+union SearchResultItem = PullRequest | Issue | Repository | User | Discussion
+
+type PageInfo {
+  endCursor: String
+  hasNextPage: Boolean!
+}
+
+# ── Pull Request ──────────────────────────────────────────────────
+
+type PullRequest implements Node {
+  id: ID!
+  number: Int!
+  title: String!
+  author: Actor
+  state: PullRequestState!
+  isDraft: Boolean!
+  url: URI!
+  createdAt: DateTime!
+  updatedAt: DateTime!
+  additions: Int!
+  deletions: Int!
+  headRefName: String!
+  baseRefName: String!
+  repository: Repository!
+  labels(first: Int): LabelConnection
+  reviewRequests(first: Int): ReviewRequestConnection
+  reviews(first: Int, states: [PullRequestReviewState!]): PullRequestReviewConnection
+  commits(last: Int): PullRequestCommitConnection
+}
+
+enum PullRequestState {
+  OPEN
+  CLOSED
+  MERGED
+}
+
+# ── Issue ─────────────────────────────────────────────────────────
+
+type Issue implements Node {
+  id: ID!
+  number: Int!
+  title: String!
+  author: Actor
+  state: IssueState!
+  url: URI!
+  createdAt: DateTime!
+  updatedAt: DateTime!
+  repository: Repository!
+  labels(first: Int): LabelConnection
+  assignees(first: Int): UserConnection
+}
+
+enum IssueState {
+  OPEN
+  CLOSED
+}
+
+# ── Actors ────────────────────────────────────────────────────────
+
+interface Actor {
+  login: String!
+  avatarUrl: URI
+}
+
+type User implements Node & Actor {
+  id: ID!
+  login: String!
+  avatarUrl: URI
+  name: String
+}
+
+type Bot implements Node & Actor {
+  id: ID!
+  login: String!
+  avatarUrl: URI
+}
+
+type Organization implements Node & Actor {
+  id: ID!
+  login: String!
+  avatarUrl: URI
+}
+
+type Mannequin implements Node & Actor {
+  id: ID!
+  login: String!
+  avatarUrl: URI
+}
+
+type EnterpriseUserAccount implements Node & Actor {
+  id: ID!
+  login: String!
+  avatarUrl: URI
+}
+
+# ── Repository ────────────────────────────────────────────────────
+
+type Repository implements Node {
+  id: ID!
+  name: String!
+  owner: RepositoryOwner!
+  url: URI!
+  defaultBranchRef: Ref
+  isArchived: Boolean!
+  nameWithOwner: String!
+  pullRequest(number: Int!): PullRequest
+}
+
+interface RepositoryOwner {
+  login: String!
+}
+
+type Ref {
+  name: String!
+}
+
+# ── Labels ────────────────────────────────────────────────────────
+
+type LabelConnection {
+  nodes: [Label]
+}
+
+type Label implements Node {
+  id: ID!
+  name: String!
+}
+
+# ── Reviews ───────────────────────────────────────────────────────
+
+type ReviewRequestConnection {
+  nodes: [ReviewRequest]
+  totalCount: Int!
+}
+
+type ReviewRequest {
+  requestedReviewer: RequestedReviewer
+}
+
+union RequestedReviewer = User | Team | Bot | Mannequin
+
+type Team implements Node {
+  id: ID!
+  name: String!
+  slug: String!
+}
+
+type PullRequestReviewConnection {
+  nodes: [PullRequestReview]
+}
+
+enum PullRequestReviewState {
+  PENDING
+  COMMENTED
+  APPROVED
+  CHANGES_REQUESTED
+  DISMISSED
+}
+
+type PullRequestReview implements Node {
+  id: ID!
+  author: Actor
+  state: PullRequestReviewState!
+  createdAt: DateTime!
+}
+
+# ── CI / Status ───────────────────────────────────────────────────
+
+type PullRequestCommitConnection {
+  nodes: [PullRequestCommit]
+}
+
+type PullRequestCommit {
+  commit: Commit!
+}
+
+type Commit implements Node {
+  id: ID!
+  statusCheckRollup: StatusCheckRollup
+}
+
+type StatusCheckRollup {
+  state: StatusState!
+}
+
+enum StatusState {
+  EXPECTED
+  ERROR
+  FAILURE
+  PENDING
+  SUCCESS
+}
+
+# ── Users ─────────────────────────────────────────────────────────
+
+type UserConnection {
+  nodes: [User]
+}
+
+# ── Stub types for union completeness ─────────────────────────────
+
+type Discussion implements Node {
+  id: ID!
+}

--- a/src-tauri/src/github/graphql/schema.graphql
+++ b/src-tauri/src/github/graphql/schema.graphql
@@ -1,5 +1,8 @@
-# Minimal GitHub GraphQL schema for PRism queries.
+# Minimal GitHub GraphQL schema subset for PRism queries.
 # Covers only the types used by dashboard.graphql and pull_request_detail.graphql.
+# This is NOT the full GitHub schema — members like ISSUE_ADVANCED (SearchType) and
+# App/MarketplaceListing (SearchResultItem) are intentionally omitted.
+# If queries grow, consider replacing with a full introspection snapshot.
 
 scalar DateTime
 scalar URI

--- a/src-tauri/src/github/mod.rs
+++ b/src-tauri/src/github/mod.rs
@@ -1,2 +1,2 @@
 pub mod auth;
-pub mod queries;
+pub(crate) mod queries;

--- a/src-tauri/src/github/mod.rs
+++ b/src-tauri/src/github/mod.rs
@@ -1,1 +1,2 @@
 pub mod auth;
+pub mod queries;

--- a/src-tauri/src/github/queries.rs
+++ b/src-tauri/src/github/queries.rs
@@ -1,0 +1,75 @@
+#![allow(dead_code)] // Generated types used by T-029 (client) and T-030 (mapping)
+
+use graphql_client::GraphQLQuery;
+
+type DateTime = String;
+#[allow(clippy::upper_case_acronyms)]
+type URI = String;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/github/graphql/schema.graphql",
+    query_path = "src/github/graphql/dashboard.graphql",
+    response_derives = "Debug, Clone",
+    variables_derives = "Debug"
+)]
+pub struct DashboardData;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/github/graphql/schema.graphql",
+    query_path = "src/github/graphql/dashboard.graphql",
+    response_derives = "Debug, Clone",
+    variables_derives = "Debug"
+)]
+pub struct RecentActivity;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/github/graphql/schema.graphql",
+    query_path = "src/github/graphql/pull_request_detail.graphql",
+    response_derives = "Debug, Clone",
+    variables_derives = "Debug"
+)]
+pub struct PullRequestDetail;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_dashboard_query_variables_construction() {
+        let vars = dashboard_data::Variables {
+            review_query: "type:pr review-requested:octocat state:open".into(),
+            my_prs_query: "type:pr author:octocat state:open".into(),
+            issues_query: "type:issue assignee:octocat state:open".into(),
+            first: 25,
+        };
+        assert_eq!(vars.first, 25);
+        assert!(vars.review_query.contains("review-requested:octocat"));
+        assert!(vars.my_prs_query.contains("author:octocat"));
+        assert!(vars.issues_query.contains("assignee:octocat"));
+    }
+
+    #[test]
+    fn test_activity_query_variables_construction() {
+        let vars = recent_activity::Variables {
+            activity_query: "type:pr type:issue involves:octocat updated:>2026-03-01".into(),
+            first: 50,
+        };
+        assert_eq!(vars.first, 50);
+        assert!(vars.activity_query.contains("involves:octocat"));
+    }
+
+    #[test]
+    fn test_pull_request_detail_variables_construction() {
+        let vars = pull_request_detail::Variables {
+            owner: "mpiton".into(),
+            name: "prism".into(),
+            number: 42,
+        };
+        assert_eq!(vars.owner, "mpiton");
+        assert_eq!(vars.name, "prism");
+        assert_eq!(vars.number, 42);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `graphql_client` v0.16 with derive macro support to Cargo.toml
- Create minimal GitHub GraphQL schema (`schema.graphql`) covering PR, Issue, Review, CI types
- Write `dashboard.graphql` with `DashboardData` (aliased searches for review requests, own PRs, assigned issues) and `RecentActivity` queries
- Write `pull_request_detail.graphql` with `PullRequestDetail` query
- Create `queries.rs` with 3 `#[derive(GraphQLQuery)]` structs generating typed Variables and ResponseData
- All generated types compile without error (128 tests pass, clippy clean)

## Test plan

- [x] `test_dashboard_query_variables_construction` — verifies 4-field Variables struct
- [x] `test_activity_query_variables_construction` — verifies 2-field Variables struct
- [x] `test_pull_request_detail_variables_construction` — verifies owner/name/number Variables
- [x] Full test suite passes (128 tests)
- [x] Clippy strict (`-D warnings`) clean
- [x] `cargo fmt` clean

Depends on: T-007 (merged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detailed pull request view: author, labels, review requests, recent reviews, latest build status, timestamps, additions/deletions, branch and repo info.
  * Dashboard: pending review requests, your pull requests, and assigned issues in one place.
  * Recent activity feed combining pull request and issue updates for quick review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->