### PR TITLE
feat(ui): add Zustand workspaces store (T-045)

### DIFF
--- a/src/stores/workspaces.test.ts
+++ b/src/stores/workspaces.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useWorkspacesStore } from "./workspaces";
+
+describe("useWorkspacesStore", () => {
+  beforeEach(() => {
+    useWorkspacesStore.setState({ activeWorkspaceId: null });
+  });
+
+  it("should default to null", () => {
+    const state = useWorkspacesStore.getState();
+    expect(state.activeWorkspaceId).toBeNull();
+  });
+
+  it("should set active workspace", () => {
+    useWorkspacesStore.getState().setActiveWorkspace("ws-123");
+    expect(useWorkspacesStore.getState().activeWorkspaceId).toBe("ws-123");
+  });
+
+  it("should clear active workspace", () => {
+    useWorkspacesStore.getState().setActiveWorkspace("ws-123");
+    useWorkspacesStore.getState().clearActiveWorkspace();
+    expect(useWorkspacesStore.getState().activeWorkspaceId).toBeNull();
+  });
+
+  it("should replace active workspace on second call", () => {
+    useWorkspacesStore.getState().setActiveWorkspace("ws-1");
+    useWorkspacesStore.getState().setActiveWorkspace("ws-2");
+    expect(useWorkspacesStore.getState().activeWorkspaceId).toBe("ws-2");
+  });
+
+  it("should not mutate previous state on setActiveWorkspace", () => {
+    const before = useWorkspacesStore.getState();
+    useWorkspacesStore.getState().setActiveWorkspace("ws-abc");
+    const after = useWorkspacesStore.getState();
+    expect(before).not.toBe(after);
+    expect(before.activeWorkspaceId).toBeNull();
+    expect(after.activeWorkspaceId).toBe("ws-abc");
+  });
+});

--- a/src/stores/workspaces.ts
+++ b/src/stores/workspaces.ts
@@ -1,0 +1,18 @@
+import { create } from "zustand";
+
+interface WorkspacesUiState {
+  readonly activeWorkspaceId: string | null;
+}
+
+interface WorkspacesActions {
+  setActiveWorkspace: (id: string) => void;
+  clearActiveWorkspace: () => void;
+}
+
+type WorkspacesState = WorkspacesUiState & WorkspacesActions;
+
+export const useWorkspacesStore = create<WorkspacesState>((set) => ({
+  activeWorkspaceId: null,
+  setActiveWorkspace: (id) => set({ activeWorkspaceId: id }),
+  clearActiveWorkspace: () => set({ activeWorkspaceId: null }),
+}));


### PR DESCRIPTION
## Summary
- Add `useWorkspacesStore` Zustand store managing `activeWorkspaceId` state
- Implements `setActiveWorkspace(id)` and `clearActiveWorkspace()` actions
- Follows existing store patterns (settings, dashboard): readonly state, separate actions interface

## Test plan
- [x] 5 unit tests covering default state, set, clear, replace, and immutability
- [x] All 104 project tests pass with no regressions
- [x] oxlint clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `zustand` workspaces store to track the active workspace in the UI and enable workspace switching (Linear T-045). Provides `setActiveWorkspace(id)` and `clearActiveWorkspace()`, with unit tests for default, set, clear, replace, and immutability.

<sup>Written for commit 3afd4374f96bc0cbd25214726b71ad2fa39da07e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced workspace state management to enable active workspace selection and clearing functionality.

* **Tests**
  * Added comprehensive test suite for workspace store operations, including state initialization, state mutations, and immutability validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->