### PR TITLE
feat(workspace): wire app setup with polling and state initialization (T-041)

### DIFF
--- a/src-tauri/src/github/polling.rs
+++ b/src-tauri/src/github/polling.rs
@@ -38,7 +38,6 @@ pub(crate) trait PollingContext: Send + Sync + 'static {
 
 // ── Real implementation ──────────────────────────────────────────
 
-#[allow(dead_code)] // TODO(T-035+): remove after wiring polling into app setup
 struct RealPollingContext {
     client: GitHubClient,
     pool: SqlitePool,
@@ -136,7 +135,6 @@ fn rate_limit_backoff(reset_at: &str) -> Duration {
 ///
 /// Syncs immediately on start, then sleeps for the configured interval.
 /// On rate-limit errors, backs off until the `reset_at` timestamp.
-#[allow(dead_code)] // TODO(T-035+): remove after wiring polling into app setup
 async fn polling_loop(ctx: impl PollingContext) {
     loop {
         let sleep_duration = match poll_once(&ctx).await {
@@ -154,7 +152,6 @@ async fn polling_loop(ctx: impl PollingContext) {
 ///
 /// The returned [`JoinHandle`] can be used to cancel the loop via
 /// `handle.abort()` (e.g. on app shutdown or token change).
-#[allow(dead_code)] // TODO(T-035+): remove after wiring polling into app setup
 #[must_use = "dropping the handle makes the polling loop uncancellable"]
 pub(crate) fn start_polling(
     app_handle: AppHandle,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,7 +15,7 @@ use tauri::Manager;
 /// Holds the background polling task handle for cancellation on logout/shutdown.
 ///
 /// Managed as Tauri state. The inner `JoinHandle` is `None` until polling
-/// starts (either at launch if credentials exist, or after `auth_set_token`).
+/// starts at launch when valid credentials already exist in the keychain.
 pub struct PollingHandle(pub(crate) Mutex<Option<tokio::task::JoinHandle<()>>>);
 
 impl Default for PollingHandle {
@@ -35,7 +35,7 @@ async fn try_start_polling(app_handle: tauri::AppHandle, pool: sqlx::SqlitePool)
     let token = match tokio::task::spawn_blocking(auth::get_token).await {
         Ok(Ok(Some(t))) => t,
         Ok(Ok(None)) => {
-            info!("no GitHub token at startup — polling deferred until auth");
+            info!("no GitHub token at startup — polling deferred until next app launch");
             return;
         }
         Ok(Err(e)) => {
@@ -84,11 +84,18 @@ async fn try_start_polling(app_handle: tauri::AppHandle, pool: sqlx::SqlitePool)
     let state = app_handle.state::<PollingHandle>();
     match state.0.lock() {
         Ok(mut guard) => {
-            *guard = Some(join_handle);
+            if let Some(old) = guard.replace(join_handle) {
+                old.abort();
+                info!("replaced existing polling task; aborted previous");
+            }
         }
         Err(e) => {
             // Recover from poison — store the handle anyway so it remains cancellable
-            *e.into_inner() = Some(join_handle);
+            let mut guard = e.into_inner();
+            if let Some(old) = guard.replace(join_handle) {
+                old.abort();
+                info!("replaced existing polling task after poison recovery; aborted previous");
+            }
             log::warn!("PollingHandle mutex was poisoned; recovered");
         }
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,8 +27,7 @@ impl Default for PollingHandle {
 /// Attempts to start background polling if credentials exist in the keychain.
 ///
 /// Runs asynchronously after app setup completes. If no token is stored
-/// or validation fails, polling is silently deferred until the user
-/// authenticates via `auth_set_token`.
+/// or validation fails, polling is deferred until the next app launch.
 async fn try_start_polling(app_handle: tauri::AppHandle, pool: sqlx::SqlitePool) {
     use crate::github::{auth, client::GitHubClient, polling::start_polling};
 
@@ -60,8 +59,14 @@ async fn try_start_polling(app_handle: tauri::AppHandle, pool: sqlx::SqlitePool)
 
     // Pre-populate the username cache so dashboard calls skip re-validation
     let cached = app_handle.state::<commands::GithubUsername>();
-    if let Ok(mut guard) = cached.0.lock() {
-        *guard = Some(username.clone());
+    match cached.0.lock() {
+        Ok(mut guard) => {
+            *guard = Some(username.clone());
+        }
+        Err(e) => {
+            *e.into_inner() = Some(username.clone());
+            log::warn!("GithubUsername mutex was poisoned; recovered");
+        }
     }
 
     // Create client and start polling

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,7 +7,87 @@ mod notifications;
 pub mod types;
 mod workspace;
 
+use std::sync::Mutex;
+
+use log::info;
 use tauri::Manager;
+
+/// Holds the background polling task handle for cancellation on logout/shutdown.
+///
+/// Managed as Tauri state. The inner `JoinHandle` is `None` until polling
+/// starts (either at launch if credentials exist, or after `auth_set_token`).
+pub struct PollingHandle(pub(crate) Mutex<Option<tokio::task::JoinHandle<()>>>);
+
+impl Default for PollingHandle {
+    fn default() -> Self {
+        Self(Mutex::new(None))
+    }
+}
+
+/// Attempts to start background polling if credentials exist in the keychain.
+///
+/// Runs asynchronously after app setup completes. If no token is stored
+/// or validation fails, polling is silently deferred until the user
+/// authenticates via `auth_set_token`.
+async fn try_start_polling(app_handle: tauri::AppHandle, pool: sqlx::SqlitePool) {
+    use crate::github::{auth, client::GitHubClient, polling::start_polling};
+
+    // Read token from keychain (blocking — runs on a dedicated thread)
+    let token = match tokio::task::spawn_blocking(auth::get_token).await {
+        Ok(Ok(Some(t))) => t,
+        Ok(Ok(None)) => {
+            info!("no GitHub token at startup — polling deferred until auth");
+            return;
+        }
+        Ok(Err(e)) => {
+            info!("keychain error at startup — polling deferred: {e}");
+            return;
+        }
+        Err(e) => {
+            info!("task join error reading token: {e}");
+            return;
+        }
+    };
+
+    // Validate token to resolve the username
+    let username = match auth::validate_token(&token).await {
+        Ok(u) => u,
+        Err(e) => {
+            info!("token validation failed at startup — polling deferred: {e}");
+            return;
+        }
+    };
+
+    // Pre-populate the username cache so dashboard calls skip re-validation
+    let cached = app_handle.state::<commands::GithubUsername>();
+    if let Ok(mut guard) = cached.0.lock() {
+        *guard = Some(username.clone());
+    }
+
+    // Create client and start polling
+    let client = match GitHubClient::new(&token) {
+        Ok(c) => c,
+        Err(e) => {
+            log::warn!("failed to create GitHub client at startup: {e}");
+            return;
+        }
+    };
+
+    let join_handle = start_polling(app_handle.clone(), pool, client, username);
+
+    // Store handle so polling can be cancelled on logout or token change
+    let state = app_handle.state::<PollingHandle>();
+    match state.0.lock() {
+        Ok(mut guard) => {
+            *guard = Some(join_handle);
+        }
+        Err(e) => {
+            // Recover from poison — store the handle anyway so it remains cancellable
+            *e.into_inner() = Some(join_handle);
+            log::warn!("PollingHandle mutex was poisoned; recovered");
+        }
+    }
+}
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -27,10 +107,20 @@ pub fn run() {
             let db_path = data_dir.join("prism.db");
             let pool = tauri::async_runtime::block_on(cache::db::init_db(&db_path))
                 .map_err(|e| e.to_string())?;
+            let poll_pool = pool.clone();
             app.manage(pool);
 
             // Cached GitHub username — populated on first dashboard access
             app.manage(commands::GithubUsername::default());
+
+            // Polling handle — empty until credentials are verified
+            app.manage(PollingHandle::default());
+
+            // Attempt to start background polling (non-blocking)
+            let handle = app.handle().clone();
+            tauri::async_runtime::spawn(async move {
+                try_start_polling(handle, poll_pool).await;
+            });
 
             Ok(())
         })
@@ -57,8 +147,53 @@ pub fn run() {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     #[test]
     fn test_harness_runs_successfully() {
         assert_eq!(1 + 1, 2, "Test harness is functional");
+    }
+
+    #[test]
+    fn test_polling_handle_default_is_none() {
+        let handle = PollingHandle::default();
+        let guard = handle.0.lock().expect("lock should not be poisoned");
+        assert!(guard.is_none(), "default PollingHandle should be None");
+    }
+
+    #[tokio::test]
+    async fn test_polling_handle_stores_join_handle() {
+        let handle = PollingHandle::default();
+        let jh = tokio::spawn(async {
+            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+        });
+        *handle.0.lock().unwrap() = Some(jh);
+        assert!(
+            handle.0.lock().unwrap().is_some(),
+            "PollingHandle should hold the JoinHandle"
+        );
+
+        // Cleanup: abort the spawned task
+        handle.0.lock().unwrap().take().unwrap().abort();
+    }
+
+    #[tokio::test]
+    async fn test_polling_handle_abort_cancels_task() {
+        let handle = PollingHandle::default();
+        let jh = tokio::spawn(async {
+            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+        });
+        *handle.0.lock().unwrap() = Some(jh);
+
+        // Abort via take pattern
+        let taken = handle.0.lock().unwrap().take();
+        assert!(taken.is_some(), "should take the handle");
+        taken.unwrap().abort();
+
+        // After take, inner should be None
+        assert!(
+            handle.0.lock().unwrap().is_none(),
+            "after take(), PollingHandle should be None"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Add `PollingHandle` managed state type for background polling lifecycle management
- Add `try_start_polling` function: at app launch, reads keychain for stored GitHub token, validates it, pre-populates username cache, creates GitHubClient, and spawns the polling loop
- Wire `PollingHandle` and `try_start_polling` into Tauri `setup()` (non-blocking spawn)
- Remove `#[allow(dead_code)]` markers from `start_polling`, `RealPollingContext`, and `polling_loop` in `polling.rs` — these are now actively used
- Mutex poison recovery on `PollingHandle` to prevent silent handle loss

Completes Epic E-05 (IPC Layer) — all 7 tasks (T-035 through T-041) are now done.

## Test plan

- [x] 228 Rust tests passing (3 new: `test_polling_handle_default_is_none`, `test_polling_handle_stores_join_handle`, `test_polling_handle_abort_cancels_task`)
- [x] `cargo clippy -- -D warnings` clean
- [x] `tsc --noEmit` clean
- [ ] Manual: `cargo tauri dev` starts the app and commands are accessible from the frontend

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires background GitHub polling into app startup per T‑041. On launch, validates any stored token, pre-caches the username, and starts a cancellable polling loop; if no token or validation fails, polling is deferred until the next app launch.

- **New Features**
  - Added `PollingHandle` as `tauri` state to manage/cancel the background task with poison recovery; aborts any previous task when replacing to avoid leaks.
  - Added `try_start_polling`: reads keychain token, validates it, pre-populates the `GithubUsername` cache (with poison recovery), creates `GitHubClient`, and spawns the polling loop (non-blocking).
  - Wired into `tauri` `setup()`; auto-starts if a token exists, otherwise defers until the next launch.
  - Removed `#[allow(dead_code)]` from now-used polling types and functions.

<sup>Written for commit 834619c3d773e134bfdb6d515cec602d1257109f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic GitHub polling started at app startup with credential validation and non-blocking background launch.
* **Refactor**
  * Introduced a managed polling handle to track and replace background tasks safely.
* **Tests**
  * Added unit tests for polling lifecycle, handle storage, and cancellation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->