### PR TITLE
feat(github): add github_get_stats + github_force_sync IPC commands (T-036)

### DIFF
--- a/src-tauri/src/cache/dashboard.rs
+++ b/src-tauri/src/cache/dashboard.rs
@@ -25,7 +25,6 @@ use super::workspaces::list_workspaces;
 ///
 /// For each PR, joins the [`ReviewSummary`] and optional [`WorkspaceSummary`].
 /// Computes `synced_at` as the most recent `last_sync_at` across all repos.
-#[allow(dead_code)]
 pub async fn assemble_dashboard_data(
     pool: &SqlitePool,
     username: &str,
@@ -225,7 +224,6 @@ fn count_to_u32(count: i64) -> u32 {
 /// - `open_issues`: issues authored by the user in `open` state
 /// - `active_workspaces`: all workspaces in `active` state (global, not user-scoped)
 /// - `unread_activity`: all activity events with `is_read = 0` (global, not user-scoped)
-#[allow(dead_code)]
 pub async fn compute_dashboard_stats(
     pool: &SqlitePool,
     username: &str,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -221,7 +221,7 @@ async fn resolve_credentials(cached: &GithubUsername) -> Result<(String, String)
     if let Ok(guard) = cached.0.lock()
         && let Some(ref u) = *guard
     {
-        return Ok((u.clone(), token.clone()));
+        return Ok((u.clone(), token));
     }
 
     // Slow path: validate token, cache username
@@ -396,11 +396,11 @@ mod tests {
     // -- resolve_credentials tests (T-036) --
 
     #[tokio::test]
-    async fn test_resolve_credentials_returns_cached_username_with_token() {
-        // When the cache has a username and the keychain has a token,
-        // resolve_credentials should return both without HTTP validation.
-        // Without a real keychain, this test verifies the error path instead:
-        // empty cache + no stored token = auth error.
+    async fn test_resolve_credentials_errors_when_no_token_stored() {
+        // With an empty cache and no keychain entry, resolve_credentials
+        // should return an authentication error (no token stored).
+        // The cached-username fast path requires a real keychain fixture
+        // and is therefore not covered here.
         let cached = GithubUsername::default();
         let result = resolve_credentials(&cached).await;
         assert!(result.is_err());

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3,11 +3,14 @@ use std::sync::Mutex;
 use log::warn;
 use serde::Serialize;
 use sqlx::SqlitePool;
+use tauri::Emitter;
 
-use crate::cache::dashboard::assemble_dashboard_data;
+use crate::cache::dashboard::{assemble_dashboard_data, compute_dashboard_stats};
+use crate::cache::sync::sync_dashboard;
 use crate::error::AppError;
 use crate::github::auth;
-use crate::types::DashboardData;
+use crate::github::client::GitHubClient;
+use crate::types::{DashboardData, DashboardStats};
 
 /// Authentication status returned by [`auth_get_status`].
 #[derive(Debug, Serialize)]
@@ -185,6 +188,79 @@ pub async fn github_get_dashboard(
         .map_err(|e| e.to_string())
 }
 
+/// Returns dashboard statistics (counts) from the local cache.
+///
+/// After the first call (which may validate the token via HTTP to resolve
+/// the username), subsequent calls are pure DB queries with no network I/O.
+/// Use for displaying badge counts, status indicators, etc.
+#[tauri::command]
+pub async fn github_get_stats(
+    pool: tauri::State<'_, SqlitePool>,
+    cached: tauri::State<'_, GithubUsername>,
+) -> Result<DashboardStats, String> {
+    let username = resolve_username(&cached).await?;
+    compute_dashboard_stats(&pool, &username)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// Resolves the authenticated username and token in a single pass.
+///
+/// Used by commands that need the raw token (e.g., `github_force_sync`).
+/// Reads the token once from the keychain, checks the username cache,
+/// and validates only if the cache is empty — avoiding the TOCTOU window
+/// of reading the keychain twice.
+async fn resolve_credentials(cached: &GithubUsername) -> Result<(String, String), String> {
+    let token = tokio::task::spawn_blocking(auth::get_token)
+        .await
+        .map_err(|e| format!("task join error: {e}"))?
+        .map_err(String::from)?
+        .ok_or_else(|| "not authenticated: no token stored".to_string())?;
+
+    // Fast path: return cached username + token
+    if let Ok(guard) = cached.0.lock()
+        && let Some(ref u) = *guard
+    {
+        return Ok((u.clone(), token.clone()));
+    }
+
+    // Slow path: validate token, cache username
+    let username = auth::validate_token(&token).await.map_err(String::from)?;
+
+    match cached.0.lock() {
+        Ok(mut guard) => *guard = Some(username.clone()),
+        Err(e) => warn!("failed to cache username (mutex poisoned): {e}"),
+    }
+
+    Ok((username, token))
+}
+
+/// Triggers an immediate GitHub data sync, bypassing the polling timer.
+///
+/// Reads the stored token and cached username in a single pass, creates
+/// a temporary [`GitHubClient`], runs `sync_dashboard`, and emits a
+/// `github:updated` event with the resulting [`DashboardStats`] payload.
+/// The frontend should listen for this event to refresh its data.
+#[tauri::command]
+pub async fn github_force_sync(
+    pool: tauri::State<'_, SqlitePool>,
+    cached: tauri::State<'_, GithubUsername>,
+    app_handle: tauri::AppHandle,
+) -> Result<(), String> {
+    let (username, token) = resolve_credentials(&cached).await?;
+    let client = GitHubClient::new(&token).map_err(|e| e.to_string())?;
+
+    let stats = sync_dashboard(&client, &pool, &username)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    if let Err(e) = app_handle.emit("github:updated", &stats) {
+        warn!("failed to emit github:updated after force sync: {e}");
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -296,6 +372,64 @@ mod tests {
         let cached = GithubUsername(Mutex::new(Some("alice".into())));
         let result = resolve_username(&cached).await.unwrap();
         assert_eq!(result, "alice");
+    }
+
+    // -- DashboardStats IPC contract tests (T-036) --
+
+    #[test]
+    fn test_dashboard_stats_serializes_camel_case() {
+        let stats = DashboardStats {
+            pending_reviews: 3,
+            open_prs: 7,
+            open_issues: 2,
+            active_workspaces: 1,
+            unread_activity: 5,
+        };
+        let json = serde_json::to_value(&stats).unwrap();
+        assert_eq!(json["pendingReviews"], 3);
+        assert_eq!(json["openPrs"], 7);
+        assert_eq!(json["openIssues"], 2);
+        assert_eq!(json["activeWorkspaces"], 1);
+        assert_eq!(json["unreadActivity"], 5);
+    }
+
+    // -- resolve_credentials tests (T-036) --
+
+    #[tokio::test]
+    async fn test_resolve_credentials_returns_cached_username_with_token() {
+        // When the cache has a username and the keychain has a token,
+        // resolve_credentials should return both without HTTP validation.
+        // Without a real keychain, this test verifies the error path instead:
+        // empty cache + no stored token = auth error.
+        let cached = GithubUsername::default();
+        let result = resolve_credentials(&cached).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("not authenticated") || err.contains("token"),
+            "expected auth error, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_resolve_credentials_skips_poisoned_cache() {
+        let cached = GithubUsername::default();
+        let cached_ref = &cached;
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = cached_ref.0.lock().unwrap();
+            panic!("intentional poison");
+        }));
+
+        // Poisoned lock should not produce a lock error — it falls through
+        // to token validation (which fails without a keychain entry).
+        let result = resolve_credentials(&cached).await;
+        match result {
+            Ok(_) => {}
+            Err(err) => assert!(
+                !err.contains("lock error"),
+                "poisoned lock should not bubble up, got: {err}"
+            ),
+        }
     }
 
     #[tokio::test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -39,6 +39,8 @@ pub fn run() {
             commands::auth_get_status,
             commands::auth_logout,
             commands::github_get_dashboard,
+            commands::github_get_stats,
+            commands::github_force_sync,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1,6 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { TAURI_COMMANDS } from "./types";
-import type { AuthStatus, DashboardData } from "./types";
+import type { AuthStatus, DashboardData, DashboardStats } from "./types";
 
 export async function authSetToken(token: string): Promise<string> {
   return invoke<string>(TAURI_COMMANDS.auth_set_token, { token });
@@ -16,4 +16,12 @@ export async function authLogout(): Promise<void> {
 
 export async function getGithubDashboard(): Promise<DashboardData> {
   return invoke<DashboardData>(TAURI_COMMANDS.github_get_dashboard);
+}
+
+export async function getGithubStats(): Promise<DashboardStats> {
+  return invoke<DashboardStats>(TAURI_COMMANDS.github_get_stats);
+}
+
+export async function forceGithubSync(): Promise<void> {
+  return invoke<void>(TAURI_COMMANDS.github_force_sync);
 }


### PR DESCRIPTION
## Summary

- **`github_get_stats`**: query-only IPC command returning `DashboardStats` (badge counts) from SQLite cache via `compute_dashboard_stats`
- **`github_force_sync`**: triggers immediate GitHub data sync bypassing the polling timer, emits `github:updated` event with fresh `DashboardStats` payload
- **`resolve_credentials`**: new helper that returns `(username, token)` in a single keychain read, avoiding TOCTOU window from separate reads
- Frontend wrappers `getGithubStats()` and `forceGithubSync()` added to `tauri.ts`
- Removed stale `#[allow(dead_code)]` from `assemble_dashboard_data` and `compute_dashboard_stats`

## Architecture

- `github_get_stats` reuses `resolve_username` (cache-first, no network after first call) + `compute_dashboard_stats` (pure DB query)
- `github_force_sync` uses `resolve_credentials` to atomically get username + token, creates a temporary `GitHubClient`, runs `sync_dashboard`, emits Tauri event
- Both commands registered in `lib.rs` invoke handler

## Files changed

| File | Change |
|------|--------|
| `src-tauri/src/commands.rs` | +2 commands, +1 helper, +3 tests |
| `src-tauri/src/lib.rs` | Register new commands |
| `src-tauri/src/cache/dashboard.rs` | Remove stale `#[allow(dead_code)]` |
| `src/lib/tauri.ts` | +2 frontend wrappers |

## Test plan

- [x] 211 Rust tests passing (`cargo test`)
- [x] Clippy clean (`cargo clippy -- -D warnings`)
- [x] `test_dashboard_stats_serializes_camel_case` — verifies IPC contract
- [x] `test_resolve_credentials_returns_cached_username_with_token` — auth error path
- [x] `test_resolve_credentials_skips_poisoned_cache` — mutex poison resilience

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two GitHub IPC commands to fetch cached dashboard stats and to force an immediate sync, plus frontend wrappers. Addresses Linear T-036 by exposing badge counts and an on-demand refresh path.

- **New Features**
  - `github_get_stats`: returns `DashboardStats` from SQLite via `compute_dashboard_stats`; resolves username once, then no network.
  - `github_force_sync`: uses `resolve_credentials`, runs `sync_dashboard` with a temporary `GitHubClient`, and emits `github:updated` with fresh `DashboardStats`.
  - Frontend: added `getGithubStats()` and `forceGithubSync()` in `tauri.ts`; commands registered in `lib.rs`.

<sup>Written for commit 7bf7188692ebc5ea1a83f58dbd0a7fb422af88d1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Retrieve GitHub dashboard statistics on demand from the app.
  * Force an immediate synchronization of GitHub data to refresh displayed stats.
  * Forced sync now triggers an update event so the UI shows fresh dashboard metrics immediately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->