### PR TITLE
feat(github): add repos IPC commands (T-037)

### DIFF
--- a/src-tauri/src/cache/repos.rs
+++ b/src-tauri/src/cache/repos.rs
@@ -90,9 +90,13 @@ pub async fn get_repo(pool: &SqlitePool, id: &str) -> Result<Repo, AppError> {
         .ok_or_else(|| AppError::NotFound(format!("repo '{id}'")))
 }
 
-/// Toggle a repo's `enabled` flag and return the updated repo.
+/// Set a repo's `enabled` flag and return the updated repo.
 /// Uses `RETURNING` for an atomic read-after-write.
-pub async fn toggle_repo(pool: &SqlitePool, id: &str, enabled: bool) -> Result<Repo, AppError> {
+pub async fn set_repo_enabled(
+    pool: &SqlitePool,
+    id: &str,
+    enabled: bool,
+) -> Result<Repo, AppError> {
     let sql = format!("UPDATE repos SET enabled = $1 WHERE id = $2 RETURNING {REPO_COLS}");
     let row: Option<RepoRow> = sqlx::query_as(&sql)
         .bind(enabled)
@@ -195,7 +199,7 @@ mod tests {
         upsert_repo(&pool, &repo).await.unwrap();
 
         // Toggle enabled off, then upsert again — enabled should be preserved
-        toggle_repo(&pool, "r-1", false).await.unwrap();
+        set_repo_enabled(&pool, "r-1", false).await.unwrap();
 
         let mut updated = repo.clone();
         updated.url = "https://github.com/mpiton/prism-v2".to_string();
@@ -247,16 +251,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_toggle_repo() {
+    async fn test_set_repo_enabled() {
         let (pool, _tmp) = test_pool().await;
         upsert_repo(&pool, &sample_repo("r-1", "mpiton", "prism"))
             .await
             .unwrap();
 
-        let disabled = toggle_repo(&pool, "r-1", false).await.unwrap();
+        let disabled = set_repo_enabled(&pool, "r-1", false).await.unwrap();
         assert!(!disabled.enabled);
 
-        let enabled = toggle_repo(&pool, "r-1", true).await.unwrap();
+        let enabled = set_repo_enabled(&pool, "r-1", true).await.unwrap();
         assert!(enabled.enabled);
 
         pool.close().await;

--- a/src-tauri/src/cache/repos.rs
+++ b/src-tauri/src/cache/repos.rs
@@ -73,7 +73,6 @@ pub async fn upsert_repo(pool: &SqlitePool, repo: &Repo) -> Result<Repo, AppErro
 }
 
 /// Return all repos ordered by `full_name`.
-#[allow(dead_code)]
 pub async fn list_repos(pool: &SqlitePool) -> Result<Vec<Repo>, AppError> {
     let sql = format!("SELECT {REPO_COLS} FROM repos ORDER BY full_name");
     let rows: Vec<RepoRow> = sqlx::query_as(&sql).fetch_all(pool).await?;
@@ -93,7 +92,6 @@ pub async fn get_repo(pool: &SqlitePool, id: &str) -> Result<Repo, AppError> {
 
 /// Toggle a repo's `enabled` flag and return the updated repo.
 /// Uses `RETURNING` for an atomic read-after-write.
-#[allow(dead_code)]
 pub async fn toggle_repo(pool: &SqlitePool, id: &str, enabled: bool) -> Result<Repo, AppError> {
     let sql = format!("UPDATE repos SET enabled = $1 WHERE id = $2 RETURNING {REPO_COLS}");
     let row: Option<RepoRow> = sqlx::query_as(&sql)
@@ -108,7 +106,6 @@ pub async fn toggle_repo(pool: &SqlitePool, id: &str, enabled: bool) -> Result<R
 
 /// Set or clear the local clone path for a repo.
 /// Uses `RETURNING` for an atomic read-after-write.
-#[allow(dead_code)]
 pub async fn set_local_path(
     pool: &SqlitePool,
     id: &str,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -6,11 +6,12 @@ use sqlx::SqlitePool;
 use tauri::Emitter;
 
 use crate::cache::dashboard::{assemble_dashboard_data, compute_dashboard_stats};
+use crate::cache::repos::{list_repos, set_local_path, toggle_repo};
 use crate::cache::sync::sync_dashboard;
 use crate::error::AppError;
 use crate::github::auth;
 use crate::github::client::GitHubClient;
-use crate::types::{DashboardData, DashboardStats};
+use crate::types::{DashboardData, DashboardStats, Repo};
 
 /// Authentication status returned by [`auth_get_status`].
 #[derive(Debug, Serialize)]
@@ -261,6 +262,44 @@ pub async fn github_force_sync(
     Ok(())
 }
 
+/// Returns all repos ordered by `full_name` (query).
+#[tauri::command]
+pub async fn repos_list(pool: tauri::State<'_, SqlitePool>) -> Result<Vec<Repo>, String> {
+    list_repos(&pool).await.map_err(|e| e.to_string())
+}
+
+/// Toggles a repo's `enabled` flag and returns the updated repo (command).
+///
+/// Tauri 2 renames `repo_id` → `repoId` and `enabled` → `enabled` for the
+/// JS caller. The frontend invokes this as `{ repoId, enabled }`.
+#[tauri::command]
+pub async fn repos_toggle(
+    pool: tauri::State<'_, SqlitePool>,
+    repo_id: String,
+    enabled: bool,
+) -> Result<Repo, String> {
+    toggle_repo(&pool, &repo_id, enabled)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// Sets or clears the local clone path for a repo (command).
+///
+/// Tauri 2 renames `repo_id` → `repoId` for the JS caller.
+/// Pass `path: null` from the frontend to clear the local path.
+/// Callers are expected to supply a canonical absolute path; validation
+/// will be enforced when workspace features consume this value.
+#[tauri::command]
+pub async fn repos_set_local_path(
+    pool: tauri::State<'_, SqlitePool>,
+    repo_id: String,
+    path: Option<String>,
+) -> Result<Repo, String> {
+    set_local_path(&pool, &repo_id, path.as_deref())
+        .await
+        .map_err(|e| e.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -430,6 +469,67 @@ mod tests {
                 "poisoned lock should not bubble up, got: {err}"
             ),
         }
+    }
+
+    // -- Repo IPC contract tests (T-037) --
+
+    #[test]
+    fn test_repo_serializes_camel_case() {
+        let repo = crate::types::Repo {
+            id: "r-1".into(),
+            org: "mpiton".into(),
+            name: "prism".into(),
+            full_name: "mpiton/prism".into(),
+            url: "https://github.com/mpiton/prism".into(),
+            default_branch: "main".into(),
+            is_archived: false,
+            enabled: true,
+            local_path: Some("/home/user/prism".into()),
+            last_sync_at: None,
+        };
+        let json = serde_json::to_value(&repo).unwrap();
+        assert_eq!(json["id"], "r-1");
+        assert_eq!(json["fullName"], "mpiton/prism");
+        assert_eq!(json["defaultBranch"], "main");
+        assert_eq!(json["isArchived"], false);
+        assert_eq!(json["localPath"], "/home/user/prism");
+        assert!(json["lastSyncAt"].is_null());
+    }
+
+    #[test]
+    fn test_repo_list_serializes_as_array() {
+        let repos = vec![
+            crate::types::Repo {
+                id: "r-1".into(),
+                org: "mpiton".into(),
+                name: "alpha".into(),
+                full_name: "mpiton/alpha".into(),
+                url: "https://github.com/mpiton/alpha".into(),
+                default_branch: "main".into(),
+                is_archived: false,
+                enabled: true,
+                local_path: None,
+                last_sync_at: None,
+            },
+            crate::types::Repo {
+                id: "r-2".into(),
+                org: "mpiton".into(),
+                name: "beta".into(),
+                full_name: "mpiton/beta".into(),
+                url: "https://github.com/mpiton/beta".into(),
+                default_branch: "develop".into(),
+                is_archived: true,
+                enabled: false,
+                local_path: None,
+                last_sync_at: Some("2026-03-26T10:00:00Z".into()),
+            },
+        ];
+        let json = serde_json::to_value(&repos).unwrap();
+        let arr = json.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0]["fullName"], "mpiton/alpha");
+        assert_eq!(arr[1]["isArchived"], true);
+        assert_eq!(arr[1]["lastSyncAt"], "2026-03-26T10:00:00Z");
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -6,7 +6,7 @@ use sqlx::SqlitePool;
 use tauri::Emitter;
 
 use crate::cache::dashboard::{assemble_dashboard_data, compute_dashboard_stats};
-use crate::cache::repos::{list_repos, set_local_path, toggle_repo};
+use crate::cache::repos::{list_repos, set_local_path, set_repo_enabled};
 use crate::cache::sync::sync_dashboard;
 use crate::error::AppError;
 use crate::github::auth;
@@ -268,17 +268,17 @@ pub async fn repos_list(pool: tauri::State<'_, SqlitePool>) -> Result<Vec<Repo>,
     list_repos(&pool).await.map_err(|e| e.to_string())
 }
 
-/// Toggles a repo's `enabled` flag and returns the updated repo (command).
+/// Sets a repo's `enabled` flag and returns the updated repo (command).
 ///
-/// Tauri 2 renames `repo_id` → `repoId` and `enabled` → `enabled` for the
-/// JS caller. The frontend invokes this as `{ repoId, enabled }`.
+/// Tauri 2 renames `repo_id` → `repoId` for the JS caller.
+/// The frontend invokes this as `{ repoId, enabled }`.
 #[tauri::command]
-pub async fn repos_toggle(
+pub async fn repos_set_enabled(
     pool: tauri::State<'_, SqlitePool>,
     repo_id: String,
     enabled: bool,
 ) -> Result<Repo, String> {
-    toggle_repo(&pool, &repo_id, enabled)
+    set_repo_enabled(&pool, &repo_id, enabled)
         .await
         .map_err(|e| e.to_string())
 }
@@ -287,15 +287,23 @@ pub async fn repos_toggle(
 ///
 /// Tauri 2 renames `repo_id` → `repoId` for the JS caller.
 /// Pass `path: null` from the frontend to clear the local path.
-/// Callers are expected to supply a canonical absolute path; validation
-/// will be enforced when workspace features consume this value.
+/// Empty/whitespace-only strings are normalised to `None`.
+/// Non-absolute paths are rejected.
 #[tauri::command]
 pub async fn repos_set_local_path(
     pool: tauri::State<'_, SqlitePool>,
     repo_id: String,
     path: Option<String>,
 ) -> Result<Repo, String> {
-    set_local_path(&pool, &repo_id, path.as_deref())
+    let normalized = path.as_deref().map(str::trim).filter(|p| !p.is_empty());
+
+    if let Some(p) = normalized
+        && !std::path::Path::new(p).is_absolute()
+    {
+        return Err("path must be an absolute path".to_string());
+    }
+
+    set_local_path(&pool, &repo_id, normalized)
         .await
         .map_err(|e| e.to_string())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -42,7 +42,7 @@ pub fn run() {
             commands::github_get_stats,
             commands::github_force_sync,
             commands::repos_list,
-            commands::repos_toggle,
+            commands::repos_set_enabled,
             commands::repos_set_local_path,
         ])
         .run(tauri::generate_context!())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -41,6 +41,9 @@ pub fn run() {
             commands::github_get_dashboard,
             commands::github_get_stats,
             commands::github_force_sync,
+            commands::repos_list,
+            commands::repos_toggle,
+            commands::repos_set_local_path,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1,6 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { TAURI_COMMANDS } from "./types";
-import type { AuthStatus, DashboardData, DashboardStats } from "./types";
+import type { AuthStatus, DashboardData, DashboardStats, Repo } from "./types";
 
 export async function authSetToken(token: string): Promise<string> {
   return invoke<string>(TAURI_COMMANDS.auth_set_token, { token });
@@ -24,4 +24,16 @@ export async function getGithubStats(): Promise<DashboardStats> {
 
 export async function forceGithubSync(): Promise<void> {
   return invoke<void>(TAURI_COMMANDS.github_force_sync);
+}
+
+export async function listRepos(): Promise<Repo[]> {
+  return invoke<Repo[]>(TAURI_COMMANDS.repos_list);
+}
+
+export async function toggleRepo(repoId: string, enabled: boolean): Promise<Repo> {
+  return invoke<Repo>(TAURI_COMMANDS.repos_toggle, { repoId, enabled });
+}
+
+export async function setRepoLocalPath(repoId: string, path: string | null): Promise<Repo> {
+  return invoke<Repo>(TAURI_COMMANDS.repos_set_local_path, { repoId, path });
 }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -30,8 +30,8 @@ export async function listRepos(): Promise<Repo[]> {
   return invoke<Repo[]>(TAURI_COMMANDS.repos_list);
 }
 
-export async function toggleRepo(repoId: string, enabled: boolean): Promise<Repo> {
-  return invoke<Repo>(TAURI_COMMANDS.repos_toggle, { repoId, enabled });
+export async function setRepoEnabled(repoId: string, enabled: boolean): Promise<Repo> {
+  return invoke<Repo>(TAURI_COMMANDS.repos_set_enabled, { repoId, enabled });
 }
 
 export async function setRepoLocalPath(repoId: string, path: string | null): Promise<Repo> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -195,7 +195,7 @@ export type TauriCommandName =
   | "github_get_stats"
   | "github_force_sync"
   | "repos_list"
-  | "repos_toggle"
+  | "repos_set_enabled"
   | "repos_set_local_path"
   | "workspace_open"
   | "workspace_suspend"
@@ -220,7 +220,7 @@ export const TAURI_COMMANDS = {
   github_get_stats: "github_get_stats",
   github_force_sync: "github_force_sync",
   repos_list: "repos_list",
-  repos_toggle: "repos_toggle",
+  repos_set_enabled: "repos_set_enabled",
   repos_set_local_path: "repos_set_local_path",
   workspace_open: "workspace_open",
   workspace_suspend: "workspace_suspend",


### PR DESCRIPTION
## Summary
- Add `repos_list`, `repos_toggle`, and `repos_set_local_path` Tauri IPC commands in `commands.rs`
- Register all 3 commands in `lib.rs` invoke handler
- Add TypeScript wrapper functions (`listRepos`, `toggleRepo`, `setRepoLocalPath`) in `tauri.ts`
- Remove stale `#[allow(dead_code)]` from `list_repos`, `toggle_repo`, `set_local_path` in `cache/repos.rs`
- Add IPC contract tests verifying camelCase serialization of `Repo` type

## Test plan
- [x] 213 Rust tests passing (including 2 new Repo serialization tests)
- [x] Clippy clean with `-D warnings`
- [x] TypeScript compilation clean (`tsc --noEmit`)
- [x] Code review: 0 CRITICAL, HIGH doc issue resolved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds repos IPC commands and TS wrappers to list repos, set enabled state, and set a repo’s local path with basic validation. Implements Linear T-037.

- **New Features**
  - Added `repos_list`, `repos_set_enabled`, `repos_set_local_path` Tauri IPC commands and registered them in the invoke handler.
  - Added TypeScript wrappers `listRepos`, `setRepoEnabled`, `setRepoLocalPath` using `@tauri-apps/api/core`; updated `TAURI_COMMANDS` and renamed Rust/TS APIs from “toggle” to “set enabled” for clarity.
  - `repos_set_local_path` trims whitespace, rejects relative paths, and supports `null` to clear; added IPC contract tests for camelCase `Repo` serialization.

<sup>Written for commit 94381ea41ed6cb3962a1d2834acb17bb202af2b4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * List repositories, enable or disable individual repositories, and configure a repository's local storage path from the app.
  * Path input is normalized (trimmed; empty cleared) and must be an absolute path; invalid paths return an error.

* **Tests**
  * Added IPC tests validating repository JSON shape and list serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->