### PR TITLE
feat(ui): add IssueCard component and Issues page (T-055)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,7 @@ function MainContent({ view }: MainContentProps): ReactElement {
     case "mine":
       return <MyPRs prs={[]} onOpen={() => {}} />;
     case "issues":
-      return <Issues />;
+      return <Issues issues={[]} onOpen={() => {}} />;
     case "feed":
       return <ActivityFeed />;
     case "workspaces":

--- a/src/components/Issues/IssueCard.test.tsx
+++ b/src/components/Issues/IssueCard.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { Issue } from "../../lib/types";
+import { IssueCard } from "./IssueCard";
+
+function makeIssue(overrides: Partial<Issue> = {}): Issue {
+  return {
+    id: "issue-1",
+    number: 42,
+    title: "Fix login bug",
+    author: "alice",
+    state: "open",
+    priority: "medium",
+    repoId: "repo-1",
+    url: "https://github.com/org/repo/issues/42",
+    labels: [],
+    createdAt: "2026-03-26T10:00:00Z",
+    updatedAt: "2026-03-26T12:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("IssueCard", () => {
+  it("should render issue with title and number", () => {
+    render(<IssueCard issue={makeIssue()} onOpen={vi.fn()} />);
+
+    expect(screen.getByText("Fix login bug")).toBeInTheDocument();
+    expect(screen.getByText("#42")).toBeInTheDocument();
+  });
+
+  it("should render issue with labels", () => {
+    render(
+      <IssueCard
+        issue={makeIssue({ labels: ["bug", "enhancement"] })}
+        onOpen={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("bug")).toBeInTheDocument();
+    expect(screen.getByText("enhancement")).toBeInTheDocument();
+  });
+
+  it("should show green dot for open issues", () => {
+    render(<IssueCard issue={makeIssue({ state: "open" })} onOpen={vi.fn()} />);
+
+    const dot = screen.getByTestId("issue-state-dot");
+    expect(dot.className).toContain("bg-green");
+  });
+
+  it("should show purple dot for closed issues", () => {
+    render(
+      <IssueCard issue={makeIssue({ state: "closed" })} onOpen={vi.fn()} />,
+    );
+
+    const dot = screen.getByTestId("issue-state-dot");
+    expect(dot.className).toContain("bg-purple");
+  });
+
+  it("should display repo id", () => {
+    render(
+      <IssueCard issue={makeIssue({ repoId: "my-repo" })} onOpen={vi.fn()} />,
+    );
+
+    expect(screen.getByText("my-repo")).toBeInTheDocument();
+  });
+
+  it("should display relative time", () => {
+    render(<IssueCard issue={makeIssue()} onOpen={vi.fn()} />);
+
+    expect(screen.getByTestId("time-ago")).toBeInTheDocument();
+  });
+
+  it("should call onOpen with url on click", async () => {
+    const onOpen = vi.fn();
+    const user = userEvent.setup();
+
+    render(<IssueCard issue={makeIssue()} onOpen={onOpen} />);
+
+    await user.click(screen.getByText("Fix login bug"));
+
+    expect(onOpen).toHaveBeenCalledWith(
+      "https://github.com/org/repo/issues/42",
+    );
+  });
+});

--- a/src/components/Issues/IssueCard.tsx
+++ b/src/components/Issues/IssueCard.tsx
@@ -1,0 +1,59 @@
+import type { MouseEvent, ReactElement } from "react";
+import { timeAgo } from "../../lib/timeAgo";
+import type { Issue, IssueState } from "../../lib/types";
+import { LabelTag } from "../atoms/LabelTag";
+
+interface IssueCardProps {
+  readonly issue: Issue;
+  readonly onOpen: (url: string) => void;
+}
+
+const STATE_DOT_COLOR: Record<IssueState, string> = {
+  open: "bg-green",
+  closed: "bg-purple",
+};
+
+export function IssueCard({ issue, onOpen }: IssueCardProps): ReactElement {
+  function handleClick(e: MouseEvent) {
+    e.preventDefault();
+    onOpen(issue.url);
+  }
+
+  return (
+    <div
+      data-testid="issue-card"
+      className={`flex items-center gap-3 rounded border border-border px-3 py-2 hover:bg-surface-hover${issue.state === "closed" ? " opacity-50" : ""}`}
+    >
+      <a
+        href={issue.url}
+        onClick={handleClick}
+        className="flex min-w-0 flex-1 cursor-pointer items-center gap-3 no-underline"
+      >
+        <span
+          data-testid="issue-state-dot"
+          className={`h-2.5 w-2.5 shrink-0 rounded-full ${STATE_DOT_COLOR[issue.state]}`}
+        />
+
+        <span className="min-w-0 truncate text-sm font-medium text-foreground">
+          {issue.title}
+        </span>
+
+        <span className="shrink-0 text-xs text-dim">#{issue.number}</span>
+
+        <span className="shrink-0 text-xs text-dim">{issue.repoId}</span>
+
+        {issue.labels.length > 0 && (
+          <span className="flex items-center gap-1">
+            {issue.labels.map((label) => (
+              <LabelTag key={label} name={label} />
+            ))}
+          </span>
+        )}
+
+        <span data-testid="time-ago" className="shrink-0 text-xs text-dim">
+          {timeAgo(issue.updatedAt)}
+        </span>
+      </a>
+    </div>
+  );
+}

--- a/src/components/Issues/IssueCard.tsx
+++ b/src/components/Issues/IssueCard.tsx
@@ -22,7 +22,7 @@ export function IssueCard({ issue, onOpen }: IssueCardProps): ReactElement {
   return (
     <div
       data-testid="issue-card"
-      className={`flex items-center gap-3 rounded border border-border px-3 py-2 hover:bg-surface-hover${issue.state === "closed" ? " opacity-50" : ""}`}
+      className="flex items-center gap-3 rounded border border-border px-3 py-2 hover:bg-surface-hover"
     >
       <a
         href={issue.url}
@@ -44,8 +44,8 @@ export function IssueCard({ issue, onOpen }: IssueCardProps): ReactElement {
 
         {issue.labels.length > 0 && (
           <span className="flex items-center gap-1">
-            {issue.labels.map((label) => (
-              <LabelTag key={label} name={label} />
+            {issue.labels.map((label, idx) => (
+              <LabelTag key={`${label}-${idx}`} name={label} />
             ))}
           </span>
         )}

--- a/src/components/Issues/Issues.test.tsx
+++ b/src/components/Issues/Issues.test.tsx
@@ -66,8 +66,17 @@ describe("Issues", () => {
     expect(closedTab).toHaveTextContent("2");
   });
 
-  it("should show empty state", () => {
+  it("should show empty state when no open issues", () => {
     render(<Issues issues={[closedIssue1]} onOpen={onOpen} />);
+
+    expect(screen.getByText(/no issues/i)).toBeInTheDocument();
+  });
+
+  it("should show empty state on closed tab when no closed issues", async () => {
+    const user = userEvent.setup();
+    render(<Issues issues={[openIssue1]} onOpen={onOpen} />);
+
+    await user.click(screen.getByRole("button", { name: /closed/i }));
 
     expect(screen.getByText(/no issues/i)).toBeInTheDocument();
   });

--- a/src/components/Issues/Issues.test.tsx
+++ b/src/components/Issues/Issues.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Issue } from "../../lib/types";
+import { Issues } from "./Issues";
+
+function makeIssue(overrides: Partial<Issue> = {}): Issue {
+  return {
+    id: `issue-${overrides.number ?? 1}`,
+    number: 1,
+    title: "Some issue",
+    author: "alice",
+    state: "open",
+    priority: "medium",
+    repoId: "repo-1",
+    url: "https://github.com/org/repo/issues/1",
+    labels: [],
+    createdAt: "2026-03-26T10:00:00Z",
+    updatedAt: "2026-03-26T12:00:00Z",
+    ...overrides,
+  };
+}
+
+const openIssue1 = makeIssue({ number: 1, title: "Open issue one", state: "open" });
+const openIssue2 = makeIssue({ number: 2, title: "Open issue two", state: "open" });
+const closedIssue1 = makeIssue({ number: 3, title: "Closed issue one", state: "closed" });
+const closedIssue2 = makeIssue({ number: 4, title: "Closed issue two", state: "closed" });
+
+const allIssues = [openIssue1, openIssue2, closedIssue1, closedIssue2];
+
+const onOpen = vi.fn();
+
+beforeEach(() => {
+  onOpen.mockClear();
+});
+
+describe("Issues", () => {
+  it("should show open issues by default", () => {
+    render(<Issues issues={allIssues} onOpen={onOpen} />);
+
+    expect(screen.getByText("Open issue one")).toBeInTheDocument();
+    expect(screen.getByText("Open issue two")).toBeInTheDocument();
+    expect(screen.queryByText("Closed issue one")).not.toBeInTheDocument();
+    expect(screen.queryByText("Closed issue two")).not.toBeInTheDocument();
+  });
+
+  it("should filter open/closed", async () => {
+    const user = userEvent.setup();
+    render(<Issues issues={allIssues} onOpen={onOpen} />);
+
+    await user.click(screen.getByRole("button", { name: /closed/i }));
+
+    expect(screen.getByText("Closed issue one")).toBeInTheDocument();
+    expect(screen.getByText("Closed issue two")).toBeInTheDocument();
+    expect(screen.queryByText("Open issue one")).not.toBeInTheDocument();
+    expect(screen.queryByText("Open issue two")).not.toBeInTheDocument();
+  });
+
+  it("should show correct counts in tabs", () => {
+    render(<Issues issues={allIssues} onOpen={onOpen} />);
+
+    const openTab = screen.getByRole("button", { name: /open/i });
+    const closedTab = screen.getByRole("button", { name: /closed/i });
+
+    expect(openTab).toHaveTextContent("2");
+    expect(closedTab).toHaveTextContent("2");
+  });
+
+  it("should show empty state", () => {
+    render(<Issues issues={[closedIssue1]} onOpen={onOpen} />);
+
+    expect(screen.getByText(/no issues/i)).toBeInTheDocument();
+  });
+
+  it("should render SectionHead with title and total count", () => {
+    render(<Issues issues={allIssues} onOpen={onOpen} />);
+
+    expect(screen.getByText("Issues")).toBeInTheDocument();
+    expect(screen.getByText("4")).toBeInTheDocument();
+  });
+
+  it("should pass onOpen to IssueCard", async () => {
+    const user = userEvent.setup();
+    render(<Issues issues={[openIssue1]} onOpen={onOpen} />);
+
+    await user.click(screen.getByText("Open issue one"));
+
+    expect(onOpen).toHaveBeenCalledWith(openIssue1.url);
+  });
+});

--- a/src/components/Issues/Issues.tsx
+++ b/src/components/Issues/Issues.tsx
@@ -1,0 +1,71 @@
+import { type ReactElement, useState } from "react";
+import type { Issue } from "../../lib/types";
+import { EmptyState } from "../atoms/EmptyState";
+import { SectionHead } from "../atoms/SectionHead";
+import { IssueCard } from "./IssueCard";
+
+interface IssuesProps {
+  readonly issues: readonly Issue[];
+  readonly onOpen: (url: string) => void;
+}
+
+type Tab = "open" | "closed";
+
+function isOpen(issue: Issue): boolean {
+  return issue.state === "open";
+}
+
+function isClosed(issue: Issue): boolean {
+  return issue.state === "closed";
+}
+
+export function Issues({ issues, onOpen }: IssuesProps): ReactElement {
+  const [tab, setTab] = useState<Tab>("open");
+
+  const openIssues = issues.filter(isOpen);
+  const closedIssues = issues.filter(isClosed);
+  const visible = tab === "open" ? openIssues : closedIssues;
+
+  return (
+    <section data-testid="issues" className="flex flex-col gap-2">
+      <SectionHead title="Issues" count={issues.length} />
+
+      <div className="flex gap-1" role="group" aria-label="Filter by state">
+        <button
+          type="button"
+          aria-pressed={tab === "open"}
+          onClick={() => setTab("open")}
+          className={`rounded px-2 py-0.5 text-xs ${
+            tab === "open"
+              ? "bg-accent text-white"
+              : "text-dim hover:text-foreground"
+          }`}
+        >
+          Open {openIssues.length}
+        </button>
+        <button
+          type="button"
+          aria-pressed={tab === "closed"}
+          onClick={() => setTab("closed")}
+          className={`rounded px-2 py-0.5 text-xs ${
+            tab === "closed"
+              ? "bg-accent text-white"
+              : "text-dim hover:text-foreground"
+          }`}
+        >
+          Closed {closedIssues.length}
+        </button>
+      </div>
+
+      {visible.length === 0 ? (
+        <EmptyState message="No issues to display" />
+      ) : (
+        <div className="flex flex-col gap-1">
+          {visible.map((issue) => (
+            <IssueCard key={issue.id} issue={issue} onOpen={onOpen} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/Issues/index.tsx
+++ b/src/components/Issues/index.tsx
@@ -1,3 +1,2 @@
-export function Issues() {
-  return <section data-testid="issues">Issues</section>;
-}
+export { IssueCard } from "./IssueCard";
+export { Issues } from "./Issues";


### PR DESCRIPTION
## Summary

• Add `IssueCard` component displaying issue state dot (green=open, purple=closed), title, number, repo, labels, and relative time
• Add `Issues` page with Open/Closed tabs for filtering, integrating with existing atoms (`SectionHead`, `EmptyState`, `LabelTag`)
• Update `App.tsx` to pass issues data and onOpen callback to the new Issues component

## Type

feat

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new Issues UI (T-055) with an `IssueCard` and an `Issues` page with Open/Closed filters and counts. Connects `Issues` to `App` and addresses review feedback.

- **New Features**
  - IssueCard: state dot (green=open, purple=closed), title, number, repo, labels, and relative time; clicking calls onOpen(url).
  - Issues page: Open/Closed tabs with counts (defaults to Open), SectionHead shows total, shows EmptyState when none.
  - Wired into App: `Issues` now requires issues and onOpen props.

<sup>Written for commit 605d8e145ccbc813576ffd172ccbc72097d2c9c3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an issue card component displaying state, title, number, labels, repo, and last-updated time.
  * Added a tabbed issue list with filtering for open/closed issues and empty-state handling.

* **Tests**
  * Added comprehensive tests for issue card and issue list, covering rendering, state indicators, filtering, counts, timestamps, and click behavior.

* **Refactor**
  * Updated module exports and integrated the new issues list into the app view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->