### PR TITLE
feat(github): implement github_get_dashboard command (T-035)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -112,16 +112,21 @@ pub async fn auth_get_status() -> Result<AuthStatus, String> {
 }
 
 /// Deletes the stored GitHub token and clears the cached username (logout).
+///
+/// Credential deletion runs first; the cache is only cleared after the
+/// token is confirmed removed, avoiding an inconsistent state where the
+/// cache is empty but the credential still exists.
 #[tauri::command]
 pub async fn auth_logout(cached: tauri::State<'_, GithubUsername>) -> Result<(), String> {
+    tokio::task::spawn_blocking(auth::delete_token)
+        .await
+        .map_err(|e| format!("task join error: {e}"))?
+        .map_err(String::from)?;
     match cached.0.lock() {
         Ok(mut guard) => *guard = None,
         Err(e) => warn!("failed to clear cached username (mutex poisoned): {e}"),
     }
-    tokio::task::spawn_blocking(auth::delete_token)
-        .await
-        .map_err(|e| format!("task join error: {e}"))?
-        .map_err(String::from)
+    Ok(())
 }
 
 /// Cached GitHub username, populated on first dashboard access.
@@ -137,13 +142,13 @@ pub struct GithubUsername(pub(crate) Mutex<Option<String>>);
 /// from the keychain, validates it against the GitHub API, and caches the
 /// resulting username for future calls.
 async fn resolve_username(cached: &GithubUsername) -> Result<String, String> {
-    // Read path: strict — fail if the lock is poisoned, since we cannot
-    // serve a dashboard without a username.
+    // Read path: best-effort — if the lock is poisoned, skip the cache
+    // and fall through to token re-validation rather than breaking the
+    // dashboard permanently.
+    if let Ok(guard) = cached.0.lock()
+        && let Some(ref u) = *guard
     {
-        let guard = cached.0.lock().map_err(|e| format!("lock error: {e}"))?;
-        if let Some(ref u) = *guard {
-            return Ok(u.clone());
-        }
+        return Ok(u.clone());
     }
 
     let token = tokio::task::spawn_blocking(auth::get_token)
@@ -293,27 +298,28 @@ mod tests {
         assert_eq!(result, "alice");
     }
 
-    #[test]
-    fn test_auth_set_token_updates_cache_on_success() {
+    #[tokio::test]
+    async fn test_resolve_username_skips_poisoned_cache() {
+        // A poisoned lock must not permanently break the dashboard;
+        // resolve_username should fall through to token validation.
         let cached = GithubUsername::default();
-        // Simulate successful login by writing to cache directly
-        match cached.0.lock() {
-            Ok(mut guard) => *guard = Some("newuser".into()),
-            Err(_) => panic!("lock poisoned"),
-        }
-        let guard = cached.0.lock().unwrap();
-        assert_eq!(guard.as_deref(), Some("newuser"));
-    }
 
-    #[test]
-    fn test_logout_clears_cached_username() {
-        let cached = GithubUsername(Mutex::new(Some("alice".into())));
-        // Simulate logout clearing the cache
-        match cached.0.lock() {
-            Ok(mut guard) => *guard = None,
-            Err(_) => panic!("lock poisoned"),
-        }
-        let guard = cached.0.lock().unwrap();
-        assert!(guard.is_none());
+        // Poison the lock by panicking inside a thread that holds it.
+        let cached_ref = &cached;
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = cached_ref.0.lock().unwrap();
+            panic!("intentional poison");
+        }));
+
+        // Lock is now poisoned — resolve_username should NOT return
+        // a lock error; it should skip the cache and try token validation,
+        // which will fail with "no token stored" in test environments.
+        let result = resolve_username(&cached).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            !err.contains("lock error"),
+            "poisoned lock should not bubble up as lock error, got: {err}"
+        );
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -44,15 +44,31 @@ fn status_from_validation(result: Result<String, AppError>) -> AuthStatus {
     }
 }
 
-/// Validates and stores a GitHub token. Returns the authenticated username.
-#[tauri::command]
-pub async fn auth_set_token(token: String) -> Result<String, String> {
+/// Core token validation and storage logic, callable from tests without Tauri state.
+async fn set_token_inner(token: String) -> Result<String, String> {
     let token = token.trim().to_string();
     let username = auth::validate_token(&token).await.map_err(String::from)?;
     tokio::task::spawn_blocking(move || auth::store_token(&token))
         .await
         .map_err(|e| format!("task join error: {e}"))?
         .map_err(String::from)?;
+    Ok(username)
+}
+
+/// Validates and stores a GitHub token. Returns the authenticated username.
+///
+/// Also updates the cached username so subsequent dashboard calls use the
+/// new identity without re-validating the token.
+#[tauri::command]
+pub async fn auth_set_token(
+    token: String,
+    cached: tauri::State<'_, GithubUsername>,
+) -> Result<String, String> {
+    let username = set_token_inner(token).await?;
+    match cached.0.lock() {
+        Ok(mut guard) => *guard = Some(username.clone()),
+        Err(e) => warn!("failed to update cached username: {e}"),
+    }
     Ok(username)
 }
 
@@ -121,6 +137,8 @@ pub struct GithubUsername(pub(crate) Mutex<Option<String>>);
 /// from the keychain, validates it against the GitHub API, and caches the
 /// resulting username for future calls.
 async fn resolve_username(cached: &GithubUsername) -> Result<String, String> {
+    // Read path: strict — fail if the lock is poisoned, since we cannot
+    // serve a dashboard without a username.
     {
         let guard = cached.0.lock().map_err(|e| format!("lock error: {e}"))?;
         if let Some(ref u) = *guard {
@@ -136,6 +154,8 @@ async fn resolve_username(cached: &GithubUsername) -> Result<String, String> {
 
     let username = auth::validate_token(&token).await.map_err(String::from)?;
 
+    // Write path: best-effort — the username was already resolved, so a
+    // poisoned lock only prevents caching; the next call will re-validate.
     match cached.0.lock() {
         Ok(mut guard) => *guard = Some(username.clone()),
         Err(e) => warn!("failed to cache username (mutex poisoned): {e}"),
@@ -203,14 +223,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_auth_set_token_rejects_empty() {
-        let result = auth_set_token("".into()).await;
+        let result = set_token_inner("".into()).await;
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("empty"));
     }
 
     #[tokio::test]
     async fn test_auth_set_token_rejects_whitespace() {
-        let result = auth_set_token("   ".into()).await;
+        let result = set_token_inner("   ".into()).await;
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("empty"));
     }
@@ -273,31 +293,27 @@ mod tests {
         assert_eq!(result, "alice");
     }
 
-    #[tokio::test]
-    async fn test_resolve_username_fails_without_token() {
+    #[test]
+    fn test_auth_set_token_updates_cache_on_success() {
         let cached = GithubUsername::default();
-        let result = resolve_username(&cached).await;
-        assert!(result.is_err());
-        // Should fail because no token is stored in the keychain during tests
+        // Simulate successful login by writing to cache directly
+        match cached.0.lock() {
+            Ok(mut guard) => *guard = Some("newuser".into()),
+            Err(_) => panic!("lock poisoned"),
+        }
+        let guard = cached.0.lock().unwrap();
+        assert_eq!(guard.as_deref(), Some("newuser"));
     }
 
-    // -- github_get_dashboard integration test (via assemble_dashboard_data) --
-
-    #[tokio::test]
-    async fn test_get_dashboard_returns_empty_data() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        let pool = crate::cache::db::init_db(&tmp.path().join("test.db"))
-            .await
-            .unwrap();
-
-        let data = assemble_dashboard_data(&pool, "alice").await.unwrap();
-
-        assert!(data.review_requests.is_empty());
-        assert!(data.my_pull_requests.is_empty());
-        assert!(data.assigned_issues.is_empty());
-        assert!(data.recent_activity.is_empty());
-        assert!(data.workspaces.is_empty());
-        assert!(data.synced_at.is_none());
-        pool.close().await;
+    #[test]
+    fn test_logout_clears_cached_username() {
+        let cached = GithubUsername(Mutex::new(Some("alice".into())));
+        // Simulate logout clearing the cache
+        match cached.0.lock() {
+            Ok(mut guard) => *guard = None,
+            Err(_) => panic!("lock poisoned"),
+        }
+        let guard = cached.0.lock().unwrap();
+        assert!(guard.is_none());
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -312,14 +312,16 @@ mod tests {
         }));
 
         // Lock is now poisoned — resolve_username should NOT return
-        // a lock error; it should skip the cache and try token validation,
-        // which will fail with "no token stored" in test environments.
+        // a lock error; it should skip the cache and try token validation.
+        // The result may be Ok (if a real token exists in the keychain) or
+        // Err (no token) — either is acceptable as long as it's not a lock error.
         let result = resolve_username(&cached).await;
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(
-            !err.contains("lock error"),
-            "poisoned lock should not bubble up as lock error, got: {err}"
-        );
+        match result {
+            Ok(_) => {}
+            Err(err) => assert!(
+                !err.contains("lock error"),
+                "poisoned lock should not bubble up as lock error, got: {err}"
+            ),
+        }
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,7 +1,13 @@
-use serde::Serialize;
+use std::sync::Mutex;
 
+use log::warn;
+use serde::Serialize;
+use sqlx::SqlitePool;
+
+use crate::cache::dashboard::assemble_dashboard_data;
 use crate::error::AppError;
 use crate::github::auth;
+use crate::types::DashboardData;
 
 /// Authentication status returned by [`auth_get_status`].
 #[derive(Debug, Serialize)]
@@ -89,13 +95,69 @@ pub async fn auth_get_status() -> Result<AuthStatus, String> {
     }
 }
 
-/// Deletes the stored GitHub token (logout).
+/// Deletes the stored GitHub token and clears the cached username (logout).
 #[tauri::command]
-pub async fn auth_logout() -> Result<(), String> {
+pub async fn auth_logout(cached: tauri::State<'_, GithubUsername>) -> Result<(), String> {
+    match cached.0.lock() {
+        Ok(mut guard) => *guard = None,
+        Err(e) => warn!("failed to clear cached username (mutex poisoned): {e}"),
+    }
     tokio::task::spawn_blocking(auth::delete_token)
         .await
         .map_err(|e| format!("task join error: {e}"))?
         .map_err(String::from)
+}
+
+/// Cached GitHub username, populated on first dashboard access.
+///
+/// Avoids re-validating the token (HTTP call) on every dashboard load.
+/// Cleared on logout so subsequent calls fail fast with "not authenticated".
+#[derive(Default)]
+pub struct GithubUsername(pub(crate) Mutex<Option<String>>);
+
+/// Resolves the authenticated GitHub username.
+///
+/// Returns the cached value if available; otherwise reads the stored token
+/// from the keychain, validates it against the GitHub API, and caches the
+/// resulting username for future calls.
+async fn resolve_username(cached: &GithubUsername) -> Result<String, String> {
+    {
+        let guard = cached.0.lock().map_err(|e| format!("lock error: {e}"))?;
+        if let Some(ref u) = *guard {
+            return Ok(u.clone());
+        }
+    }
+
+    let token = tokio::task::spawn_blocking(auth::get_token)
+        .await
+        .map_err(|e| format!("task join error: {e}"))?
+        .map_err(String::from)?
+        .ok_or_else(|| "not authenticated: no token stored".to_string())?;
+
+    let username = auth::validate_token(&token).await.map_err(String::from)?;
+
+    match cached.0.lock() {
+        Ok(mut guard) => *guard = Some(username.clone()),
+        Err(e) => warn!("failed to cache username (mutex poisoned): {e}"),
+    }
+
+    Ok(username)
+}
+
+/// Returns the full dashboard data for the authenticated user.
+///
+/// Reads the DB pool and cached username from Tauri managed state.
+/// On the first call (or after logout), validates the stored token to
+/// resolve the username, caching it for subsequent calls.
+#[tauri::command]
+pub async fn github_get_dashboard(
+    pool: tauri::State<'_, SqlitePool>,
+    cached: tauri::State<'_, GithubUsername>,
+) -> Result<DashboardData, String> {
+    let username = resolve_username(&cached).await?;
+    assemble_dashboard_data(&pool, &username)
+        .await
+        .map_err(|e| e.to_string())
 }
 
 #[cfg(test)]
@@ -193,5 +255,49 @@ mod tests {
             err.contains("rate limited"),
             "expected 'rate limited' in '{err}'"
         );
+    }
+
+    // -- GithubUsername + resolve_username tests --
+
+    #[test]
+    fn test_github_username_default_is_none() {
+        let cached = GithubUsername::default();
+        let guard = cached.0.lock().unwrap();
+        assert!(guard.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_resolve_username_returns_cached_value() {
+        let cached = GithubUsername(Mutex::new(Some("alice".into())));
+        let result = resolve_username(&cached).await.unwrap();
+        assert_eq!(result, "alice");
+    }
+
+    #[tokio::test]
+    async fn test_resolve_username_fails_without_token() {
+        let cached = GithubUsername::default();
+        let result = resolve_username(&cached).await;
+        assert!(result.is_err());
+        // Should fail because no token is stored in the keychain during tests
+    }
+
+    // -- github_get_dashboard integration test (via assemble_dashboard_data) --
+
+    #[tokio::test]
+    async fn test_get_dashboard_returns_empty_data() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let pool = crate::cache::db::init_db(&tmp.path().join("test.db"))
+            .await
+            .unwrap();
+
+        let data = assemble_dashboard_data(&pool, "alice").await.unwrap();
+
+        assert!(data.review_requests.is_empty());
+        assert!(data.my_pull_requests.is_empty());
+        assert!(data.assigned_issues.is_empty());
+        assert!(data.recent_activity.is_empty());
+        assert!(data.workspaces.is_empty());
+        assert!(data.synced_at.is_none());
+        pool.close().await;
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,8 @@ mod notifications;
 pub mod types;
 mod workspace;
 
+use tauri::Manager;
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -18,12 +20,25 @@ pub fn run() {
                         .build(),
                 )?;
             }
+
+            // Initialize SQLite database
+            let data_dir = app.path().app_data_dir()?;
+            std::fs::create_dir_all(&data_dir)?;
+            let db_path = data_dir.join("prism.db");
+            let pool = tauri::async_runtime::block_on(cache::db::init_db(&db_path))
+                .map_err(|e| e.to_string())?;
+            app.manage(pool);
+
+            // Cached GitHub username — populated on first dashboard access
+            app.manage(commands::GithubUsername::default());
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
             commands::auth_set_token,
             commands::auth_get_status,
             commands::auth_logout,
+            commands::github_get_dashboard,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1,6 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { TAURI_COMMANDS } from "./types";
-import type { AuthStatus } from "./types";
+import type { AuthStatus, DashboardData } from "./types";
 
 export async function authSetToken(token: string): Promise<string> {
   return invoke<string>(TAURI_COMMANDS.auth_set_token, { token });
@@ -12,4 +12,8 @@ export async function authGetStatus(): Promise<AuthStatus> {
 
 export async function authLogout(): Promise<void> {
   return invoke<void>(TAURI_COMMANDS.auth_logout);
+}
+
+export async function getGithubDashboard(): Promise<DashboardData> {
+  return invoke<DashboardData>(TAURI_COMMANDS.github_get_dashboard);
 }


### PR DESCRIPTION
## Summary
- Add `github_get_dashboard` Tauri IPC command that returns full `DashboardData` for the authenticated user
- Initialize SQLite pool in Tauri `setup()` and manage as state (`tauri::State<SqlitePool>`)
- Add `GithubUsername` cached state to avoid re-validating the GitHub token on every dashboard load
- Update `auth_logout` to clear the cached username on sign-out

## Architecture
- `resolve_username()` checks the cached `Mutex<Option<String>>` first; on cache miss, reads the stored token from keychain and validates against GitHub API
- DB pool initialized via `tauri::async_runtime::block_on(init_db(...))` in the setup closure — blocks briefly at startup, pool is ready before any command runs
- Lock poisoning handled explicitly with `log::warn!` instead of silent `let _ =`

## Files changed
- `src-tauri/src/commands.rs` — `GithubUsername`, `resolve_username`, `github_get_dashboard`, updated `auth_logout`
- `src-tauri/src/lib.rs` — DB pool init in setup, state management, command registration

## Test plan
- [x] `test_github_username_default_is_none` — Default state is None
- [x] `test_resolve_username_returns_cached_value` — Cache hit returns stored username
- [x] `test_resolve_username_fails_without_token` — Cache miss without keychain token errors
- [x] `test_get_dashboard_returns_empty_data` — Integration test via `assemble_dashboard_data`
- [x] All 209 tests passing, clippy clean (`-D warnings`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements Linear T-035 by adding a `github_get_dashboard` IPC command with a cached GitHub username and a shared `SqlitePool` to speed up dashboard loads. Also exposes a `getGithubDashboard()` frontend helper and keeps the cache in sync on login/logout.

- **New Features**
  - `github_get_dashboard` returns `DashboardData` via `assemble_dashboard_data`, using `SqlitePool` managed in `setup()`.
  - Cached `GithubUsername` avoids re-validating the token; updated on `auth_set_token` and cleared on `auth_logout`.
  - Frontend wrapper `getGithubDashboard()` added in `src/lib/tauri.ts`.

- **Bug Fixes**
  - `auth_logout` deletes the token before clearing the cache; poisoned cache locks now fall back to token validation in `resolve_username`.
  - Cleanup/tests: extracted `set_token_inner`, removed flaky/duplicate tests, made the poisoned-cache test deterministic, and minor clippy cleanups.

<sup>Written for commit b40fe5e633a3b6e54682e20d5de70b6e264aea03. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Frontend can fetch a GitHub dashboard for the authenticated user; app now initializes a local database and a managed username cache at startup.

* **Improvements**
  * Token validation and secure storage now update a cached username; logout clears the cache and commands handle cache-unavailable cases more gracefully.

* **Tests**
  * Added tests for token validation, username cache behavior (including poisoned-cache scenarios), dashboard retrieval, and logout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->