### PR TITLE
feat(ui): add useNotifications hook (T-047)

### DIFF
--- a/src/hooks/useNotifications.test.ts
+++ b/src/hooks/useNotifications.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useNotifications } from "./useNotifications";
+
+vi.mock("../lib/tauri", () => ({
+  onEvent: vi.fn(),
+}));
+
+import { onEvent } from "../lib/tauri";
+
+describe("useNotifications", () => {
+  let unlistenReviewRequest: Mock;
+  let unlistenCiFailure: Mock;
+  let unlistenPrApproved: Mock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    unlistenReviewRequest = vi.fn();
+    unlistenCiFailure = vi.fn();
+    unlistenPrApproved = vi.fn();
+
+    (onEvent as Mock)
+      .mockResolvedValueOnce(unlistenReviewRequest)
+      .mockResolvedValueOnce(unlistenCiFailure)
+      .mockResolvedValueOnce(unlistenPrApproved);
+  });
+
+  it("should capture review_request event", async () => {
+    const { result } = renderHook(() => useNotifications());
+
+    // Wait for listeners to register
+    await vi.waitFor(() => {
+      expect(onEvent).toHaveBeenCalledWith(
+        "notification:review_request",
+        expect.any(Function),
+      );
+    });
+
+    // Simulate event
+    const call = (onEvent as Mock).mock.calls.find(
+      (c: unknown[]) => c[0] === "notification:review_request",
+    );
+    const handler = call![1] as (payload: unknown) => void;
+
+    act(() => {
+      handler({ prNumber: 42, repo: "mpiton/prism", title: "Fix bug" });
+    });
+
+    expect(result.current.notifications).toHaveLength(1);
+    const notif = result.current.notifications[0];
+    expect(notif).toMatchObject({
+      type: "review_request",
+      payload: { prNumber: 42, repo: "mpiton/prism", title: "Fix bug" },
+    });
+    expect(notif?.id).toBeDefined();
+    expect(notif?.timestamp).toBeDefined();
+  });
+
+  it("should capture ci_failure event", async () => {
+    const { result } = renderHook(() => useNotifications());
+
+    await vi.waitFor(() => {
+      expect(onEvent).toHaveBeenCalledWith(
+        "notification:ci_failure",
+        expect.any(Function),
+      );
+    });
+
+    const call = (onEvent as Mock).mock.calls.find(
+      (c: unknown[]) => c[0] === "notification:ci_failure",
+    );
+    const handler = call![1] as (payload: unknown) => void;
+
+    act(() => {
+      handler({ prNumber: 10, repo: "mpiton/prism", check: "ci/build" });
+    });
+
+    expect(result.current.notifications).toHaveLength(1);
+    expect(result.current.notifications[0]).toMatchObject({
+      type: "ci_failure",
+      payload: { prNumber: 10, repo: "mpiton/prism", check: "ci/build" },
+    });
+  });
+
+  it("should clear notification", async () => {
+    const { result } = renderHook(() => useNotifications());
+
+    await vi.waitFor(() => {
+      expect(onEvent).toHaveBeenCalledTimes(3);
+    });
+
+    // Add two notifications
+    const reviewHandler = (onEvent as Mock).mock.calls.find(
+      (c: unknown[]) => c[0] === "notification:review_request",
+    )![1] as (payload: unknown) => void;
+
+    const approvedHandler = (onEvent as Mock).mock.calls.find(
+      (c: unknown[]) => c[0] === "notification:pr_approved",
+    )![1] as (payload: unknown) => void;
+
+    act(() => {
+      reviewHandler({ prNumber: 1 });
+      approvedHandler({ prNumber: 2 });
+    });
+
+    expect(result.current.notifications).toHaveLength(2);
+
+    // Clear the first notification
+    const firstNotif = result.current.notifications[0];
+    expect(firstNotif).toBeDefined();
+    const idToRemove = firstNotif!.id;
+    act(() => {
+      result.current.clearNotification(idToRemove);
+    });
+
+    expect(result.current.notifications).toHaveLength(1);
+    expect(result.current.notifications[0]?.id).not.toBe(idToRemove);
+  });
+
+  it("should call all unlisten functions on unmount", async () => {
+    const { unmount } = renderHook(() => useNotifications());
+
+    await vi.waitFor(() => {
+      expect(onEvent).toHaveBeenCalledTimes(3);
+    });
+
+    unmount();
+
+    expect(unlistenReviewRequest).toHaveBeenCalledOnce();
+    expect(unlistenCiFailure).toHaveBeenCalledOnce();
+    expect(unlistenPrApproved).toHaveBeenCalledOnce();
+  });
+
+  it("should capture pr_approved event", async () => {
+    const { result } = renderHook(() => useNotifications());
+
+    await vi.waitFor(() => {
+      expect(onEvent).toHaveBeenCalledWith(
+        "notification:pr_approved",
+        expect.any(Function),
+      );
+    });
+
+    const call = (onEvent as Mock).mock.calls.find(
+      (c: unknown[]) => c[0] === "notification:pr_approved",
+    );
+    const handler = call![1] as (payload: unknown) => void;
+
+    act(() => {
+      handler({ prNumber: 5, repo: "mpiton/prism" });
+    });
+
+    expect(result.current.notifications).toHaveLength(1);
+    expect(result.current.notifications[0]).toMatchObject({
+      type: "pr_approved",
+      payload: { prNumber: 5, repo: "mpiton/prism" },
+    });
+  });
+});

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -55,7 +55,11 @@ export function useNotifications() {
     return () => {
       cancelled = true;
       for (const fn of unlistenFns) {
-        fn();
+        try {
+          fn();
+        } catch (err) {
+          console.error("[useNotifications] unlisten failed:", err);
+        }
       }
     };
   }, []);

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -1,0 +1,73 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { onEvent } from "../lib/tauri";
+import { TAURI_EVENTS } from "../lib/types";
+
+type NotificationType = "review_request" | "ci_failure" | "pr_approved";
+
+export interface Notification {
+  id: string;
+  type: NotificationType;
+  payload: unknown;
+  timestamp: number;
+}
+
+let nextId = 0;
+
+function makeId(): string {
+  nextId += 1;
+  return `notif-${nextId}`;
+}
+
+const EVENT_TYPE_MAP: ReadonlyArray<{
+  event: (typeof TAURI_EVENTS)[keyof typeof TAURI_EVENTS];
+  type: NotificationType;
+}> = [
+  { event: TAURI_EVENTS["notification:review_request"], type: "review_request" },
+  { event: TAURI_EVENTS["notification:ci_failure"], type: "ci_failure" },
+  { event: TAURI_EVENTS["notification:pr_approved"], type: "pr_approved" },
+];
+
+export function useNotifications() {
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+  const cancelledRef = useRef(false);
+
+  useEffect(() => {
+    cancelledRef.current = false;
+    const unlistenFns: Array<() => void> = [];
+
+    for (const { event, type } of EVENT_TYPE_MAP) {
+      onEvent(event, (payload: unknown) => {
+        const notification: Notification = {
+          id: makeId(),
+          type,
+          payload,
+          timestamp: Date.now(),
+        };
+        setNotifications((prev) => [...prev, notification]);
+      })
+        .then((unlisten) => {
+          if (cancelledRef.current) {
+            unlisten();
+          } else {
+            unlistenFns.push(unlisten);
+          }
+        })
+        .catch((err: unknown) => {
+          console.error(`[useNotifications] failed to register ${event} listener:`, err);
+        });
+    }
+
+    return () => {
+      cancelledRef.current = true;
+      for (const fn of unlistenFns) {
+        fn();
+      }
+    };
+  }, []);
+
+  const clearNotification = useCallback((id: string) => {
+    setNotifications((prev) => prev.filter((n) => n.id !== id));
+  }, []);
+
+  return { notifications, clearNotification };
+}

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { onEvent } from "../lib/tauri";
 import { TAURI_EVENTS } from "../lib/types";
 
@@ -9,13 +9,6 @@ export interface Notification {
   type: NotificationType;
   payload: unknown;
   timestamp: number;
-}
-
-let nextId = 0;
-
-function makeId(): string {
-  nextId += 1;
-  return `notif-${nextId}`;
 }
 
 const EVENT_TYPE_MAP: ReadonlyArray<{
@@ -29,16 +22,18 @@ const EVENT_TYPE_MAP: ReadonlyArray<{
 
 export function useNotifications() {
   const [notifications, setNotifications] = useState<Notification[]>([]);
-  const cancelledRef = useRef(false);
 
   useEffect(() => {
-    cancelledRef.current = false;
+    let cancelled = false;
     const unlistenFns: Array<() => void> = [];
 
     for (const { event, type } of EVENT_TYPE_MAP) {
       onEvent(event, (payload: unknown) => {
+        if (cancelled) {
+          return;
+        }
         const notification: Notification = {
-          id: makeId(),
+          id: crypto.randomUUID(),
           type,
           payload,
           timestamp: Date.now(),
@@ -46,7 +41,7 @@ export function useNotifications() {
         setNotifications((prev) => [...prev, notification]);
       })
         .then((unlisten) => {
-          if (cancelledRef.current) {
+          if (cancelled) {
             unlisten();
           } else {
             unlistenFns.push(unlisten);
@@ -58,7 +53,7 @@ export function useNotifications() {
     }
 
     return () => {
-      cancelledRef.current = true;
+      cancelled = true;
       for (const fn of unlistenFns) {
         fn();
       }


### PR DESCRIPTION
## Summary
- Add `useNotifications` hook that listens to Tauri events: `notification:review_request`, `notification:ci_failure`, `notification:pr_approved`
- Each event is captured as a typed `Notification` object with id, type, payload, and timestamp
- Exposes `{ notifications, clearNotification }` for consumer components

## Test plan
- [x] `it("should capture review_request event")` — verifies event payload stored
- [x] `it("should capture ci_failure event")` — verifies CI failure events
- [x] `it("should capture pr_approved event")` — verifies approval events
- [x] `it("should clear notification")` — verifies removal by id
- [x] `it("should call all unlisten functions on unmount")` — verifies cleanup
- [x] `tsc --noEmit` passes
- [x] `oxlint` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `useNotifications`, a React hook that subscribes to Tauri notification events and provides a typed, real-time feed for the UI. Fulfills Linear T-047 by enabling review, CI, and approval alerts.

- **New Features**
  - Subscribes to `notification:review_request`, `notification:ci_failure`, `notification:pr_approved`.
  - Appends typed `Notification` entries with `id`, `type`, `payload`, and `timestamp`.
  - Exposes `{ notifications, clearNotification }` and unsubscribes all listeners on unmount.

- **Bug Fixes**
  - Prevents state updates after unmount and ensures late-resolving listeners are unregistered.
  - Adds defensive try/catch in cleanup and logs registration/unlisten errors for easier debugging.

<sup>Written for commit 2e7771c883a5318179dd8a3af644613da5cc934f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time notifications for review requests, CI failures, and PR approvals.
  * Dismiss individual notifications to manage your notification inbox.
* **Bug Fixes**
  * Improved listener cleanup to prevent duplicate or lingering notifications when leaving views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->