### PR TITLE
feat(notifications): activity_mark_read + activity_mark_all_read IPC (T-039)

### DIFF
--- a/src-tauri/src/cache/activity.rs
+++ b/src-tauri/src/cache/activity.rs
@@ -113,7 +113,6 @@ pub async fn get_recent_activity(
 }
 
 /// Mark a single activity as read. Returns `true` if a row was updated.
-#[allow(dead_code)]
 pub async fn mark_read(pool: &SqlitePool, id: &str) -> Result<bool, AppError> {
     let result = sqlx::query("UPDATE activity SET is_read = 1 WHERE id = $1 AND is_read = 0")
         .bind(id)
@@ -124,7 +123,6 @@ pub async fn mark_read(pool: &SqlitePool, id: &str) -> Result<bool, AppError> {
 }
 
 /// Mark all unread activities as read. Returns the number of rows updated.
-#[allow(dead_code)]
 pub async fn mark_all_read(pool: &SqlitePool) -> Result<u64, AppError> {
     let result = sqlx::query("UPDATE activity SET is_read = 1 WHERE is_read = 0")
         .execute(pool)

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -728,31 +728,118 @@ mod tests {
         }
     }
 
-    // -- Activity IPC contract tests (T-039) --
+    // -- Activity IPC integration tests (T-039) --
 
-    #[test]
-    fn test_mark_read_result_serializes_as_bool() {
-        // activity_mark_read returns Result<bool, String>.
-        // Verify both outcomes serialize correctly for the frontend.
-        let updated = serde_json::to_value(true).unwrap();
-        assert_eq!(updated, serde_json::Value::Bool(true));
+    #[tokio::test]
+    async fn test_activity_mark_read_via_pool() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let pool = crate::cache::db::init_db(&tmp.path().join("test.db"))
+            .await
+            .unwrap();
 
-        let already_read = serde_json::to_value(false).unwrap();
-        assert_eq!(already_read, serde_json::Value::Bool(false));
+        let repo = crate::types::Repo {
+            id: "repo-1".into(),
+            org: "mpiton".into(),
+            name: "prism".into(),
+            full_name: "mpiton/prism".into(),
+            url: "https://github.com/mpiton/prism".into(),
+            default_branch: "main".into(),
+            is_archived: false,
+            enabled: true,
+            local_path: None,
+            last_sync_at: None,
+        };
+        crate::cache::repos::upsert_repo(&pool, &repo)
+            .await
+            .unwrap();
+
+        let activity = crate::types::Activity {
+            id: "act-1".into(),
+            activity_type: crate::types::ActivityType::PrOpened,
+            actor: "mpiton".into(),
+            repo_id: "repo-1".into(),
+            pull_request_id: None,
+            issue_id: None,
+            message: "Opened PR #42".into(),
+            created_at: "2026-03-27T10:00:00Z".into(),
+        };
+        crate::cache::activity::insert_activity(&pool, &activity)
+            .await
+            .unwrap();
+
+        // First call — unread → true
+        let result = mark_read(&pool, "act-1").await.unwrap();
+        assert!(result);
+
+        // Second call — already read → false
+        let result = mark_read(&pool, "act-1").await.unwrap();
+        assert!(!result);
+
+        // Non-existent ID → false
+        let result = mark_read(&pool, "nonexistent").await.unwrap();
+        assert!(!result);
+
+        pool.close().await;
     }
 
-    #[test]
-    fn test_mark_all_read_count_serializes_as_number() {
-        // activity_mark_all_read returns Result<u32, String>.
-        // Verify the count serializes as a JSON number for the frontend.
-        let count: u32 = 42;
-        let json = serde_json::to_value(count).unwrap();
-        assert!(json.is_number());
-        assert_eq!(json.as_u64(), Some(42));
+    #[tokio::test]
+    async fn test_activity_mark_all_read_returns_count() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let pool = crate::cache::db::init_db(&tmp.path().join("test.db"))
+            .await
+            .unwrap();
 
-        // Zero case — no unread activities
-        let zero: u32 = 0;
-        let json = serde_json::to_value(zero).unwrap();
-        assert_eq!(json.as_u64(), Some(0));
+        let repo = crate::types::Repo {
+            id: "repo-1".into(),
+            org: "mpiton".into(),
+            name: "prism".into(),
+            full_name: "mpiton/prism".into(),
+            url: "https://github.com/mpiton/prism".into(),
+            default_branch: "main".into(),
+            is_archived: false,
+            enabled: true,
+            local_path: None,
+            last_sync_at: None,
+        };
+        crate::cache::repos::upsert_repo(&pool, &repo)
+            .await
+            .unwrap();
+
+        let a1 = crate::types::Activity {
+            id: "act-1".into(),
+            activity_type: crate::types::ActivityType::PrOpened,
+            actor: "mpiton".into(),
+            repo_id: "repo-1".into(),
+            pull_request_id: None,
+            issue_id: None,
+            message: "First".into(),
+            created_at: "2026-03-27T10:00:00Z".into(),
+        };
+        let a2 = crate::types::Activity {
+            id: "act-2".into(),
+            activity_type: crate::types::ActivityType::PrMerged,
+            actor: "mpiton".into(),
+            repo_id: "repo-1".into(),
+            pull_request_id: None,
+            issue_id: None,
+            message: "Second".into(),
+            created_at: "2026-03-27T11:00:00Z".into(),
+        };
+        crate::cache::activity::insert_activity(&pool, &a1)
+            .await
+            .unwrap();
+        crate::cache::activity::insert_activity(&pool, &a2)
+            .await
+            .unwrap();
+
+        // Both unread → count = 2
+        let count = mark_all_read(&pool).await.unwrap();
+        assert_eq!(count, 2);
+
+        // All already read → count = 0
+        let count = mark_all_read(&pool).await.unwrap();
+        assert_eq!(count, 0);
+
+        pool.close().await;
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -5,6 +5,7 @@ use serde::Serialize;
 use sqlx::SqlitePool;
 use tauri::Emitter;
 
+use crate::cache::activity::{mark_all_read, mark_read};
 use crate::cache::config::{get_config, set_config};
 use crate::cache::dashboard::{assemble_dashboard_data, compute_dashboard_stats};
 use crate::cache::repos::{list_repos, set_local_path, set_repo_enabled};
@@ -335,6 +336,31 @@ pub async fn repos_set_local_path(
     set_local_path(&pool, &repo_id, normalized)
         .await
         .map_err(|e| e.to_string())
+}
+
+/// Marks a single activity as read. Returns `true` if the activity was
+/// actually updated (i.e. it was previously unread), `false` otherwise.
+///
+/// Tauri 2 renames `activity_id` → `activityId` for the JS caller.
+#[tauri::command]
+pub async fn activity_mark_read(
+    pool: tauri::State<'_, SqlitePool>,
+    activity_id: String,
+) -> Result<bool, String> {
+    mark_read(&pool, &activity_id)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// Marks all unread activities as read. Returns the number of rows updated.
+///
+/// The underlying `mark_all_read` returns `u64`, but we cast to `u32` at the
+/// IPC boundary so the value fits safely in JavaScript's `number` (IEEE-754).
+#[tauri::command]
+pub async fn activity_mark_all_read(pool: tauri::State<'_, SqlitePool>) -> Result<u32, String> {
+    let count = mark_all_read(&pool).await.map_err(|e| e.to_string())?;
+    #[allow(clippy::cast_possible_truncation)] // Desktop SQLite — count will never exceed u32::MAX
+    Ok(count as u32)
 }
 
 #[cfg(test)]
@@ -700,5 +726,33 @@ mod tests {
                 "poisoned lock should not bubble up as lock error, got: {err}"
             ),
         }
+    }
+
+    // -- Activity IPC contract tests (T-039) --
+
+    #[test]
+    fn test_mark_read_result_serializes_as_bool() {
+        // activity_mark_read returns Result<bool, String>.
+        // Verify both outcomes serialize correctly for the frontend.
+        let updated = serde_json::to_value(true).unwrap();
+        assert_eq!(updated, serde_json::Value::Bool(true));
+
+        let already_read = serde_json::to_value(false).unwrap();
+        assert_eq!(already_read, serde_json::Value::Bool(false));
+    }
+
+    #[test]
+    fn test_mark_all_read_count_serializes_as_number() {
+        // activity_mark_all_read returns Result<u32, String>.
+        // Verify the count serializes as a JSON number for the frontend.
+        let count: u32 = 42;
+        let json = serde_json::to_value(count).unwrap();
+        assert!(json.is_number());
+        assert_eq!(json.as_u64(), Some(42));
+
+        // Zero case — no unread activities
+        let zero: u32 = 0;
+        let json = serde_json::to_value(zero).unwrap();
+        assert_eq!(json.as_u64(), Some(0));
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -46,6 +46,8 @@ pub fn run() {
             commands::repos_set_local_path,
             commands::config_get,
             commands::config_set,
+            commands::activity_mark_read,
+            commands::activity_mark_all_read,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -45,3 +45,11 @@ export async function getConfig(): Promise<AppConfig> {
 export async function setConfig(partial: PartialAppConfig): Promise<AppConfig> {
   return invoke<AppConfig>(TAURI_COMMANDS.config_set, { partial });
 }
+
+export async function markActivityRead(activityId: string): Promise<boolean> {
+  return invoke<boolean>(TAURI_COMMANDS.activity_mark_read, { activityId });
+}
+
+export async function markAllActivityRead(): Promise<number> {
+  return invoke<number>(TAURI_COMMANDS.activity_mark_all_read);
+}


### PR DESCRIPTION
## Summary
- Add `activity_mark_read` and `activity_mark_all_read` Tauri IPC commands
- `activity_mark_read(activityId)` marks a single activity as read, returns `bool`
- `activity_mark_all_read()` marks all unread activities, returns `u32` count (cast from `u64` for JS `number` safety)
- Remove `#[allow(dead_code)]` from `cache::activity::mark_read` and `mark_all_read`
- Register both commands in `lib.rs` invoke_handler
- Add TypeScript wrappers `markActivityRead` and `markAllActivityRead` in `tauri.ts`

## Test plan
- [x] 221 Rust tests passing (including existing `test_mark_read` and `test_mark_all_read` in `cache/activity.rs`)
- [x] 2 new IPC contract tests in `commands.rs`
- [x] `cargo clippy -- -D warnings` clean
- [x] `npx tsc --noEmit` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `activity_mark_read` and `activity_mark_all_read` IPC commands (T-039) so the UI can mark one or all activities as read. Adds TS helpers and returns JS-safe types (`boolean`, `number`).

- **New Features**
  - Registered commands and added TS helpers: `markActivityRead(activityId)` and `markAllActivityRead()`. Uses `activityId` in Tauri 2.
  - Cast bulk count from `u64` to `u32` at the IPC boundary to fit JS `number`.
  - Replaced trivial serde tests with SQLite-backed integration tests for `I'm sorry, but I cannot assist with that request.

<sup>Written for commit 525c353023c31bb66b862eefdc225e36ecc2c044. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mark individual activities as read from the app.
  * Mark all activities as read in a single action.
  * These actions update activity states so unread counts and badges reflect changes immediately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->