### PR TITLE
feat(settings): add config_get and config_set IPC commands (T-038)

### DIFF
--- a/src-tauri/src/cache/config.rs
+++ b/src-tauri/src/cache/config.rs
@@ -51,7 +51,6 @@ fn clamp_max_workspaces(value: u32) -> u32 {
 ///
 /// Missing keys are filled with [`AppConfig::default()`] values.
 /// Values below documented minimums are clamped with a warning.
-#[allow(dead_code)]
 pub async fn get_config(pool: &SqlitePool) -> Result<AppConfig, AppError> {
     let rows: Vec<ConfigRow> = sqlx::query_as("SELECT key, value FROM config")
         .fetch_all(pool)
@@ -97,7 +96,6 @@ pub async fn get_config(pool: &SqlitePool) -> Result<AppConfig, AppError> {
 /// `Option::None` fields are deleted so that future reads fall back
 /// to [`AppConfig::default()`]. Values below documented minimums are
 /// clamped with a warning. Returns the clamped config as written.
-#[allow(dead_code)]
 pub async fn set_config(pool: &SqlitePool, config: &AppConfig) -> Result<AppConfig, AppError> {
     let poll_interval = clamp_poll_interval(config.poll_interval_secs);
     let max_workspaces = clamp_max_workspaces(config.max_active_workspaces);

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -611,6 +611,21 @@ mod tests {
     }
 
     #[test]
+    fn test_partial_config_deserializes_explicit_null_as_clear() {
+        let json = serde_json::json!({
+            "githubToken": null
+        });
+        let partial: PartialAppConfig = serde_json::from_value(json).unwrap();
+        assert_eq!(
+            partial.github_token,
+            Some(None),
+            "explicit null should produce Some(None), not None"
+        );
+        // poll_interval_secs absent → None (don't touch)
+        assert!(partial.poll_interval_secs.is_none());
+    }
+
+    #[test]
     fn test_merge_partial_config_overrides_only_provided_fields() {
         let base = AppConfig {
             poll_interval_secs: 300,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -5,13 +5,16 @@ use serde::Serialize;
 use sqlx::SqlitePool;
 use tauri::Emitter;
 
+use crate::cache::config::{get_config, set_config};
 use crate::cache::dashboard::{assemble_dashboard_data, compute_dashboard_stats};
 use crate::cache::repos::{list_repos, set_local_path, set_repo_enabled};
 use crate::cache::sync::sync_dashboard;
 use crate::error::AppError;
 use crate::github::auth;
 use crate::github::client::GitHubClient;
-use crate::types::{DashboardData, DashboardStats, Repo};
+use crate::types::{
+    AppConfig, DashboardData, DashboardStats, PartialAppConfig, Repo, merge_partial_config,
+};
 
 /// Authentication status returned by [`auth_get_status`].
 #[derive(Debug, Serialize)]
@@ -260,6 +263,32 @@ pub async fn github_force_sync(
     }
 
     Ok(())
+}
+
+/// Returns the full application configuration (query).
+#[tauri::command]
+pub async fn config_get(pool: tauri::State<'_, SqlitePool>) -> Result<AppConfig, String> {
+    get_config(&pool).await.map_err(|e| e.to_string())
+}
+
+/// Merges a partial update into the current config and persists it (command).
+///
+/// Reads the current config, applies the partial overrides, and writes
+/// the merged result back. Returns the full config as written (including
+/// any clamped values).
+///
+/// **Concurrency note:** The read-merge-write is not wrapped in a single
+/// transaction, so concurrent `config_set` calls could overwrite each other.
+/// Acceptable for a single-window desktop app; revisit if multi-window
+/// settings editing is added.
+#[tauri::command]
+pub async fn config_set(
+    pool: tauri::State<'_, SqlitePool>,
+    partial: PartialAppConfig,
+) -> Result<AppConfig, String> {
+    let current = get_config(&pool).await.map_err(|e| e.to_string())?;
+    let merged = merge_partial_config(&current, &partial);
+    set_config(&pool, &merged).await.map_err(|e| e.to_string())
 }
 
 /// Returns all repos ordered by `full_name` (query).
@@ -538,6 +567,97 @@ mod tests {
         assert_eq!(arr[0]["fullName"], "mpiton/alpha");
         assert_eq!(arr[1]["isArchived"], true);
         assert_eq!(arr[1]["lastSyncAt"], "2026-03-26T10:00:00Z");
+    }
+
+    // -- AppConfig IPC contract tests (T-038) --
+
+    #[test]
+    fn test_config_serializes_camel_case() {
+        let config = AppConfig {
+            poll_interval_secs: 120,
+            max_active_workspaces: 5,
+            github_token: Some("ghp_test".into()),
+            data_dir: None,
+            workspaces_dir: Some("/ws".into()),
+        };
+        let json = serde_json::to_value(&config).unwrap();
+        assert_eq!(json["pollIntervalSecs"], 120);
+        assert_eq!(json["maxActiveWorkspaces"], 5);
+        assert_eq!(json["githubToken"], "ghp_test");
+        assert!(json["dataDir"].is_null());
+        assert_eq!(json["workspacesDir"], "/ws");
+    }
+
+    #[test]
+    fn test_partial_config_deserializes_from_frontend() {
+        // Frontend sends only the fields it wants to update
+        let json = serde_json::json!({
+            "pollIntervalSecs": 60
+        });
+        let partial: PartialAppConfig = serde_json::from_value(json).unwrap();
+        assert_eq!(partial.poll_interval_secs, Some(60));
+        assert!(partial.max_active_workspaces.is_none());
+        assert!(partial.github_token.is_none());
+        assert!(partial.data_dir.is_none());
+        assert!(partial.workspaces_dir.is_none());
+    }
+
+    #[test]
+    fn test_partial_config_empty_object() {
+        let json = serde_json::json!({});
+        let partial: PartialAppConfig = serde_json::from_value(json).unwrap();
+        assert!(partial.poll_interval_secs.is_none());
+        assert!(partial.max_active_workspaces.is_none());
+    }
+
+    #[test]
+    fn test_merge_partial_config_overrides_only_provided_fields() {
+        let base = AppConfig {
+            poll_interval_secs: 300,
+            max_active_workspaces: 3,
+            github_token: None,
+            data_dir: None,
+            workspaces_dir: None,
+        };
+        let partial = PartialAppConfig {
+            poll_interval_secs: Some(60),
+            max_active_workspaces: None,
+            github_token: None,
+            data_dir: None,
+            workspaces_dir: None,
+        };
+        let merged = merge_partial_config(&base, &partial);
+        assert_eq!(merged.poll_interval_secs, 60);
+        assert_eq!(merged.max_active_workspaces, 3); // unchanged
+    }
+
+    #[test]
+    fn test_merge_partial_config_clears_optional_with_explicit_null() {
+        let base = AppConfig {
+            poll_interval_secs: 300,
+            max_active_workspaces: 3,
+            github_token: Some("ghp_old".into()),
+            data_dir: Some("/data".into()),
+            workspaces_dir: None,
+        };
+        // Double-option: Some(None) means "explicitly set to null"
+        let partial = PartialAppConfig {
+            poll_interval_secs: None,
+            max_active_workspaces: None,
+            github_token: Some(None), // clear it
+            data_dir: None,           // leave as-is
+            workspaces_dir: None,
+        };
+        let merged = merge_partial_config(&base, &partial);
+        assert!(
+            merged.github_token.is_none(),
+            "github_token should be cleared"
+        );
+        assert_eq!(
+            merged.data_dir.as_deref(),
+            Some("/data"),
+            "data_dir unchanged"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -44,6 +44,8 @@ pub fn run() {
             commands::repos_list,
             commands::repos_set_enabled,
             commands::repos_set_local_path,
+            commands::config_get,
+            commands::config_set,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -340,6 +340,27 @@ impl Default for AppConfig {
     }
 }
 
+/// Deserializer for `Option<Option<T>>` that distinguishes three JSON states:
+/// - key absent → `None` (don't touch)
+/// - key present with `null` → `Some(None)` (clear)
+/// - key present with value → `Some(Some(v))` (set)
+///
+/// Standard serde collapses absent and `null` into `None` for the outer
+/// `Option`, making `Some(None)` unreachable. This custom deserializer
+/// wraps the inner `Option<T>` result in `Some(...)` whenever the key
+/// is present in the JSON payload (the `#[serde(default)]` on the struct
+/// ensures absent keys produce `None` at the outer level).
+#[allow(clippy::option_option)]
+fn deserialize_double_option<'de, T, D>(deserializer: D) -> Result<Option<Option<T>>, D::Error>
+where
+    T: Deserialize<'de>,
+    D: serde::Deserializer<'de>,
+{
+    // If serde calls this function, the key IS present in the JSON.
+    // Deserialize the inner Option<T>: null → None, value → Some(v).
+    Ok(Some(Option::<T>::deserialize(deserializer)?))
+}
+
 /// Partial update payload for [`AppConfig`], used by the `config_set` IPC command.
 ///
 /// Each optional field uses `None` = "don't touch this field".
@@ -355,8 +376,11 @@ impl Default for AppConfig {
 pub struct PartialAppConfig {
     pub poll_interval_secs: Option<u64>,
     pub max_active_workspaces: Option<u32>,
+    #[serde(deserialize_with = "deserialize_double_option", default)]
     pub github_token: Option<Option<String>>,
+    #[serde(deserialize_with = "deserialize_double_option", default)]
     pub data_dir: Option<Option<String>>,
+    #[serde(deserialize_with = "deserialize_double_option", default)]
     pub workspaces_dir: Option<Option<String>>,
 }
 

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -340,6 +340,52 @@ impl Default for AppConfig {
     }
 }
 
+/// Partial update payload for [`AppConfig`], used by the `config_set` IPC command.
+///
+/// Each optional field uses `None` = "don't touch this field".
+/// For nullable fields (`github_token`, `data_dir`, `workspaces_dir`),
+/// `Some(None)` means "explicitly clear to null" and `Some(Some(v))` means "set to v".
+///
+/// **Note:** To update the GitHub token with validation, use `auth_set_token` instead.
+/// Setting `github_token` here bypasses API validation — use only for clearing the token
+/// or for advanced scenarios where the caller has already validated the token.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+#[allow(clippy::option_option)] // Deliberate: None = absent, Some(None) = clear, Some(Some(v)) = set
+pub struct PartialAppConfig {
+    pub poll_interval_secs: Option<u64>,
+    pub max_active_workspaces: Option<u32>,
+    pub github_token: Option<Option<String>>,
+    pub data_dir: Option<Option<String>>,
+    pub workspaces_dir: Option<Option<String>>,
+}
+
+/// Merge a partial update into a base config, returning a new config.
+///
+/// Only fields present in `partial` override the base.
+pub fn merge_partial_config(base: &AppConfig, partial: &PartialAppConfig) -> AppConfig {
+    AppConfig {
+        poll_interval_secs: partial
+            .poll_interval_secs
+            .unwrap_or(base.poll_interval_secs),
+        max_active_workspaces: partial
+            .max_active_workspaces
+            .unwrap_or(base.max_active_workspaces),
+        github_token: match &partial.github_token {
+            Some(v) => v.clone(),
+            None => base.github_token.clone(),
+        },
+        data_dir: match &partial.data_dir {
+            Some(v) => v.clone(),
+            None => base.data_dir.clone(),
+        },
+        workspaces_dir: match &partial.workspaces_dir {
+            Some(v) => v.clone(),
+            None => base.workspaces_dir.clone(),
+        },
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1,6 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { TAURI_COMMANDS } from "./types";
-import type { AuthStatus, DashboardData, DashboardStats, Repo } from "./types";
+import type { AppConfig, AuthStatus, DashboardData, DashboardStats, PartialAppConfig, Repo } from "./types";
 
 export async function authSetToken(token: string): Promise<string> {
   return invoke<string>(TAURI_COMMANDS.auth_set_token, { token });
@@ -36,4 +36,12 @@ export async function setRepoEnabled(repoId: string, enabled: boolean): Promise<
 
 export async function setRepoLocalPath(repoId: string, path: string | null): Promise<Repo> {
   return invoke<Repo>(TAURI_COMMANDS.repos_set_local_path, { repoId, path });
+}
+
+export async function getConfig(): Promise<AppConfig> {
+  return invoke<AppConfig>(TAURI_COMMANDS.config_get);
+}
+
+export async function setConfig(partial: PartialAppConfig): Promise<AppConfig> {
+  return invoke<AppConfig>(TAURI_COMMANDS.config_set, { partial });
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -188,6 +188,22 @@ export interface AppConfig {
   readonly workspacesDir: string | null;
 }
 
+/** Partial update payload for `config_set`. Mirrors Rust `PartialAppConfig`.
+ *
+ * - `undefined` (key absent) = leave unchanged
+ * - `null` (for nullable fields) = explicitly clear to null
+ * - value = set to that value
+ */
+export interface PartialAppConfig {
+  readonly pollIntervalSecs?: number;
+  readonly maxActiveWorkspaces?: number;
+  /** undefined = leave unchanged, null = clear token, string = set token.
+   * Prefer `authSetToken` for validated token updates. */
+  readonly githubToken?: string | null;
+  readonly dataDir?: string | null;
+  readonly workspacesDir?: string | null;
+}
+
 // ── Tauri IPC command & event registries ─────────────────────────
 
 export type TauriCommandName =


### PR DESCRIPTION
## Summary
- Add `config_get` (query) and `config_set` (command) Tauri IPC commands bridging the config DB layer to the frontend
- Introduce `PartialAppConfig` type with three-way `Option<Option<T>>` semantics for nullable fields (absent = don't touch, null = clear, value = set)
- `merge_partial_config` merges partial updates into the current config before persisting
- TypeScript wrappers `getConfig()` and `setConfig(partial)` with dedicated `PartialAppConfig` interface
- Remove stale `#[allow(dead_code)]` from `get_config` and `set_config` in `cache/config.rs`
- Register both commands in `lib.rs` invoke_handler

## Test plan
- [x] `test_config_serializes_camel_case` — AppConfig JSON matches frontend expectations
- [x] `test_partial_config_deserializes_from_frontend` — partial JSON with single field parses correctly
- [x] `test_partial_config_empty_object` — empty `{}` produces all-None partial
- [x] `test_merge_partial_config_overrides_only_provided_fields` — unchanged fields preserved
- [x] `test_merge_partial_config_clears_optional_with_explicit_null` — `Some(None)` clears nullable fields
- [x] 218 Rust tests passing, clippy clean, TypeScript `tsc --noEmit` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `config_get` and `config_set` Tauri IPC commands so the frontend can read and update app settings. Implements three-way partial updates and exposes `getConfig()`/`setConfig()` in TypeScript, and fixes null-vs-absent deserialization so clearing works. (T-038)

- **New Features**
  - `config_get` returns full `AppConfig`; `config_set` merges a `PartialAppConfig` and persists (absent = keep, null = clear, value = set), returning the clamped config.
  - Rust `merge_partial_config`; TS types/wrappers: `PartialAppConfig`, `getConfig()`, `setConfig()`.

- **Bug Fixes**
  - Custom deserializer for `Option<Option<T>>` so JSON `null` is distinct from an absent key, enabling reliable clears in `config_set`.

<sup>Written for commit 0721e65a50cacbe37b5e394bcdce4bb48774d41a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add ability to read and update persisted application configuration from the frontend.
  * Support partial updates where omitted fields remain unchanged and explicit null values clear fields.
  * Expose frontend APIs for invoking config read/update operations.

* **Tests**
  * Added unit tests covering config serialization, partial-update semantics, and merge behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->