### PR TITLE
feat(ui): add Zustand dashboard store (T-043)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "@tanstack/react-query": "^5.95.2",
         "@tauri-apps/api": "^2.10.1",
         "react": "^19.2.4",
-        "react-dom": "^19.2.4"
+        "react-dom": "^19.2.4",
+        "zustand": "^5.0.12"
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.2.2",
@@ -2241,7 +2242,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2586,7 +2587,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -4150,6 +4151,35 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/zustand": {
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.12.tgz",
+      "integrity": "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "@tanstack/react-query": "^5.95.2",
     "@tauri-apps/api": "^2.10.1",
     "react": "^19.2.4",
-    "react-dom": "^19.2.4"
+    "react-dom": "^19.2.4",
+    "zustand": "^5.0.12"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.2",

--- a/src/stores/dashboard.test.ts
+++ b/src/stores/dashboard.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useDashboardStore } from "./dashboard";
+
+describe("useDashboardStore", () => {
+  beforeEach(() => {
+    useDashboardStore.setState({ currentView: "overview", activeFilters: {} });
+  });
+
+  it("should have default view as overview", () => {
+    const state = useDashboardStore.getState();
+    expect(state.currentView).toBe("overview");
+  });
+
+  it("should have empty filters by default", () => {
+    const state = useDashboardStore.getState();
+    expect(state.activeFilters).toEqual({});
+  });
+
+  it("should set view", () => {
+    useDashboardStore.getState().setView("reviews");
+    expect(useDashboardStore.getState().currentView).toBe("reviews");
+
+    useDashboardStore.getState().setView("settings");
+    expect(useDashboardStore.getState().currentView).toBe("settings");
+  });
+
+  it("should set filter", () => {
+    useDashboardStore.getState().setFilter({ repo: "prism" });
+    expect(useDashboardStore.getState().activeFilters).toEqual({
+      repo: "prism",
+    });
+  });
+
+  it("should merge filters when setting multiple", () => {
+    useDashboardStore.getState().setFilter({ repo: "prism" });
+    useDashboardStore.getState().setFilter({ priority: "high" });
+    expect(useDashboardStore.getState().activeFilters).toEqual({
+      repo: "prism",
+      priority: "high",
+    });
+  });
+
+  it("should overwrite existing filter key", () => {
+    useDashboardStore.getState().setFilter({ repo: "prism" });
+    useDashboardStore.getState().setFilter({ repo: "other-repo" });
+    expect(useDashboardStore.getState().activeFilters.repo).toBe("other-repo");
+  });
+
+  it("should clear filters", () => {
+    useDashboardStore.getState().setFilter({ repo: "prism", priority: "high" });
+    useDashboardStore.getState().clearFilters();
+    expect(useDashboardStore.getState().activeFilters).toEqual({});
+  });
+
+  it("should not mutate previous state on setView", () => {
+    const before = useDashboardStore.getState();
+    useDashboardStore.getState().setView("workspaces");
+    const after = useDashboardStore.getState();
+    expect(before).not.toBe(after);
+    expect(before.currentView).toBe("overview");
+    expect(after.currentView).toBe("workspaces");
+  });
+
+  it("should not mutate previous filters on setFilter", () => {
+    useDashboardStore.getState().setFilter({ repo: "prism" });
+    const filtersBefore = useDashboardStore.getState().activeFilters;
+    useDashboardStore.getState().setFilter({ priority: "critical" });
+    const filtersAfter = useDashboardStore.getState().activeFilters;
+    expect(filtersBefore).not.toBe(filtersAfter);
+    expect(filtersBefore).toEqual({ repo: "prism" });
+  });
+});

--- a/src/stores/dashboard.test.ts
+++ b/src/stores/dashboard.test.ts
@@ -52,6 +52,27 @@ describe("useDashboardStore", () => {
     expect(useDashboardStore.getState().activeFilters).toEqual({});
   });
 
+  it("should handle all filter types together", () => {
+    useDashboardStore.getState().setFilter({
+      repo: "prism",
+      priority: "high",
+      ciStatus: "success",
+    });
+    expect(useDashboardStore.getState().activeFilters).toEqual({
+      repo: "prism",
+      priority: "high",
+      ciStatus: "success",
+    });
+  });
+
+  it("should ignore undefined values in setFilter", () => {
+    useDashboardStore.getState().setFilter({ repo: "prism" });
+    useDashboardStore.getState().setFilter({ priority: undefined });
+    const filters = useDashboardStore.getState().activeFilters;
+    expect(filters).toEqual({ repo: "prism" });
+    expect(Object.keys(filters)).toEqual(["repo"]);
+  });
+
   it("should not mutate previous state on setView", () => {
     const before = useDashboardStore.getState();
     useDashboardStore.getState().setView("workspaces");

--- a/src/stores/dashboard.test.ts
+++ b/src/stores/dashboard.test.ts
@@ -65,7 +65,15 @@ describe("useDashboardStore", () => {
     });
   });
 
-  it("should ignore undefined values in setFilter", () => {
+  it("should remove a single filter via undefined", () => {
+    useDashboardStore.getState().setFilter({ repo: "prism", priority: "high" });
+    useDashboardStore.getState().setFilter({ repo: undefined });
+    const filters = useDashboardStore.getState().activeFilters;
+    expect(filters).toEqual({ priority: "high" });
+    expect(Object.keys(filters)).not.toContain("repo");
+  });
+
+  it("should not add ghost keys from undefined values", () => {
     useDashboardStore.getState().setFilter({ repo: "prism" });
     useDashboardStore.getState().setFilter({ priority: undefined });
     const filters = useDashboardStore.getState().activeFilters;

--- a/src/stores/dashboard.ts
+++ b/src/stores/dashboard.ts
@@ -35,10 +35,11 @@ export const useDashboardStore = create<DashboardState>((set) => ({
   setView: (view) => set({ currentView: view }),
   setFilter: (filter) =>
     set((state) => {
-      const sanitized = Object.fromEntries(
-        Object.entries(filter).filter(([, v]) => v !== undefined),
-      ) as Partial<DashboardFilters>;
-      return { activeFilters: { ...state.activeFilters, ...sanitized } };
+      const merged = { ...state.activeFilters, ...filter };
+      const cleaned = Object.fromEntries(
+        Object.entries(merged).filter(([, v]) => v !== undefined),
+      ) as DashboardFilters;
+      return { activeFilters: cleaned };
     }),
   clearFilters: () => set({ activeFilters: {} }),
 }));

--- a/src/stores/dashboard.ts
+++ b/src/stores/dashboard.ts
@@ -16,7 +16,7 @@ export interface DashboardFilters {
   readonly ciStatus?: CiStatus;
 }
 
-interface DashboardData {
+interface DashboardUiState {
   readonly currentView: DashboardView;
   readonly activeFilters: DashboardFilters;
 }
@@ -27,15 +27,18 @@ interface DashboardActions {
   clearFilters: () => void;
 }
 
-type DashboardState = DashboardData & DashboardActions;
+type DashboardState = DashboardUiState & DashboardActions;
 
 export const useDashboardStore = create<DashboardState>((set) => ({
   currentView: "overview",
   activeFilters: {},
   setView: (view) => set({ currentView: view }),
   setFilter: (filter) =>
-    set((state) => ({
-      activeFilters: { ...state.activeFilters, ...filter },
-    })),
+    set((state) => {
+      const sanitized = Object.fromEntries(
+        Object.entries(filter).filter(([, v]) => v !== undefined),
+      ) as Partial<DashboardFilters>;
+      return { activeFilters: { ...state.activeFilters, ...sanitized } };
+    }),
   clearFilters: () => set({ activeFilters: {} }),
 }));

--- a/src/stores/dashboard.ts
+++ b/src/stores/dashboard.ts
@@ -1,0 +1,41 @@
+import { create } from "zustand";
+import type { Priority, CiStatus } from "../lib/types";
+
+export type DashboardView =
+  | "overview"
+  | "reviews"
+  | "mine"
+  | "issues"
+  | "feed"
+  | "workspaces"
+  | "settings";
+
+export interface DashboardFilters {
+  readonly repo?: string;
+  readonly priority?: Priority;
+  readonly ciStatus?: CiStatus;
+}
+
+interface DashboardData {
+  readonly currentView: DashboardView;
+  readonly activeFilters: DashboardFilters;
+}
+
+interface DashboardActions {
+  setView: (view: DashboardView) => void;
+  setFilter: (filter: Partial<DashboardFilters>) => void;
+  clearFilters: () => void;
+}
+
+type DashboardState = DashboardData & DashboardActions;
+
+export const useDashboardStore = create<DashboardState>((set) => ({
+  currentView: "overview",
+  activeFilters: {},
+  setView: (view) => set({ currentView: view }),
+  setFilter: (filter) =>
+    set((state) => ({
+      activeFilters: { ...state.activeFilters, ...filter },
+    })),
+  clearFilters: () => set({ activeFilters: {} }),
+}));


### PR DESCRIPTION
## Summary

• Add Zustand store for dashboard state management
• Implement currentView with 7 view options (overview, reviews, mine, issues, feed, workspaces, settings)
• Implement activeFilters with repo, priority, and ciStatus filter support
• Add immutable actions: setView, setFilter, clearFilters
• 9 unit tests covering state transitions, filter merging, and immutability guarantees
• Install zustand@5.0.12 dependency

## Type

feat

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a global dashboard state store using `zustand` for view switching and filter management to meet T-043. Also enables removing a single filter via `setFilter({ key: undefined })` and fixes a naming conflict.

- **New Features**
  - `useDashboardStore` with `currentView` and `activeFilters` for centralized dashboard state.
  - 7 views: overview, reviews, mine, issues, feed, workspaces, settings.
  - Filters: `repo`, `priority`, `ciStatus`; actions: `setView`, `setFilter` (merges), `clearFilters` (resets).
  - 12 unit tests covering view changes, filter merging, immutability, `ciStatus`, and undefined handling.

- **Bug Fixes**
  - Renamed `DashboardData` to `DashboardUiState` to avoid collision with types in `lib/types.ts`.
  - Merge then strip `undefined` in `setFilter` to prevent ghost keys and allow single-filter removal.

<sup>Written for commit 4a4ac18515391f8538fce5664f32fb962246266e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard: improved view switching and more reliable filter management (apply, merge, remove, and clear filters)
* **Chores**
  * Added a runtime state-management dependency to support dashboard functionality
* **Tests**
  * Added tests covering dashboard view and filter behavior, immutability, and filter sanitization
<!-- end of auto-generated comment: release notes by coderabbit.ai -->