### PR TITLE
feat(ui): add MyPrCard component (T-053)

### DIFF
--- a/src/components/MyPRs/MyPrCard.test.tsx
+++ b/src/components/MyPRs/MyPrCard.test.tsx
@@ -181,11 +181,21 @@ describe("MyPrCard", () => {
     expect(handleWs).toHaveBeenCalledWith("ws-1");
   });
 
+  it("should not show MERGEABLE when PR is closed", () => {
+    const data: PullRequestWithReview = {
+      ...basePr,
+      pullRequest: { ...basePr.pullRequest, state: "closed" },
+    };
+    render(<MyPrCard data={data} onOpen={vi.fn()} />);
+    expect(screen.queryByText("MERGEABLE")).not.toBeInTheDocument();
+  });
+
   it("should show time ago", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-26T14:00:00Z"));
     render(<MyPrCard data={basePr} onOpen={vi.fn()} />);
-    // updatedAt is in the past, so should display a time string
     const timeElement = screen.getByTestId("time-ago");
-    expect(timeElement).toBeInTheDocument();
-    expect(timeElement.textContent).not.toBe("");
+    expect(timeElement).toHaveTextContent("2h");
+    vi.useRealTimers();
   });
 });

--- a/src/components/MyPRs/MyPrCard.test.tsx
+++ b/src/components/MyPRs/MyPrCard.test.tsx
@@ -1,0 +1,191 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { PullRequestWithReview } from "../../lib/types";
+import { MyPrCard } from "./MyPrCard";
+
+const basePr: PullRequestWithReview = {
+  pullRequest: {
+    id: "pr-1",
+    number: 99,
+    title: "Add dashboard feature",
+    author: "me",
+    state: "open",
+    ciStatus: "success",
+    priority: "medium",
+    repoId: "repo-1",
+    url: "https://github.com/org/repo/pull/99",
+    labels: [],
+    additions: 42,
+    deletions: 7,
+    createdAt: "2026-03-26T10:00:00Z",
+    updatedAt: "2026-03-26T12:00:00Z",
+  },
+  reviewSummary: {
+    totalReviews: 3,
+    approved: 2,
+    changesRequested: 0,
+    pending: 1,
+    reviewers: ["alice", "bob", "carol"],
+  },
+  workspace: {
+    id: "ws-1",
+    state: "active",
+    lastNoteContent: null,
+  },
+};
+
+describe("MyPrCard", () => {
+  it("should render PR title and number", () => {
+    render(<MyPrCard data={basePr} onOpen={vi.fn()} />);
+    expect(screen.getByText("Add dashboard feature")).toBeInTheDocument();
+    expect(screen.getByText("#99")).toBeInTheDocument();
+  });
+
+  it("should show CI dot", () => {
+    render(<MyPrCard data={basePr} onOpen={vi.fn()} />);
+    const ciDot = screen.getByTestId("ci-dot");
+    expect(ciDot).toBeInTheDocument();
+  });
+
+  it("should show diff stats", () => {
+    render(<MyPrCard data={basePr} onOpen={vi.fn()} />);
+    expect(screen.getByText("+42")).toBeInTheDocument();
+    expect(screen.getByText("-7")).toBeInTheDocument();
+  });
+
+  it("should show CI badge", () => {
+    render(<MyPrCard data={basePr} onOpen={vi.fn()} />);
+    expect(screen.getByText("PASS")).toBeInTheDocument();
+  });
+
+  it("should show review dots", () => {
+    render(<MyPrCard data={basePr} onOpen={vi.fn()} />);
+    const dots = screen.getAllByTestId("review-dot");
+    expect(dots).toHaveLength(3);
+  });
+
+  it("should color review dots correctly (green=approved, red=changes, grey=pending)", () => {
+    const data: PullRequestWithReview = {
+      ...basePr,
+      reviewSummary: {
+        totalReviews: 3,
+        approved: 1,
+        changesRequested: 1,
+        pending: 1,
+        reviewers: ["alice", "bob", "carol"],
+      },
+    };
+    render(<MyPrCard data={data} onOpen={vi.fn()} />);
+    const dots = screen.getAllByTestId("review-dot");
+    expect(dots[0]).toHaveClass("bg-green");
+    expect(dots[1]).toHaveClass("bg-red");
+    expect(dots[2]).toHaveClass("bg-dim");
+  });
+
+  it("should show MERGEABLE when ci=pass && approved>0 && changes=0", () => {
+    render(<MyPrCard data={basePr} onOpen={vi.fn()} />);
+    expect(screen.getByText("MERGEABLE")).toBeInTheDocument();
+  });
+
+  it("should not show MERGEABLE when CI fails", () => {
+    const data: PullRequestWithReview = {
+      ...basePr,
+      pullRequest: { ...basePr.pullRequest, ciStatus: "failure" },
+    };
+    render(<MyPrCard data={data} onOpen={vi.fn()} />);
+    expect(screen.queryByText("MERGEABLE")).not.toBeInTheDocument();
+  });
+
+  it("should not show MERGEABLE when changes requested", () => {
+    const data: PullRequestWithReview = {
+      ...basePr,
+      reviewSummary: {
+        ...basePr.reviewSummary,
+        changesRequested: 1,
+      },
+    };
+    render(<MyPrCard data={data} onOpen={vi.fn()} />);
+    expect(screen.queryByText("MERGEABLE")).not.toBeInTheDocument();
+  });
+
+  it("should not show MERGEABLE when no approvals", () => {
+    const data: PullRequestWithReview = {
+      ...basePr,
+      reviewSummary: {
+        ...basePr.reviewSummary,
+        approved: 0,
+      },
+    };
+    render(<MyPrCard data={data} onOpen={vi.fn()} />);
+    expect(screen.queryByText("MERGEABLE")).not.toBeInTheDocument();
+  });
+
+  it("should dim merged PRs", () => {
+    const data: PullRequestWithReview = {
+      ...basePr,
+      pullRequest: { ...basePr.pullRequest, state: "merged" },
+    };
+    render(<MyPrCard data={data} onOpen={vi.fn()} />);
+    const row = screen.getByTestId("my-pr-card");
+    expect(row).toHaveClass("opacity-50");
+  });
+
+  it("should show line-through on merged PR title", () => {
+    const data: PullRequestWithReview = {
+      ...basePr,
+      pullRequest: { ...basePr.pullRequest, state: "merged" },
+    };
+    render(<MyPrCard data={data} onOpen={vi.fn()} />);
+    const title = screen.getByText("Add dashboard feature");
+    expect(title).toHaveClass("line-through");
+  });
+
+  it("should not dim open PRs", () => {
+    render(<MyPrCard data={basePr} onOpen={vi.fn()} />);
+    const row = screen.getByTestId("my-pr-card");
+    expect(row).not.toHaveClass("opacity-50");
+  });
+
+  it("should show workspace badge", () => {
+    render(<MyPrCard data={basePr} onOpen={vi.fn()} />);
+    expect(screen.getByText("resume")).toBeInTheDocument();
+  });
+
+  it("should not show workspace badge when no workspace", () => {
+    const data: PullRequestWithReview = {
+      ...basePr,
+      workspace: null,
+    };
+    render(<MyPrCard data={data} onOpen={vi.fn()} />);
+    expect(screen.queryByText("resume")).not.toBeInTheDocument();
+    expect(screen.queryByText("wake")).not.toBeInTheDocument();
+    expect(screen.queryByText("open")).not.toBeInTheDocument();
+  });
+
+  it("should call onOpen on click", async () => {
+    const handleOpen = vi.fn();
+    render(<MyPrCard data={basePr} onOpen={handleOpen} />);
+    await userEvent.click(screen.getByRole("link"));
+    expect(handleOpen).toHaveBeenCalledWith(
+      "https://github.com/org/repo/pull/99",
+    );
+  });
+
+  it("should call onWorkspaceAction when badge clicked", async () => {
+    const handleWs = vi.fn();
+    render(
+      <MyPrCard data={basePr} onOpen={vi.fn()} onWorkspaceAction={handleWs} />,
+    );
+    await userEvent.click(screen.getByRole("button"));
+    expect(handleWs).toHaveBeenCalledWith("ws-1");
+  });
+
+  it("should show time ago", () => {
+    render(<MyPrCard data={basePr} onOpen={vi.fn()} />);
+    // updatedAt is in the past, so should display a time string
+    const timeElement = screen.getByTestId("time-ago");
+    expect(timeElement).toBeInTheDocument();
+    expect(timeElement.textContent).not.toBe("");
+  });
+});

--- a/src/components/MyPRs/MyPrCard.tsx
+++ b/src/components/MyPRs/MyPrCard.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from "react";
+import { timeAgo } from "../../lib/timeAgo";
 import type { CiStatus, PullRequestWithReview } from "../../lib/types";
 import { CI } from "../atoms/CI";
 import { Diff } from "../atoms/Diff";
@@ -10,23 +11,10 @@ interface MyPrCardProps {
   readonly onWorkspaceAction?: (workspaceId: string) => void;
 }
 
-function timeAgo(dateStr: string): string {
-  const date = new Date(dateStr);
-  if (Number.isNaN(date.getTime())) return "";
-  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
-  if (seconds < 0) return "now";
-  if (seconds < 60) return `${seconds}s`;
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h`;
-  const days = Math.floor(hours / 24);
-  return `${days}d`;
-}
-
 function isMergeable(data: PullRequestWithReview): boolean {
   const { pullRequest: pr, reviewSummary } = data;
   return (
+    pr.state === "open" &&
     pr.ciStatus === "success" &&
     reviewSummary.approved > 0 &&
     reviewSummary.changesRequested === 0
@@ -107,7 +95,7 @@ export function MyPrCard({
           ))}
         </span>
 
-        {isMergeable(data) && !merged && (
+        {isMergeable(data) && (
           <span className="shrink-0 rounded bg-green/20 px-1.5 py-0.5 text-xs font-semibold text-green">
             MERGEABLE
           </span>

--- a/src/components/MyPRs/MyPrCard.tsx
+++ b/src/components/MyPRs/MyPrCard.tsx
@@ -1,0 +1,134 @@
+import type { ReactElement } from "react";
+import type { CiStatus, PullRequestWithReview } from "../../lib/types";
+import { CI } from "../atoms/CI";
+import { Diff } from "../atoms/Diff";
+import { WsBadge } from "../atoms/WsBadge";
+
+interface MyPrCardProps {
+  readonly data: PullRequestWithReview;
+  readonly onOpen: (url: string) => void;
+  readonly onWorkspaceAction?: (workspaceId: string) => void;
+}
+
+function timeAgo(dateStr: string): string {
+  const date = new Date(dateStr);
+  if (Number.isNaN(date.getTime())) return "";
+  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
+  if (seconds < 0) return "now";
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  return `${days}d`;
+}
+
+function isMergeable(data: PullRequestWithReview): boolean {
+  const { pullRequest: pr, reviewSummary } = data;
+  return (
+    pr.ciStatus === "success" &&
+    reviewSummary.approved > 0 &&
+    reviewSummary.changesRequested === 0
+  );
+}
+
+const CI_DOT_COLOR: Record<CiStatus, string> = {
+  success: "bg-green",
+  failure: "bg-red",
+  running: "bg-orange",
+  pending: "bg-dim",
+  cancelled: "bg-dim",
+};
+
+interface ReviewDot {
+  readonly key: string;
+  readonly color: string;
+}
+
+function buildReviewDots(reviewSummary: PullRequestWithReview["reviewSummary"]): readonly ReviewDot[] {
+  const dots: ReviewDot[] = [];
+  for (let i = 0; i < reviewSummary.approved; i++) dots.push({ key: `approved-${i}`, color: "bg-green" });
+  for (let i = 0; i < reviewSummary.changesRequested; i++) dots.push({ key: `changes-${i}`, color: "bg-red" });
+  for (let i = 0; i < reviewSummary.pending; i++) dots.push({ key: `pending-${i}`, color: "bg-dim" });
+  return dots;
+}
+
+export function MyPrCard({
+  data,
+  onOpen,
+  onWorkspaceAction,
+}: MyPrCardProps): ReactElement {
+  const { pullRequest: pr, workspace } = data;
+  const merged = pr.state === "merged";
+  const reviewDots = buildReviewDots(data.reviewSummary);
+
+  function handleClick(e: React.MouseEvent) {
+    e.preventDefault();
+    onOpen(pr.url);
+  }
+
+  return (
+    <div
+      data-testid="my-pr-card"
+      className={`flex items-center gap-3 rounded border border-border px-3 py-2 hover:bg-surface-hover${merged ? " opacity-50" : ""}`}
+    >
+      <a
+        href={pr.url}
+        onClick={handleClick}
+        className="flex min-w-0 flex-1 cursor-pointer items-center gap-3 no-underline"
+      >
+        <span
+          data-testid="ci-dot"
+          className={`h-2.5 w-2.5 shrink-0 rounded-full ${CI_DOT_COLOR[pr.ciStatus]}`}
+        />
+
+        <span
+          className={`min-w-0 truncate text-sm font-medium text-foreground${merged ? " line-through" : ""}`}
+        >
+          {pr.title}
+        </span>
+
+        <span className="shrink-0 text-xs text-dim">#{pr.number}</span>
+
+        {pr.additions !== undefined && pr.deletions !== undefined && (
+          <Diff additions={pr.additions} deletions={pr.deletions} />
+        )}
+
+        <CI status={pr.ciStatus} />
+
+        <span className="flex items-center gap-0.5">
+          {reviewDots.map((dot) => (
+            <span
+              key={dot.key}
+              data-testid="review-dot"
+              className={`h-2 w-2 rounded-full ${dot.color}`}
+            />
+          ))}
+        </span>
+
+        {isMergeable(data) && !merged && (
+          <span className="shrink-0 rounded bg-green/20 px-1.5 py-0.5 text-xs font-semibold text-green">
+            MERGEABLE
+          </span>
+        )}
+
+        <span data-testid="time-ago" className="shrink-0 text-xs text-dim">
+          {timeAgo(pr.updatedAt)}
+        </span>
+      </a>
+
+      {workspace && (
+        <WsBadge
+          state={workspace.state}
+          onClick={
+            onWorkspaceAction
+              ? () => onWorkspaceAction(workspace.id)
+              : undefined
+          }
+          ariaLabel={`${workspace.state === "active" ? "Resume" : workspace.state === "suspended" ? "Wake" : "Open"} workspace for PR #${pr.number}`}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/ReviewQueue/ReviewCard.tsx
+++ b/src/components/ReviewQueue/ReviewCard.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from "react";
+import { timeAgo } from "../../lib/timeAgo";
 import type { PullRequestWithReview } from "../../lib/types";
 import { CI } from "../atoms/CI";
 import { Diff } from "../atoms/Diff";
@@ -9,20 +10,6 @@ interface ReviewCardProps {
   readonly data: PullRequestWithReview;
   readonly onOpen: (url: string) => void;
   readonly onWorkspaceAction?: (workspaceId: string) => void;
-}
-
-function timeAgo(dateStr: string): string {
-  const date = new Date(dateStr);
-  if (Number.isNaN(date.getTime())) return "";
-  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
-  if (seconds < 0) return "now";
-  if (seconds < 60) return `${seconds}s`;
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h`;
-  const days = Math.floor(hours / 24);
-  return `${days}d`;
 }
 
 export function ReviewCard({

--- a/src/lib/timeAgo.ts
+++ b/src/lib/timeAgo.ts
@@ -11,7 +11,7 @@ export function timeAgo(dateStr: string): string {
   const days = Math.floor(hours / 24);
   if (days < 7) return `${days}d`;
   const weeks = Math.floor(days / 7);
-  if (weeks < 52) return `${weeks}w`;
   const years = Math.floor(days / 365);
+  if (years < 1) return `${weeks}w`;
   return `${years}y`;
 }

--- a/src/lib/timeAgo.ts
+++ b/src/lib/timeAgo.ts
@@ -1,0 +1,17 @@
+export function timeAgo(dateStr: string): string {
+  const date = new Date(dateStr);
+  if (Number.isNaN(date.getTime())) return "";
+  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
+  if (seconds < 0) return "now";
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d`;
+  const weeks = Math.floor(days / 7);
+  if (weeks < 52) return `${weeks}w`;
+  const years = Math.floor(days / 365);
+  return `${years}y`;
+}


### PR DESCRIPTION
## Summary

• Add `MyPrCard` component — compact row for user's own PRs
• CI dot (color-coded), title (line-through if merged), PR number, diff stats, CI badge, review dots (green/red/grey), WsBadge, time ago
• MERGEABLE indicator when ci=pass && approved>0 && changes=0
• Merged PRs rendered with reduced opacity
• 18 tests covering all variants and interactions

## Type

feat

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `MyPrCard`: a compact row for your PRs with clear CI, review, diff, and workspace signals. Aligns with Linear T-053 and adds a shared `timeAgo` utility used by `ReviewCard`.

- **New Features**
  - CI dot + badge; title + PR number; diff via `Diff`.
  - Review dots: green (approved), red (changes), grey (pending).
  - "MERGEABLE" only when PR is open, CI=success, approved>0, and changes=0.
  - Time-ago from `updatedAt`.
  - Optional `WsBadge` with `onWorkspaceAction`.
  - 18 tests, including deterministic time-ago.

- **Bug Fixes**
  - Fixed off-by-one at week/year boundary in `timeAgo`.

<sup>Written for commit 0486a6fa54d90a8ea00d9bc9367b9ee5117eb9af. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PR card UI showing title/number, CI status, diff stats, review indicators, mergeability badge, workspace badge, and “time ago”; supports opening PRs and workspace actions.

* **Tests**
  * Added tests for rendering, review-dot states, mergeable rules, workspace behaviors, interactions, and time-ago output.

* **Refactor**
  * Introduced a shared time-ago utility and switched components to use it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->