### PR TITLE
feat(ui): add useKeyboard hook (T-048)

### DIFF
--- a/src/hooks/useKeyboard.test.ts
+++ b/src/hooks/useKeyboard.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, type RenderHookResult } from "@testing-library/react";
+import { useKeyboard, type KeyboardActions } from "./useKeyboard";
+
+function fireKey(
+  key: string,
+  opts: Partial<KeyboardEventInit> = {},
+): void {
+  document.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, ...opts }));
+}
+
+function createActions(): KeyboardActions {
+  return {
+    onNavigate: vi.fn(),
+    onOpen: vi.fn(),
+    onOpenWorkspace: vi.fn(),
+    onSwitchWorkspace: vi.fn(),
+    onEscape: vi.fn(),
+    onCommandPalette: vi.fn(),
+  };
+}
+
+describe("useKeyboard", () => {
+  let actions: KeyboardActions;
+  let hook: RenderHookResult<void, KeyboardActions>;
+
+  beforeEach(() => {
+    actions = createActions();
+    hook = renderHook(() => useKeyboard(actions));
+  });
+
+  afterEach(() => {
+    hook.unmount();
+  });
+
+  it("should navigate down when j is pressed", () => {
+    fireKey("j");
+    expect(actions.onNavigate).toHaveBeenCalledWith("down");
+  });
+
+  it("should navigate up when k is pressed", () => {
+    fireKey("k");
+    expect(actions.onNavigate).toHaveBeenCalledWith("up");
+  });
+
+  it("should call onOpen when Enter is pressed", () => {
+    fireKey("Enter");
+    expect(actions.onOpen).toHaveBeenCalledOnce();
+  });
+
+  it("should call onOpenWorkspace when w is pressed", () => {
+    fireKey("w");
+    expect(actions.onOpenWorkspace).toHaveBeenCalledOnce();
+  });
+
+  it("should call onEscape when Escape is pressed", () => {
+    fireKey("Escape");
+    expect(actions.onEscape).toHaveBeenCalledOnce();
+  });
+
+  it("should open command palette when Cmd+K is pressed", () => {
+    fireKey("k", { metaKey: true });
+    expect(actions.onCommandPalette).toHaveBeenCalledOnce();
+    expect(actions.onNavigate).not.toHaveBeenCalled();
+  });
+
+  it("should open command palette when Ctrl+K is pressed", () => {
+    fireKey("k", { ctrlKey: true });
+    expect(actions.onCommandPalette).toHaveBeenCalledOnce();
+    expect(actions.onNavigate).not.toHaveBeenCalled();
+  });
+
+  it("should switch workspace when Ctrl+1/2/3 is pressed", () => {
+    fireKey("1", { ctrlKey: true });
+    fireKey("2", { ctrlKey: true });
+    fireKey("3", { ctrlKey: true });
+    expect(actions.onSwitchWorkspace).toHaveBeenCalledTimes(3);
+    expect(actions.onSwitchWorkspace).toHaveBeenNthCalledWith(1, 0);
+    expect(actions.onSwitchWorkspace).toHaveBeenNthCalledWith(2, 1);
+    expect(actions.onSwitchWorkspace).toHaveBeenNthCalledWith(3, 2);
+  });
+
+  it("should switch workspace when Cmd+1/2/3 is pressed", () => {
+    fireKey("1", { metaKey: true });
+    fireKey("2", { metaKey: true });
+    fireKey("3", { metaKey: true });
+    expect(actions.onSwitchWorkspace).toHaveBeenCalledTimes(3);
+    expect(actions.onSwitchWorkspace).toHaveBeenNthCalledWith(1, 0);
+    expect(actions.onSwitchWorkspace).toHaveBeenNthCalledWith(2, 1);
+    expect(actions.onSwitchWorkspace).toHaveBeenNthCalledWith(3, 2);
+  });
+
+  it("should not fire when typing in an input element", () => {
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "j", bubbles: true }));
+    expect(actions.onNavigate).not.toHaveBeenCalled();
+    document.body.removeChild(input);
+  });
+
+  it("should not fire when typing in a textarea", () => {
+    const textarea = document.createElement("textarea");
+    document.body.appendChild(textarea);
+    textarea.dispatchEvent(new KeyboardEvent("keydown", { key: "k", bubbles: true }));
+    expect(actions.onNavigate).not.toHaveBeenCalled();
+    document.body.removeChild(textarea);
+  });
+
+  it("should clean up listener on unmount", () => {
+    hook.unmount();
+    fireKey("j");
+    expect(actions.onNavigate).not.toHaveBeenCalled();
+    // Re-create hook so afterEach unmount doesn't error
+    hook = renderHook(() => useKeyboard(actions));
+  });
+
+  it("should ignore plain keys when modifier is held", () => {
+    fireKey("j", { ctrlKey: true });
+    fireKey("w", { metaKey: true });
+    expect(actions.onNavigate).not.toHaveBeenCalled();
+    expect(actions.onOpenWorkspace).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useKeyboard.test.ts
+++ b/src/hooks/useKeyboard.test.ts
@@ -144,6 +144,17 @@ describe("useKeyboard", () => {
     hook = renderHook(() => useKeyboard(actions));
   });
 
+  it("should handle shortcuts when Caps Lock is active", () => {
+    fireKey("J");
+    expect(actions.onNavigate).toHaveBeenCalledWith("down");
+    fireKey("K");
+    expect(actions.onNavigate).toHaveBeenCalledWith("up");
+    fireKey("W");
+    expect(actions.onOpenWorkspace).toHaveBeenCalledOnce();
+    fireKey("K", { metaKey: true });
+    expect(actions.onCommandPalette).toHaveBeenCalledOnce();
+  });
+
   it("should ignore plain keys when modifier is held", () => {
     fireKey("j", { ctrlKey: true });
     fireKey("w", { metaKey: true });

--- a/src/hooks/useKeyboard.test.ts
+++ b/src/hooks/useKeyboard.test.ts
@@ -106,6 +106,23 @@ describe("useKeyboard", () => {
     document.body.removeChild(textarea);
   });
 
+  it("should not fire when typing in a select element", () => {
+    const select = document.createElement("select");
+    document.body.appendChild(select);
+    select.dispatchEvent(new KeyboardEvent("keydown", { key: "j", bubbles: true }));
+    expect(actions.onNavigate).not.toHaveBeenCalled();
+    document.body.removeChild(select);
+  });
+
+  it("should not fire when typing in a contenteditable element", () => {
+    const div = document.createElement("div");
+    div.contentEditable = "true";
+    document.body.appendChild(div);
+    div.dispatchEvent(new KeyboardEvent("keydown", { key: "j", bubbles: true }));
+    expect(actions.onNavigate).not.toHaveBeenCalled();
+    document.body.removeChild(div);
+  });
+
   it("should clean up listener on unmount", () => {
     hook.unmount();
     fireKey("j");
@@ -117,7 +134,12 @@ describe("useKeyboard", () => {
   it("should ignore plain keys when modifier is held", () => {
     fireKey("j", { ctrlKey: true });
     fireKey("w", { metaKey: true });
+    fireKey("j", { altKey: true });
+    fireKey("Enter", { altKey: true });
+    fireKey("Escape", { altKey: true });
     expect(actions.onNavigate).not.toHaveBeenCalled();
     expect(actions.onOpenWorkspace).not.toHaveBeenCalled();
+    expect(actions.onOpen).not.toHaveBeenCalled();
+    expect(actions.onEscape).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/useKeyboard.test.ts
+++ b/src/hooks/useKeyboard.test.ts
@@ -70,6 +70,19 @@ describe("useKeyboard", () => {
     expect(actions.onNavigate).not.toHaveBeenCalled();
   });
 
+  it("should not trigger command palette when Alt+K is pressed", () => {
+    fireKey("k", { altKey: true });
+    expect(actions.onCommandPalette).not.toHaveBeenCalled();
+    expect(actions.onNavigate).not.toHaveBeenCalled();
+  });
+
+  it("should not switch workspace when Alt+1/2/3 is pressed", () => {
+    fireKey("1", { altKey: true });
+    fireKey("2", { altKey: true });
+    fireKey("3", { altKey: true });
+    expect(actions.onSwitchWorkspace).not.toHaveBeenCalled();
+  });
+
   it("should switch workspace when Ctrl+1/2/3 is pressed", () => {
     fireKey("1", { ctrlKey: true });
     fireKey("2", { ctrlKey: true });

--- a/src/hooks/useKeyboard.ts
+++ b/src/hooks/useKeyboard.ts
@@ -27,21 +27,22 @@ export function useKeyboard(actions: KeyboardActions): void {
     function handleKeyDown(event: KeyboardEvent): void {
       if (isInputTarget(event)) return;
 
-      const hasModifier = event.metaKey || event.ctrlKey || event.altKey;
+      const actionModifier = event.metaKey || event.ctrlKey;
+      const anyModifier = actionModifier || event.altKey;
 
-      if (hasModifier && event.key === "k") {
+      if (actionModifier && event.key === "k") {
         event.preventDefault();
         actionsRef.current.onCommandPalette();
         return;
       }
 
-      if (hasModifier && event.key >= "1" && event.key <= "3") {
+      if (actionModifier && event.key >= "1" && event.key <= "3") {
         event.preventDefault();
         actionsRef.current.onSwitchWorkspace(Number(event.key) - 1);
         return;
       }
 
-      if (hasModifier) return;
+      if (anyModifier) return;
 
       switch (event.key) {
         case "j":
@@ -51,7 +52,6 @@ export function useKeyboard(actions: KeyboardActions): void {
           actionsRef.current.onNavigate("up");
           break;
         case "Enter":
-          event.preventDefault();
           actionsRef.current.onOpen();
           break;
         case "w":

--- a/src/hooks/useKeyboard.ts
+++ b/src/hooks/useKeyboard.ts
@@ -15,20 +15,19 @@ function isInputTarget(event: KeyboardEvent): boolean {
   const target = event.target;
   if (!(target instanceof Element)) return false;
   if (INPUT_TAGS.has(target.tagName)) return true;
-  return target instanceof HTMLElement && target.isContentEditable;
+  return target instanceof HTMLElement &&
+    (target.isContentEditable || target.contentEditable === "true");
 }
 
 export function useKeyboard(actions: KeyboardActions): void {
   const actionsRef = useRef(actions);
-  useEffect(() => {
-    actionsRef.current = actions;
-  });
+  actionsRef.current = actions;
 
   useEffect(() => {
     function handleKeyDown(event: KeyboardEvent): void {
       if (isInputTarget(event)) return;
 
-      const hasModifier = event.metaKey || event.ctrlKey;
+      const hasModifier = event.metaKey || event.ctrlKey || event.altKey;
 
       if (hasModifier && event.key === "k") {
         event.preventDefault();
@@ -52,6 +51,7 @@ export function useKeyboard(actions: KeyboardActions): void {
           actionsRef.current.onNavigate("up");
           break;
         case "Enter":
+          event.preventDefault();
           actionsRef.current.onOpen();
           break;
         case "w":

--- a/src/hooks/useKeyboard.ts
+++ b/src/hooks/useKeyboard.ts
@@ -27,24 +27,25 @@ export function useKeyboard(actions: KeyboardActions): void {
     function handleKeyDown(event: KeyboardEvent): void {
       if (isInputTarget(event)) return;
 
+      const key = event.key.length === 1 ? event.key.toLowerCase() : event.key;
       const actionModifier = event.metaKey || event.ctrlKey;
       const anyModifier = actionModifier || event.altKey;
 
-      if (actionModifier && event.key === "k") {
+      if (actionModifier && key === "k") {
         event.preventDefault();
         actionsRef.current.onCommandPalette();
         return;
       }
 
-      if (actionModifier && event.key >= "1" && event.key <= "3") {
+      if (actionModifier && key >= "1" && key <= "3") {
         event.preventDefault();
-        actionsRef.current.onSwitchWorkspace(Number(event.key) - 1);
+        actionsRef.current.onSwitchWorkspace(Number(key) - 1);
         return;
       }
 
       if (anyModifier) return;
 
-      switch (event.key) {
+      switch (key) {
         case "j":
           actionsRef.current.onNavigate("down");
           break;

--- a/src/hooks/useKeyboard.ts
+++ b/src/hooks/useKeyboard.ts
@@ -1,0 +1,70 @@
+import { useEffect, useRef } from "react";
+
+export interface KeyboardActions {
+  readonly onNavigate: (direction: "up" | "down") => void;
+  readonly onOpen: () => void;
+  readonly onOpenWorkspace: () => void;
+  readonly onSwitchWorkspace: (index: number) => void;
+  readonly onEscape: () => void;
+  readonly onCommandPalette: () => void;
+}
+
+const INPUT_TAGS = new Set(["INPUT", "TEXTAREA", "SELECT"]);
+
+function isInputTarget(event: KeyboardEvent): boolean {
+  const target = event.target;
+  if (!(target instanceof Element)) return false;
+  if (INPUT_TAGS.has(target.tagName)) return true;
+  return target instanceof HTMLElement && target.isContentEditable;
+}
+
+export function useKeyboard(actions: KeyboardActions): void {
+  const actionsRef = useRef(actions);
+  useEffect(() => {
+    actionsRef.current = actions;
+  });
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent): void {
+      if (isInputTarget(event)) return;
+
+      const hasModifier = event.metaKey || event.ctrlKey;
+
+      if (hasModifier && event.key === "k") {
+        event.preventDefault();
+        actionsRef.current.onCommandPalette();
+        return;
+      }
+
+      if (hasModifier && event.key >= "1" && event.key <= "3") {
+        event.preventDefault();
+        actionsRef.current.onSwitchWorkspace(Number(event.key) - 1);
+        return;
+      }
+
+      if (hasModifier) return;
+
+      switch (event.key) {
+        case "j":
+          actionsRef.current.onNavigate("down");
+          break;
+        case "k":
+          actionsRef.current.onNavigate("up");
+          break;
+        case "Enter":
+          actionsRef.current.onOpen();
+          break;
+        case "w":
+          actionsRef.current.onOpenWorkspace();
+          break;
+        case "Escape":
+          event.preventDefault();
+          actionsRef.current.onEscape();
+          break;
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, []);
+}


### PR DESCRIPTION
## Summary
- Add `useKeyboard` hook that registers global keyboard shortcuts via `document` keydown listener
- Shortcuts: `j/k` (navigate), `Enter` (open), `w` (workspace), `Ctrl/Cmd+1-3` (switch workspace), `Escape` (dashboard), `Cmd/Ctrl+K` (command palette)
- Uses `useRef` for ref-stable callbacks (no stale closure on re-render)
- Skips events from input, textarea, select, and contenteditable elements
- Cross-platform: both `Ctrl` and `Cmd` modifiers supported

## Test plan
- [x] 13 unit tests covering all shortcuts, input suppression, modifier guards, and cleanup
- [x] TypeScript strict mode — 0 errors
- [x] oxlint — 0 warnings
- [x] Full suite: 127 tests passing, 0 regressions
- [x] Coverage: 97% statements, 100% functions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `useKeyboard` hook with global shortcuts for navigation, workspace switching, and the command palette. Implements Linear T-048 with cross‑platform Ctrl/Cmd shortcuts, Alt suppression, Caps Lock resilience, and safe behavior in editable fields.

- **New Features**
  - Global `document` keydown: `j/k` navigate, `Enter` open, `w` open workspace, `Escape` back, `Cmd/Ctrl+K` command palette, `Cmd/Ctrl+1-3` switch workspaces.
  - Skips `input`/`textarea`/`select`/`contenteditable`. Only Ctrl/Cmd trigger palette and workspace switching (Alt+K and Alt+1–3 do nothing). No `preventDefault` on `Enter`; `Escape` still prevents default. Normalizes single‑char keys to lowercase for Caps Lock. Ref‑stable callbacks via synchronous ref; cleans up on unmount.

<sup>Written for commit 73952f0046bec326bee803516cbb9dddc1f0ec14. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcuts: j/k for list navigation, Enter to open, w to open workspace, Escape to cancel, Cmd/Ctrl+K for command palette, and Cmd/Ctrl+1–3 to switch workspaces. Shortcuts are ignored while typing in inputs, textareas, selects, or editable content.

* **Tests**
  * Added unit tests covering all shortcuts, modifier handling, Caps Lock case-insensitivity, workspace-switch ordering, suppression while typing, and listener cleanup on unmount.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->