### PR TITLE
feat(ui): add MyPRs page with tabs (T-054)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ function MainContent({ view }: MainContentProps): ReactElement {
     case "reviews":
       return <ReviewQueue reviews={[]} onOpen={() => {}} />;
     case "mine":
-      return <MyPRs />;
+      return <MyPRs prs={[]} onOpen={() => {}} />;
     case "issues":
       return <Issues />;
     case "feed":

--- a/src/components/MyPRs/MyPRs.test.tsx
+++ b/src/components/MyPRs/MyPRs.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { PullRequestWithReview } from "../../lib/types";
+import { MyPRs } from "./index";
+
+function makePr(
+  overrides: Partial<PullRequestWithReview["pullRequest"]> = {},
+): PullRequestWithReview {
+  return {
+    pullRequest: {
+      id: `pr-${overrides.number ?? 1}`,
+      number: 1,
+      title: "Some PR",
+      author: "me",
+      state: "open",
+      ciStatus: "success",
+      priority: "medium",
+      repoId: "repo-1",
+      url: "https://github.com/org/repo/pull/1",
+      labels: [],
+      additions: 10,
+      deletions: 2,
+      createdAt: "2026-03-26T10:00:00Z",
+      updatedAt: "2026-03-26T12:00:00Z",
+      ...overrides,
+    },
+    reviewSummary: {
+      totalReviews: 1,
+      approved: 1,
+      changesRequested: 0,
+      pending: 0,
+      reviewers: ["alice"],
+    },
+  };
+}
+
+const openPr1 = makePr({ number: 1, title: "Open PR one", state: "open" });
+const openPr2 = makePr({ number: 2, title: "Open PR two", state: "open" });
+const draftPr = makePr({ number: 3, title: "Draft PR", state: "draft" });
+const mergedPr1 = makePr({ number: 4, title: "Merged PR one", state: "merged" });
+const mergedPr2 = makePr({ number: 5, title: "Merged PR two", state: "merged" });
+
+const allPrs = [openPr1, openPr2, draftPr, mergedPr1, mergedPr2];
+
+const onOpen = vi.fn();
+
+describe("MyPRs", () => {
+  it("should show open PRs by default", () => {
+    render(<MyPRs prs={allPrs} onOpen={onOpen} />);
+
+    expect(screen.getByText("Open PR one")).toBeInTheDocument();
+    expect(screen.getByText("Open PR two")).toBeInTheDocument();
+    expect(screen.getByText("Draft PR")).toBeInTheDocument();
+    expect(screen.queryByText("Merged PR one")).not.toBeInTheDocument();
+    expect(screen.queryByText("Merged PR two")).not.toBeInTheDocument();
+  });
+
+  it("should switch to merged tab", async () => {
+    const user = userEvent.setup();
+    render(<MyPRs prs={allPrs} onOpen={onOpen} />);
+
+    await user.click(screen.getByRole("button", { name: /merged/i }));
+
+    expect(screen.getByText("Merged PR one")).toBeInTheDocument();
+    expect(screen.getByText("Merged PR two")).toBeInTheDocument();
+    expect(screen.queryByText("Open PR one")).not.toBeInTheDocument();
+    expect(screen.queryByText("Draft PR")).not.toBeInTheDocument();
+  });
+
+  it("should show correct counts", () => {
+    render(<MyPRs prs={allPrs} onOpen={onOpen} />);
+
+    const openTab = screen.getByRole("button", { name: /open/i });
+    const mergedTab = screen.getByRole("button", { name: /merged/i });
+
+    expect(openTab).toHaveTextContent("3");
+    expect(mergedTab).toHaveTextContent("2");
+  });
+
+  it("should show empty state when no PRs match current tab", () => {
+    render(<MyPRs prs={[mergedPr1]} onOpen={onOpen} />);
+
+    expect(screen.getByText(/no pull requests/i)).toBeInTheDocument();
+  });
+
+  it("should render SectionHead with title and total count", () => {
+    render(<MyPRs prs={allPrs} onOpen={onOpen} />);
+
+    expect(screen.getByText("My PRs")).toBeInTheDocument();
+    expect(screen.getByText("5")).toBeInTheDocument();
+  });
+
+  it("should pass onOpen to MyPrCard", async () => {
+    const user = userEvent.setup();
+    render(<MyPRs prs={[openPr1]} onOpen={onOpen} />);
+
+    await user.click(screen.getByText("Open PR one"));
+
+    expect(onOpen).toHaveBeenCalledWith(openPr1.pullRequest.url);
+  });
+});

--- a/src/components/MyPRs/MyPRs.test.tsx
+++ b/src/components/MyPRs/MyPRs.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { PullRequestWithReview } from "../../lib/types";
 import { MyPRs } from "./index";
 
@@ -32,6 +32,7 @@ function makePr(
       pending: 0,
       reviewers: ["alice"],
     },
+    workspace: null,
   };
 }
 
@@ -44,6 +45,10 @@ const mergedPr2 = makePr({ number: 5, title: "Merged PR two", state: "merged" })
 const allPrs = [openPr1, openPr2, draftPr, mergedPr1, mergedPr2];
 
 const onOpen = vi.fn();
+
+beforeEach(() => {
+  onOpen.mockClear();
+});
 
 describe("MyPRs", () => {
   it("should show open PRs by default", () => {
@@ -89,6 +94,15 @@ describe("MyPRs", () => {
 
     expect(screen.getByText("My PRs")).toBeInTheDocument();
     expect(screen.getByText("5")).toBeInTheDocument();
+  });
+
+  it("should exclude closed PRs from total count", () => {
+    const closedPr = makePr({ number: 6, title: "Closed PR", state: "closed" });
+    render(<MyPRs prs={[openPr1, closedPr, mergedPr1]} onOpen={onOpen} />);
+
+    expect(screen.getByText("My PRs")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.queryByText("Closed PR")).not.toBeInTheDocument();
   });
 
   it("should pass onOpen to MyPrCard", async () => {

--- a/src/components/MyPRs/MyPRs.tsx
+++ b/src/components/MyPRs/MyPRs.tsx
@@ -1,0 +1,82 @@
+import { type ReactElement, useState } from "react";
+import type { PullRequestWithReview } from "../../lib/types";
+import { EmptyState } from "../atoms/EmptyState";
+import { SectionHead } from "../atoms/SectionHead";
+import { MyPrCard } from "./MyPrCard";
+
+interface MyPRsProps {
+  readonly prs: readonly PullRequestWithReview[];
+  readonly onOpen: (url: string) => void;
+  readonly onWorkspaceAction?: (workspaceId: string) => void;
+}
+
+type Tab = "open" | "merged";
+
+function isOpen(pr: PullRequestWithReview): boolean {
+  const { state } = pr.pullRequest;
+  return state === "open" || state === "draft";
+}
+
+function isMerged(pr: PullRequestWithReview): boolean {
+  return pr.pullRequest.state === "merged";
+}
+
+export function MyPRs({
+  prs,
+  onOpen,
+  onWorkspaceAction,
+}: MyPRsProps): ReactElement {
+  const [tab, setTab] = useState<Tab>("open");
+
+  const openPrs = prs.filter(isOpen);
+  const mergedPrs = prs.filter(isMerged);
+  const visible = tab === "open" ? openPrs : mergedPrs;
+
+  return (
+    <section data-testid="my-prs" className="flex flex-col gap-2">
+      <SectionHead title="My PRs" count={prs.length} />
+
+      <div className="flex gap-1" role="group" aria-label="Filter by state">
+        <button
+          type="button"
+          aria-pressed={tab === "open"}
+          onClick={() => setTab("open")}
+          className={`rounded px-2 py-0.5 text-xs ${
+            tab === "open"
+              ? "bg-accent text-white"
+              : "text-dim hover:text-foreground"
+          }`}
+        >
+          Open {openPrs.length}
+        </button>
+        <button
+          type="button"
+          aria-pressed={tab === "merged"}
+          onClick={() => setTab("merged")}
+          className={`rounded px-2 py-0.5 text-xs ${
+            tab === "merged"
+              ? "bg-accent text-white"
+              : "text-dim hover:text-foreground"
+          }`}
+        >
+          Merged {mergedPrs.length}
+        </button>
+      </div>
+
+      {visible.length === 0 ? (
+        <EmptyState message="No pull requests to display" />
+      ) : (
+        <div className="flex flex-col gap-1">
+          {visible.map((pr) => (
+            <MyPrCard
+              key={pr.pullRequest.id}
+              data={pr}
+              onOpen={onOpen}
+              onWorkspaceAction={onWorkspaceAction}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/MyPRs/MyPRs.tsx
+++ b/src/components/MyPRs/MyPRs.tsx
@@ -34,7 +34,7 @@ export function MyPRs({
 
   return (
     <section data-testid="my-prs" className="flex flex-col gap-2">
-      <SectionHead title="My PRs" count={prs.length} />
+      <SectionHead title="My PRs" count={openPrs.length + mergedPrs.length} />
 
       <div className="flex gap-1" role="group" aria-label="Filter by state">
         <button

--- a/src/components/MyPRs/index.tsx
+++ b/src/components/MyPRs/index.tsx
@@ -1,3 +1,1 @@
-export function MyPRs() {
-  return <section data-testid="my-prs">MyPRs</section>;
-}
+export { MyPRs } from "./MyPRs";


### PR DESCRIPTION
## Summary

• MyPRs page component with Open/Merged tabs
• Tab counts updated dynamically based on state filter (open/draft vs merged)
• SectionHead displays title and total PR count
• EmptyState shown when no PRs match current tab filter
• MyPrCard integration for individual PR display
• Keyboard accessible tab buttons with aria-pressed

## Test Coverage

6 new tests covering:
- Default open tab display
- Tab switching behavior
- Count accuracy per tab
- Empty state rendering
- SectionHead with total count
- onOpen callback propagation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a MyPRs page to browse your PRs and wires it into the app. Aligns with Linear T-054 requirements.

- **New Features**
  - Tab filtering for Open (includes Draft) and Merged.
  - Dynamic counts per tab; SectionHead shows total PRs (closed excluded).
  - EmptyState when no PRs match the selected tab.
  - Renders MyPrCard with onOpen and optional onWorkspaceAction.
  - Keyboard-accessible tab buttons (aria-pressed).

<sup>Written for commit cb169894c1e22b99bd2eeb2d460b1f78b30de4e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "My PRs" view with tabs to switch between open (including drafts) and merged pull requests
  * Shows badge counts per state and a total PR count in the section header
  * Displays an empty-state message when no PRs match the selected tab
  * Clicking a PR opens it

* **Tests**
  * Added comprehensive tests covering filtering, counts, empty-state, and open-PR behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->