### PR TITLE
feat(ui): add Zustand settings store (T-044)

### DIFF
--- a/src/stores/settings.test.ts
+++ b/src/stores/settings.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useSettingsStore } from "./settings";
+import type { AppConfig } from "../lib/types";
+
+const fakeConfig: AppConfig = {
+  pollIntervalSecs: 60,
+  maxActiveWorkspaces: 3,
+  githubToken: "FAKE_TOKEN_FOR_TESTING",
+  dataDir: "/home/user/.local/share/prism",
+  workspacesDir: "/home/user/.prism/workspaces",
+};
+
+describe("useSettingsStore", () => {
+  beforeEach(() => {
+    useSettingsStore.setState({ config: null, isLoading: false });
+  });
+
+  it("should default to null", () => {
+    const state = useSettingsStore.getState();
+    expect(state.config).toBeNull();
+    expect(state.isLoading).toBe(false);
+  });
+
+  it("should set config", () => {
+    useSettingsStore.getState().setConfig(fakeConfig);
+    expect(useSettingsStore.getState().config).toEqual(fakeConfig);
+  });
+
+  it("should accept a config with null optional fields", () => {
+    const minimal: AppConfig = {
+      pollIntervalSecs: 30,
+      maxActiveWorkspaces: 1,
+      githubToken: null,
+      dataDir: null,
+      workspacesDir: null,
+    };
+    useSettingsStore.getState().setConfig(minimal);
+    expect(useSettingsStore.getState().config).toEqual(minimal);
+  });
+
+  it("should replace config entirely on second setConfig call", () => {
+    useSettingsStore.getState().setConfig(fakeConfig);
+    const updated: AppConfig = { ...fakeConfig, pollIntervalSecs: 120 };
+    useSettingsStore.getState().setConfig(updated);
+    expect(useSettingsStore.getState().config).toEqual(updated);
+  });
+
+  it("should allow setting config back to null", () => {
+    useSettingsStore.getState().setConfig(fakeConfig);
+    useSettingsStore.getState().setConfig(null);
+    expect(useSettingsStore.getState().config).toBeNull();
+  });
+
+  it("should set loading state", () => {
+    useSettingsStore.getState().setLoading(true);
+    expect(useSettingsStore.getState().isLoading).toBe(true);
+
+    useSettingsStore.getState().setLoading(false);
+    expect(useSettingsStore.getState().isLoading).toBe(false);
+  });
+
+  it("should not mutate previous state on setConfig", () => {
+    const before = useSettingsStore.getState();
+    useSettingsStore.getState().setConfig(fakeConfig);
+    const after = useSettingsStore.getState();
+    expect(before).not.toBe(after);
+    expect(before.config).toBeNull();
+    expect(after.config).toEqual(fakeConfig);
+  });
+});

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -1,0 +1,21 @@
+import { create } from "zustand";
+import type { AppConfig } from "../lib/types";
+
+interface SettingsUiState {
+  readonly config: AppConfig | null;
+  readonly isLoading: boolean;
+}
+
+interface SettingsActions {
+  setConfig: (config: AppConfig | null) => void;
+  setLoading: (loading: boolean) => void;
+}
+
+type SettingsState = SettingsUiState & SettingsActions;
+
+export const useSettingsStore = create<SettingsState>((set) => ({
+  config: null,
+  isLoading: false,
+  setConfig: (config) => set({ config }),
+  setLoading: (loading) => set({ isLoading: loading }),
+}));


### PR DESCRIPTION
## Summary

• Add `useSettingsStore` Zustand store with `config` and `isLoading` state
• Implement `setConfig()` and `setLoading()` actions
• Full test coverage: 7 tests including null field handling and immutability checks

## Type

feat

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `zustand`-based settings store for UI state with `config` and `isLoading`, plus actions to update both. Addresses Linear T-044 by centralizing app settings.

- **New Features**
  - `useSettingsStore` with `config: AppConfig | null` and `isLoading: boolean`
  - Actions: `setConfig(config | null)` and `setLoading(boolean)`
  - 7 unit tests covering defaults, null optional fields, and immutability

<sup>Written for commit 8881b249fd9649bfc88b9b035a78c01adca88828. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for settings store functionality.

* **Chores**
  * Implemented internal settings store infrastructure for state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->