### PR TITLE
feat(cache): Implement activity sync from GitHub GraphQL API (T-033)

### DIFF
--- a/src-tauri/src/cache/activity.rs
+++ b/src-tauri/src/cache/activity.rs
@@ -133,6 +133,33 @@ pub async fn mark_all_read(pool: &SqlitePool) -> Result<u64, AppError> {
     Ok(result.rows_affected())
 }
 
+/// Insert an activity, ignoring duplicates (by primary key).
+///
+/// Returns `true` if a new row was inserted, `false` if the ID already existed.
+/// Accepts any sqlx executor (pool, connection, or transaction) for flexibility.
+#[allow(dead_code)]
+pub async fn upsert_activity<'e, E>(executor: E, activity: &Activity) -> Result<bool, AppError>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Sqlite>,
+{
+    let result = sqlx::query(
+        "INSERT OR IGNORE INTO activity (id, activity_type, actor, repo_id, pull_request_id, issue_id, message, created_at) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+    )
+    .bind(&activity.id)
+    .bind(activity_type_to_str(&activity.activity_type))
+    .bind(&activity.actor)
+    .bind(&activity.repo_id)
+    .bind(&activity.pull_request_id)
+    .bind(&activity.issue_id)
+    .bind(&activity.message)
+    .bind(&activity.created_at)
+    .execute(executor)
+    .await?;
+
+    Ok(result.rows_affected() > 0)
+}
+
 /// Retrieve a single activity by ID.
 #[allow(dead_code)]
 pub async fn get_activity_by_id(pool: &SqlitePool, id: &str) -> Result<Option<Activity>, AppError> {

--- a/src-tauri/src/cache/sync.rs
+++ b/src-tauri/src/cache/sync.rs
@@ -8,6 +8,7 @@ use std::collections::HashSet;
 
 use sqlx::SqlitePool;
 
+use crate::cache::activity::upsert_activity;
 use crate::cache::dashboard::compute_dashboard_stats;
 use crate::cache::issues::upsert_issue;
 use crate::cache::pull_requests::upsert_pull_request;
@@ -16,9 +17,10 @@ use crate::cache::reviews::upsert_review;
 use crate::error::AppError;
 use crate::github::client::GitHubClient;
 use crate::github::models::{map_issue, map_pr, map_review};
-use crate::github::queries::DashboardData;
 use crate::github::queries::dashboard_data::{self, IssueFields, PrFields};
-use crate::types::{DashboardStats, Repo};
+use crate::github::queries::recent_activity;
+use crate::github::queries::{DashboardData, RecentActivity};
+use crate::types::{Activity, ActivityType, DashboardStats, Repo};
 
 /// Synchronize dashboard data from GitHub API into the local cache.
 ///
@@ -290,6 +292,147 @@ impl AsIssueFields for dashboard_data::DashboardDataAssignedIssuesNodes {
             _ => None,
         }
     }
+}
+
+// ── Activity sync (T-033) ──────────────────────────────────────
+
+/// Validate that a `since` value contains only ISO 8601 safe characters.
+///
+/// Prevents search query injection via malicious `since` values.
+/// Accepts date (`2026-03-01`) or datetime (`2026-03-01T10:00:00Z`).
+fn validate_since(since: &str) -> Result<(), AppError> {
+    let valid = since.len() >= 10
+        && since
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == ':' || c == 'T' || c == 'Z');
+
+    if valid {
+        Ok(())
+    } else {
+        Err(AppError::Config(format!("invalid since value: {since}")))
+    }
+}
+
+/// Synchronize recent activity from GitHub API into the local cache.
+///
+/// 1. Build search query: `involves:{username} updated:>{since}`
+/// 2. Execute GraphQL `RecentActivity` query
+/// 3. Map PR and Issue nodes to `Activity` items
+/// 4. Deduplicate by ID in memory
+/// 5. Insert new items (skip already-known IDs via `INSERT OR IGNORE`)
+/// 6. Return the count of newly inserted activities
+///
+/// Note: `pull_request_id` and `issue_id` FK fields on `Activity` are left
+/// `None` because the referenced entities may not exist in the local cache
+/// (e.g. mentions from repos not tracked by `sync_dashboard`). The entity
+/// node ID is embedded in the deterministic `activity.id` for traceability.
+pub async fn sync_activity(
+    client: &GitHubClient,
+    pool: &SqlitePool,
+    username: &str,
+    since: &str,
+) -> Result<u32, AppError> {
+    validate_username(username)?;
+    validate_since(since)?;
+
+    let variables = recent_activity::Variables {
+        activity_query: format!("involves:{username} updated:>{since}"),
+        first: 100,
+    };
+
+    let data = client.execute_graphql::<RecentActivity>(variables).await?;
+
+    let activities = map_activity_nodes(&data);
+    let inserted = persist_activity_batch(pool, &activities).await?;
+
+    Ok(inserted)
+}
+
+/// Map all search nodes from a `RecentActivity` response to `Activity` items.
+///
+/// Skips unrecognized node types (e.g. future GitHub schema additions).
+/// Activity type is derived from the item state (open/merged/closed).
+/// The activity ID is deterministic: `activity-{pr|issue}-{node_id}`.
+fn map_activity_nodes(data: &recent_activity::ResponseData) -> Vec<Activity> {
+    let mut activities = Vec::new();
+
+    let Some(nodes) = &data.search.nodes else {
+        return activities;
+    };
+
+    for node in nodes.iter().filter_map(|n| n.as_ref()) {
+        match node {
+            recent_activity::RecentActivitySearchNodes::PullRequest(pr) => {
+                let activity_type = match &pr.state {
+                    recent_activity::PullRequestState::MERGED => ActivityType::PrMerged,
+                    recent_activity::PullRequestState::CLOSED => ActivityType::PrClosed,
+                    _ => ActivityType::PrOpened,
+                };
+                let actor = pr
+                    .author
+                    .as_ref()
+                    .map_or_else(|| "ghost".to_string(), |a| a.login.clone());
+
+                activities.push(Activity {
+                    id: format!("activity-pr-{}", pr.id),
+                    activity_type,
+                    actor,
+                    repo_id: pr.repository.name_with_owner.clone(),
+                    pull_request_id: None,
+                    issue_id: None,
+                    message: format!("PR #{}: {}", pr.number, pr.title),
+                    created_at: pr.updated_at.clone(),
+                });
+            }
+            recent_activity::RecentActivitySearchNodes::Issue(issue) => {
+                let activity_type = match &issue.state {
+                    recent_activity::IssueState::CLOSED => ActivityType::IssueClosed,
+                    _ => ActivityType::IssueOpened,
+                };
+                let actor = issue
+                    .author
+                    .as_ref()
+                    .map_or_else(|| "ghost".to_string(), |a| a.login.clone());
+
+                activities.push(Activity {
+                    id: format!("activity-issue-{}", issue.id),
+                    activity_type,
+                    actor,
+                    repo_id: issue.repository.name_with_owner.clone(),
+                    pull_request_id: None,
+                    issue_id: None,
+                    message: format!("Issue #{}: {}", issue.number, issue.title),
+                    created_at: issue.updated_at.clone(),
+                });
+            }
+            _ => {}
+        }
+    }
+
+    activities
+}
+
+/// Persist a batch of `Activity` items, deduplicating by ID.
+///
+/// Uses `INSERT OR IGNORE` to skip activities already in the database.
+/// In-memory dedup via `HashSet` prevents redundant SQL round-trips
+/// when the same node appears multiple times in the API response.
+///
+/// Returns the count of newly inserted rows.
+async fn persist_activity_batch(
+    pool: &SqlitePool,
+    activities: &[Activity],
+) -> Result<u32, AppError> {
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut inserted: u32 = 0;
+
+    for activity in activities {
+        if seen.insert(activity.id.clone()) && upsert_activity(pool, activity).await? {
+            inserted += 1;
+        }
+    }
+
+    Ok(inserted)
 }
 
 #[cfg(test)]
@@ -736,5 +879,201 @@ mod tests {
             .unwrap();
         assert_eq!(repo.last_sync_at.as_deref(), Some("2026-03-26T12:00:00Z"));
         pool.close().await;
+    }
+
+    // ── Activity sync tests (T-033) ──────────────────────────────
+
+    fn make_activity_pr_node(
+        id: &str,
+        number: i64,
+        title: &str,
+        state: recent_activity::PullRequestState,
+    ) -> recent_activity::RecentActivitySearchNodes {
+        recent_activity::RecentActivitySearchNodes::PullRequest(recent_activity::PrFields {
+            id: id.to_string(),
+            number,
+            title: title.to_string(),
+            author: Some(recent_activity::PrFieldsAuthor {
+                login: "octocat".to_string(),
+                on: recent_activity::PrFieldsAuthorOn::User,
+            }),
+            state,
+            is_draft: false,
+            url: format!("https://github.com/org/repo/pull/{number}"),
+            created_at: "2026-03-20T10:00:00Z".to_string(),
+            updated_at: "2026-03-25T15:00:00Z".to_string(),
+            additions: 10,
+            deletions: 5,
+            head_ref_name: "fix/something".to_string(),
+            repository: recent_activity::PrFieldsRepository {
+                name_with_owner: "org/repo".to_string(),
+            },
+            labels: None,
+            review_requests: None,
+            reviews: None,
+            commits: None,
+        })
+    }
+
+    fn make_activity_issue_node(
+        id: &str,
+        number: i64,
+        title: &str,
+        state: recent_activity::IssueState,
+    ) -> recent_activity::RecentActivitySearchNodes {
+        recent_activity::RecentActivitySearchNodes::Issue(recent_activity::IssueFields {
+            id: id.to_string(),
+            number,
+            title: title.to_string(),
+            author: Some(recent_activity::IssueFieldsAuthor {
+                login: "alice".to_string(),
+                on: recent_activity::IssueFieldsAuthorOn::User,
+            }),
+            state,
+            url: format!("https://github.com/org/repo/issues/{number}"),
+            created_at: "2026-03-20T10:00:00Z".to_string(),
+            updated_at: "2026-03-25T16:00:00Z".to_string(),
+            repository: recent_activity::IssueFieldsRepository {
+                name_with_owner: "org/repo".to_string(),
+            },
+            labels: None,
+        })
+    }
+
+    fn make_activity_response(
+        nodes: Vec<recent_activity::RecentActivitySearchNodes>,
+    ) -> recent_activity::ResponseData {
+        recent_activity::ResponseData {
+            search: recent_activity::RecentActivitySearch {
+                nodes: Some(nodes.into_iter().map(Some).collect()),
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn test_sync_activity_inserts_mentions() {
+        let (pool, _tmp) = test_pool().await;
+        upsert_repo(&pool, &sample_repo()).await.unwrap();
+
+        let response = make_activity_response(vec![
+            make_activity_pr_node(
+                "PR_A",
+                10,
+                "Fix auth",
+                recent_activity::PullRequestState::OPEN,
+            ),
+            make_activity_issue_node(
+                "ISSUE_B",
+                20,
+                "Bug in login",
+                recent_activity::IssueState::OPEN,
+            ),
+        ]);
+
+        let activities = map_activity_nodes(&response);
+        assert_eq!(activities.len(), 2);
+
+        let inserted = persist_activity_batch(&pool, &activities).await.unwrap();
+        assert_eq!(inserted, 2);
+
+        // Verify the PR activity
+        let pr_act = crate::cache::activity::get_activity_by_id(&pool, "activity-pr-PR_A")
+            .await
+            .unwrap()
+            .expect("PR activity should exist");
+        assert_eq!(pr_act.activity_type, ActivityType::PrOpened);
+        assert_eq!(pr_act.actor, "octocat");
+        assert_eq!(pr_act.repo_id, "org/repo");
+        assert_eq!(pr_act.pull_request_id, None);
+        assert!(pr_act.message.contains("PR #10"));
+
+        // Verify the Issue activity
+        let issue_act = crate::cache::activity::get_activity_by_id(&pool, "activity-issue-ISSUE_B")
+            .await
+            .unwrap()
+            .expect("Issue activity should exist");
+        assert_eq!(issue_act.activity_type, ActivityType::IssueOpened);
+        assert_eq!(issue_act.actor, "alice");
+        assert_eq!(issue_act.issue_id, None);
+        assert!(issue_act.message.contains("Issue #20"));
+
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_sync_activity_dedup() {
+        let (pool, _tmp) = test_pool().await;
+        upsert_repo(&pool, &sample_repo()).await.unwrap();
+
+        // Same PR appears twice in the response (can happen with search queries)
+        let response = make_activity_response(vec![
+            make_activity_pr_node(
+                "PR_DUP",
+                42,
+                "Same PR",
+                recent_activity::PullRequestState::OPEN,
+            ),
+            make_activity_pr_node(
+                "PR_DUP",
+                42,
+                "Same PR",
+                recent_activity::PullRequestState::OPEN,
+            ),
+        ]);
+
+        let activities = map_activity_nodes(&response);
+        // Both map to the same activity-pr-PR_DUP ID
+        assert_eq!(activities.len(), 2);
+
+        // persist_activity_batch deduplicates by ID
+        let inserted = persist_activity_batch(&pool, &activities).await.unwrap();
+        assert_eq!(inserted, 1, "duplicate should be skipped");
+
+        // Second call: already in DB, INSERT OR IGNORE skips
+        let inserted_again = persist_activity_batch(&pool, &activities).await.unwrap();
+        assert_eq!(
+            inserted_again, 0,
+            "already-persisted items should be skipped"
+        );
+
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_sync_activity_empty() {
+        let (pool, _tmp) = test_pool().await;
+
+        let response = recent_activity::ResponseData {
+            search: recent_activity::RecentActivitySearch { nodes: None },
+        };
+
+        let activities = map_activity_nodes(&response);
+        assert!(activities.is_empty());
+
+        let inserted = persist_activity_batch(&pool, &activities).await.unwrap();
+        assert_eq!(inserted, 0);
+
+        pool.close().await;
+    }
+
+    #[test]
+    fn test_validate_since_valid() {
+        assert!(validate_since("2026-03-01").is_ok());
+        assert!(validate_since("2026-03-01T10:00:00Z").is_ok());
+        assert!(validate_since("2026-01-15T23:59:59Z").is_ok());
+    }
+
+    #[test]
+    fn test_validate_since_invalid() {
+        assert!(validate_since("").is_err(), "empty");
+        assert!(validate_since("short").is_err(), "too short");
+        assert!(
+            validate_since("2026-03-01 involves:evil").is_err(),
+            "injection attempt"
+        );
+        assert!(
+            validate_since("2026-03-01T10:00:00Z extra").is_err(),
+            "space in value"
+        );
     }
 }

--- a/src-tauri/src/cache/sync.rs
+++ b/src-tauri/src/cache/sync.rs
@@ -299,12 +299,16 @@ impl AsIssueFields for dashboard_data::DashboardDataAssignedIssuesNodes {
 /// Validate that a `since` value contains only ISO 8601 safe characters.
 ///
 /// Prevents search query injection via malicious `since` values.
-/// Accepts date (`2026-03-01`) or datetime (`2026-03-01T10:00:00Z`).
+/// Accepts date (`2026-03-01`) or datetime (`2026-03-01T10:00:00Z`),
+/// including timezone offsets (`+05:30`) and fractional seconds (`.123`).
 fn validate_since(since: &str) -> Result<(), AppError> {
+    let bytes = since.as_bytes();
     let valid = since.len() >= 10
+        && bytes.get(4) == Some(&b'-')
+        && bytes.get(7) == Some(&b'-')
         && since
             .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == ':' || c == 'T' || c == 'Z');
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | ':' | 'T' | 'Z' | '+' | '.'));
 
     if valid {
         Ok(())
@@ -352,7 +356,9 @@ pub async fn sync_activity(
 ///
 /// Skips unrecognized node types (e.g. future GitHub schema additions).
 /// Activity type is derived from the item state (open/merged/closed).
-/// The activity ID is deterministic: `activity-{pr|issue}-{node_id}`.
+/// The activity ID is deterministic and state-specific:
+/// `activity-{pr|issue}-{node_id}-{state}` so that state transitions
+/// (e.g. open → merged) produce distinct records in the activity feed.
 fn map_activity_nodes(data: &recent_activity::ResponseData) -> Vec<Activity> {
     let mut activities = Vec::new();
 
@@ -363,10 +369,10 @@ fn map_activity_nodes(data: &recent_activity::ResponseData) -> Vec<Activity> {
     for node in nodes.iter().filter_map(|n| n.as_ref()) {
         match node {
             recent_activity::RecentActivitySearchNodes::PullRequest(pr) => {
-                let activity_type = match &pr.state {
-                    recent_activity::PullRequestState::MERGED => ActivityType::PrMerged,
-                    recent_activity::PullRequestState::CLOSED => ActivityType::PrClosed,
-                    _ => ActivityType::PrOpened,
+                let (activity_type, state_tag) = match &pr.state {
+                    recent_activity::PullRequestState::MERGED => (ActivityType::PrMerged, "merged"),
+                    recent_activity::PullRequestState::CLOSED => (ActivityType::PrClosed, "closed"),
+                    _ => (ActivityType::PrOpened, "open"),
                 };
                 let actor = pr
                     .author
@@ -374,7 +380,7 @@ fn map_activity_nodes(data: &recent_activity::ResponseData) -> Vec<Activity> {
                     .map_or_else(|| "ghost".to_string(), |a| a.login.clone());
 
                 activities.push(Activity {
-                    id: format!("activity-pr-{}", pr.id),
+                    id: format!("activity-pr-{}-{state_tag}", pr.id),
                     activity_type,
                     actor,
                     repo_id: pr.repository.name_with_owner.clone(),
@@ -385,9 +391,9 @@ fn map_activity_nodes(data: &recent_activity::ResponseData) -> Vec<Activity> {
                 });
             }
             recent_activity::RecentActivitySearchNodes::Issue(issue) => {
-                let activity_type = match &issue.state {
-                    recent_activity::IssueState::CLOSED => ActivityType::IssueClosed,
-                    _ => ActivityType::IssueOpened,
+                let (activity_type, state_tag) = match &issue.state {
+                    recent_activity::IssueState::CLOSED => (ActivityType::IssueClosed, "closed"),
+                    _ => (ActivityType::IssueOpened, "open"),
                 };
                 let actor = issue
                     .author
@@ -395,7 +401,7 @@ fn map_activity_nodes(data: &recent_activity::ResponseData) -> Vec<Activity> {
                     .map_or_else(|| "ghost".to_string(), |a| a.login.clone());
 
                 activities.push(Activity {
-                    id: format!("activity-issue-{}", issue.id),
+                    id: format!("activity-issue-{}-{state_tag}", issue.id),
                     activity_type,
                     actor,
                     repo_id: issue.repository.name_with_owner.clone(),
@@ -414,9 +420,10 @@ fn map_activity_nodes(data: &recent_activity::ResponseData) -> Vec<Activity> {
 
 /// Persist a batch of `Activity` items, deduplicating by ID.
 ///
-/// Uses `INSERT OR IGNORE` to skip activities already in the database.
+/// Uses a single transaction for atomicity and performance.
 /// In-memory dedup via `HashSet` prevents redundant SQL round-trips
 /// when the same node appears multiple times in the API response.
+/// `INSERT OR IGNORE` skips activities already in the database.
 ///
 /// Returns the count of newly inserted rows.
 async fn persist_activity_batch(
@@ -425,13 +432,16 @@ async fn persist_activity_batch(
 ) -> Result<u32, AppError> {
     let mut seen: HashSet<String> = HashSet::new();
     let mut inserted: u32 = 0;
+    let mut tx = pool.begin().await?;
 
     for activity in activities {
-        if seen.insert(activity.id.clone()) && upsert_activity(pool, activity).await? {
+        #[allow(clippy::explicit_auto_deref)]
+        if seen.insert(activity.id.clone()) && upsert_activity(&mut *tx, activity).await? {
             inserted += 1;
         }
     }
 
+    tx.commit().await?;
     Ok(inserted)
 }
 
@@ -976,8 +986,8 @@ mod tests {
         let inserted = persist_activity_batch(&pool, &activities).await.unwrap();
         assert_eq!(inserted, 2);
 
-        // Verify the PR activity
-        let pr_act = crate::cache::activity::get_activity_by_id(&pool, "activity-pr-PR_A")
+        // Verify the PR activity (state-specific ID: open)
+        let pr_act = crate::cache::activity::get_activity_by_id(&pool, "activity-pr-PR_A-open")
             .await
             .unwrap()
             .expect("PR activity should exist");
@@ -987,11 +997,12 @@ mod tests {
         assert_eq!(pr_act.pull_request_id, None);
         assert!(pr_act.message.contains("PR #10"));
 
-        // Verify the Issue activity
-        let issue_act = crate::cache::activity::get_activity_by_id(&pool, "activity-issue-ISSUE_B")
-            .await
-            .unwrap()
-            .expect("Issue activity should exist");
+        // Verify the Issue activity (state-specific ID: open)
+        let issue_act =
+            crate::cache::activity::get_activity_by_id(&pool, "activity-issue-ISSUE_B-open")
+                .await
+                .unwrap()
+                .expect("Issue activity should exist");
         assert_eq!(issue_act.activity_type, ActivityType::IssueOpened);
         assert_eq!(issue_act.actor, "alice");
         assert_eq!(issue_act.issue_id, None);
@@ -1022,7 +1033,7 @@ mod tests {
         ]);
 
         let activities = map_activity_nodes(&response);
-        // Both map to the same activity-pr-PR_DUP ID
+        // Both map to the same activity-pr-PR_DUP-open ID
         assert_eq!(activities.len(), 2);
 
         // persist_activity_batch deduplicates by ID
@@ -1056,11 +1067,66 @@ mod tests {
         pool.close().await;
     }
 
+    #[tokio::test]
+    async fn test_sync_activity_state_transitions() {
+        let (pool, _tmp) = test_pool().await;
+        upsert_repo(&pool, &sample_repo()).await.unwrap();
+
+        // First sync: PR is open
+        let response_open = make_activity_response(vec![make_activity_pr_node(
+            "PR_X",
+            99,
+            "My PR",
+            recent_activity::PullRequestState::OPEN,
+        )]);
+        let activities_open = map_activity_nodes(&response_open);
+        let inserted = persist_activity_batch(&pool, &activities_open)
+            .await
+            .unwrap();
+        assert_eq!(inserted, 1);
+
+        // Second sync: same PR is now merged — should produce a NEW record
+        let response_merged = make_activity_response(vec![make_activity_pr_node(
+            "PR_X",
+            99,
+            "My PR",
+            recent_activity::PullRequestState::MERGED,
+        )]);
+        let activities_merged = map_activity_nodes(&response_merged);
+        let inserted = persist_activity_batch(&pool, &activities_merged)
+            .await
+            .unwrap();
+        assert_eq!(
+            inserted, 1,
+            "merged state should produce a new activity record"
+        );
+
+        // Both records exist in DB
+        let open = crate::cache::activity::get_activity_by_id(&pool, "activity-pr-PR_X-open")
+            .await
+            .unwrap();
+        assert!(open.is_some());
+        assert_eq!(open.unwrap().activity_type, ActivityType::PrOpened);
+
+        let merged = crate::cache::activity::get_activity_by_id(&pool, "activity-pr-PR_X-merged")
+            .await
+            .unwrap();
+        assert!(merged.is_some());
+        assert_eq!(merged.unwrap().activity_type, ActivityType::PrMerged);
+
+        pool.close().await;
+    }
+
     #[test]
     fn test_validate_since_valid() {
         assert!(validate_since("2026-03-01").is_ok());
         assert!(validate_since("2026-03-01T10:00:00Z").is_ok());
         assert!(validate_since("2026-01-15T23:59:59Z").is_ok());
+        // Timezone offsets
+        assert!(validate_since("2026-03-01T10:00:00+05:30").is_ok());
+        assert!(validate_since("2026-03-01T10:00:00-05:30").is_ok());
+        // Fractional seconds
+        assert!(validate_since("2026-03-01T10:00:00.123Z").is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

• Implement `sync_activity()` to fetch recent GitHub activity (PR opens/merges/closes, issue opens/closes) via RecentActivity GraphQL query
• Add validation for `since` parameter (ISO 8601 format only) to prevent search query injection
• Map GraphQL PR/Issue nodes to Activity domain objects with deterministic ID generation
• Deduplication via in-memory HashSet + DB-level INSERT OR IGNORE
• Add `upsert_activity()` to activity.rs with generic executor pattern for transaction support
• Comprehensive test coverage: 5 new tests validating mapping, deduplication, empty responses, and validation

## Type

feat

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements T-033 by syncing recent GitHub PR/issue activity into the local cache for a user. Adds safer `since` validation, state-specific activity IDs, and transactional inserts to avoid duplicates and surface mentions across repos.

- **New Features**
  - `sync_activity()` runs `RecentActivity` GraphQL search `involves:{username} updated:>{since}` and maps nodes to `Activity`.
  - Deterministic, state-specific IDs `activity-{pr|issue}-{node_id}-{open|closed|merged}` so state changes create separate records.
  - In-memory dedup plus `upsert_activity()` using DB `INSERT OR IGNORE` within a single transaction; returns count of newly inserted rows.
  - Hardened input validation for `username` and ISO 8601 `since` (allows `+` and `.` for offsets/fractions; basic YYYY-MM-DD check) to prevent search query injection.

<sup>Written for commit 5f5214a574eb94e06ed499b846120c128e028b41. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added activity synchronization from GitHub to automatically track and store pull request and issue updates.
  * Added safe input validation and deduplication to ensure only new, sanitized activity records are stored.
* **Tests**
  * Added unit tests covering validation, activity mapping, persistence, deduplication, and state transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->