### PR TITLE
feat(ui): add ActivityItem component and ActivityFeed page with filters (T-056)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,7 @@ function MainContent({ view }: MainContentProps): ReactElement {
     case "issues":
       return <Issues issues={[]} onOpen={() => {}} />;
     case "feed":
-      return <ActivityFeed />;
+      return <ActivityFeed activities={[]} onMarkAllRead={() => {}} />;
     case "workspaces":
       return <Workspace />;
     case "settings":

--- a/src/components/ActivityFeed/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed/ActivityFeed.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Activity } from "../../lib/types";
+import { ActivityFeed } from "./ActivityFeed";
+
+function makeActivity(overrides: Partial<Activity> = {}): Activity {
+  return {
+    id: "act-1",
+    activityType: "comment_added",
+    actor: "alice",
+    repoId: "org/repo",
+    pullRequestId: "pr-1",
+    issueId: null,
+    message: "Some comment",
+    createdAt: "2026-03-28T10:00:00Z",
+    ...overrides,
+  };
+}
+
+const commentActivity = makeActivity({ id: "act-c", activityType: "comment_added", message: "A comment" });
+const reviewActivity = makeActivity({ id: "act-r", activityType: "review_submitted", message: "Approved" });
+const ciActivity = makeActivity({ id: "act-ci", activityType: "ci_completed", message: "CI passed" });
+const prOpenedActivity = makeActivity({ id: "act-pr", activityType: "pr_opened", message: "Opened PR" });
+const issueClosed = makeActivity({ id: "act-ic", activityType: "issue_closed", message: "Issue closed" });
+
+const allActivities = [commentActivity, reviewActivity, ciActivity, prOpenedActivity, issueClosed];
+
+const onMarkAllRead = vi.fn();
+
+beforeEach(() => {
+  onMarkAllRead.mockClear();
+});
+
+describe("ActivityFeed", () => {
+  it("should render all activities when no filter is selected", () => {
+    render(<ActivityFeed activities={allActivities} onMarkAllRead={onMarkAllRead} />);
+
+    expect(screen.getAllByTestId("activity-item")).toHaveLength(5);
+  });
+
+  it("should filter by type when comment filter is clicked", async () => {
+    const user = userEvent.setup();
+    render(<ActivityFeed activities={allActivities} onMarkAllRead={onMarkAllRead} />);
+
+    await user.click(screen.getByRole("button", { name: /comment/i }));
+
+    expect(screen.getAllByTestId("activity-item")).toHaveLength(1);
+  });
+
+  it("should show all when All filter is selected after filtering", async () => {
+    const user = userEvent.setup();
+    render(<ActivityFeed activities={allActivities} onMarkAllRead={onMarkAllRead} />);
+
+    await user.click(screen.getByRole("button", { name: /review/i }));
+    await user.click(screen.getByRole("button", { name: /^all$/i }));
+
+    expect(screen.getAllByTestId("activity-item")).toHaveLength(5);
+  });
+
+  it("should mark all as read when button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<ActivityFeed activities={allActivities} onMarkAllRead={onMarkAllRead} />);
+
+    await user.click(screen.getByRole("button", { name: /mark all read/i }));
+
+    expect(onMarkAllRead).toHaveBeenCalledOnce();
+  });
+
+  it("should show empty state when no activities match filter", async () => {
+    const user = userEvent.setup();
+    render(<ActivityFeed activities={[commentActivity]} onMarkAllRead={onMarkAllRead} />);
+
+    await user.click(screen.getByRole("button", { name: /ci/i }));
+
+    expect(screen.getByText(/no activity/i)).toBeInTheDocument();
+  });
+
+  it("should render SectionHead with title and count when activities are provided", () => {
+    render(<ActivityFeed activities={allActivities} onMarkAllRead={onMarkAllRead} />);
+
+    expect(screen.getByText("Activity")).toBeInTheDocument();
+    expect(screen.getByText("5")).toBeInTheDocument();
+  });
+});

--- a/src/components/ActivityFeed/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed/ActivityFeed.test.tsx
@@ -19,12 +19,13 @@ function makeActivity(overrides: Partial<Activity> = {}): Activity {
 }
 
 const commentActivity = makeActivity({ id: "act-c", activityType: "comment_added", message: "A comment" });
+const mentionActivity = makeActivity({ id: "act-m", activityType: "comment_added", message: "Hey @alice check this out" });
 const reviewActivity = makeActivity({ id: "act-r", activityType: "review_submitted", message: "Approved" });
 const ciActivity = makeActivity({ id: "act-ci", activityType: "ci_completed", message: "CI passed" });
 const prOpenedActivity = makeActivity({ id: "act-pr", activityType: "pr_opened", message: "Opened PR" });
 const issueClosed = makeActivity({ id: "act-ic", activityType: "issue_closed", message: "Issue closed" });
 
-const allActivities = [commentActivity, reviewActivity, ciActivity, prOpenedActivity, issueClosed];
+const allActivities = [commentActivity, mentionActivity, reviewActivity, ciActivity, prOpenedActivity, issueClosed];
 
 const onMarkAllRead = vi.fn();
 
@@ -36,7 +37,7 @@ describe("ActivityFeed", () => {
   it("should render all activities when no filter is selected", () => {
     render(<ActivityFeed activities={allActivities} onMarkAllRead={onMarkAllRead} />);
 
-    expect(screen.getAllByTestId("activity-item")).toHaveLength(5);
+    expect(screen.getAllByTestId("activity-item")).toHaveLength(6);
   });
 
   it("should filter by type when comment filter is clicked", async () => {
@@ -45,7 +46,7 @@ describe("ActivityFeed", () => {
 
     await user.click(screen.getByRole("button", { name: /comment/i }));
 
-    expect(screen.getAllByTestId("activity-item")).toHaveLength(1);
+    expect(screen.getAllByTestId("activity-item")).toHaveLength(2);
   });
 
   it("should show all when All filter is selected after filtering", async () => {
@@ -55,7 +56,16 @@ describe("ActivityFeed", () => {
     await user.click(screen.getByRole("button", { name: /review/i }));
     await user.click(screen.getByRole("button", { name: /^all$/i }));
 
-    expect(screen.getAllByTestId("activity-item")).toHaveLength(5);
+    expect(screen.getAllByTestId("activity-item")).toHaveLength(6);
+  });
+
+  it("should filter mentions when mention filter is clicked", async () => {
+    const user = userEvent.setup();
+    render(<ActivityFeed activities={allActivities} onMarkAllRead={onMarkAllRead} />);
+
+    await user.click(screen.getByRole("button", { name: /mention/i }));
+
+    expect(screen.getAllByTestId("activity-item")).toHaveLength(1);
   });
 
   it("should mark all as read when button is clicked", async () => {
@@ -76,10 +86,10 @@ describe("ActivityFeed", () => {
     expect(screen.getByText(/no activity/i)).toBeInTheDocument();
   });
 
-  it("should render SectionHead with title and count when activities are provided", () => {
+  it("should render SectionHead with filtered count when activities are provided", () => {
     render(<ActivityFeed activities={allActivities} onMarkAllRead={onMarkAllRead} />);
 
     expect(screen.getByText("Activity")).toBeInTheDocument();
-    expect(screen.getByText("5")).toBeInTheDocument();
+    expect(screen.getByText("6")).toBeInTheDocument();
   });
 });

--- a/src/components/ActivityFeed/ActivityFeed.tsx
+++ b/src/components/ActivityFeed/ActivityFeed.tsx
@@ -11,18 +11,22 @@ interface ActivityFeedProps {
 
 type FilterType = "all" | "comment" | "review" | "ci" | "mention" | "other";
 
-const FILTER_MATCH: Record<Exclude<FilterType, "all">, readonly ActivityType[]> = {
+const FILTER_MATCH: Record<Exclude<FilterType, "all" | "mention">, readonly ActivityType[]> = {
   comment: ["comment_added"],
   review: ["review_submitted"],
   ci: ["ci_completed"],
-  mention: [],
   other: ["pr_opened", "pr_merged", "pr_closed", "issue_opened", "issue_closed"],
 };
 
-const FILTER_LABELS: readonly FilterType[] = ["all", "comment", "review", "ci", "mention", "other"];
+const MENTION_PATTERN = /(^|\s)@\w+/;
+
+const FILTER_LABELS = ["all", "comment", "review", "ci", "mention", "other"] as const satisfies readonly FilterType[];
 
 function matchesFilter(activity: Activity, filter: FilterType): boolean {
   if (filter === "all") return true;
+  if (filter === "mention") {
+    return activity.activityType === "comment_added" && MENTION_PATTERN.test(activity.message);
+  }
   return FILTER_MATCH[filter].includes(activity.activityType);
 }
 
@@ -33,7 +37,7 @@ export function ActivityFeed({ activities, onMarkAllRead }: ActivityFeedProps): 
 
   return (
     <section data-testid="activity-feed" className="flex flex-col gap-2">
-      <SectionHead title="Activity" count={activities.length} />
+      <SectionHead title="Activity" count={visible.length} />
 
       <div className="flex items-center gap-1">
         <div className="flex gap-1" role="group" aria-label="Filter by type">

--- a/src/components/ActivityFeed/ActivityFeed.tsx
+++ b/src/components/ActivityFeed/ActivityFeed.tsx
@@ -1,0 +1,77 @@
+import { type ReactElement, useState } from "react";
+import type { Activity, ActivityType } from "../../lib/types";
+import { EmptyState } from "../atoms/EmptyState";
+import { SectionHead } from "../atoms/SectionHead";
+import { ActivityItem } from "./ActivityItem";
+
+interface ActivityFeedProps {
+  readonly activities: readonly Activity[];
+  readonly onMarkAllRead: () => void;
+}
+
+type FilterType = "all" | "comment" | "review" | "ci" | "mention" | "other";
+
+const FILTER_MATCH: Record<Exclude<FilterType, "all">, readonly ActivityType[]> = {
+  comment: ["comment_added"],
+  review: ["review_submitted"],
+  ci: ["ci_completed"],
+  mention: [],
+  other: ["pr_opened", "pr_merged", "pr_closed", "issue_opened", "issue_closed"],
+};
+
+const FILTER_LABELS: readonly FilterType[] = ["all", "comment", "review", "ci", "mention", "other"];
+
+function matchesFilter(activity: Activity, filter: FilterType): boolean {
+  if (filter === "all") return true;
+  return FILTER_MATCH[filter].includes(activity.activityType);
+}
+
+export function ActivityFeed({ activities, onMarkAllRead }: ActivityFeedProps): ReactElement {
+  const [filter, setFilter] = useState<FilterType>("all");
+
+  const visible = activities.filter((a) => matchesFilter(a, filter));
+
+  return (
+    <section data-testid="activity-feed" className="flex flex-col gap-2">
+      <SectionHead title="Activity" count={activities.length} />
+
+      <div className="flex items-center gap-1">
+        <div className="flex gap-1" role="group" aria-label="Filter by type">
+          {FILTER_LABELS.map((f) => (
+            <button
+              key={f}
+              type="button"
+              aria-pressed={filter === f}
+              onClick={() => setFilter(f)}
+              className={`rounded px-2 py-0.5 text-xs capitalize ${
+                filter === f
+                  ? "bg-accent text-white"
+                  : "text-dim hover:text-foreground"
+              }`}
+            >
+              {f}
+            </button>
+          ))}
+        </div>
+
+        <button
+          type="button"
+          onClick={onMarkAllRead}
+          className="ml-auto rounded px-2 py-0.5 text-xs text-dim hover:text-foreground"
+        >
+          Mark all read
+        </button>
+      </div>
+
+      {visible.length === 0 ? (
+        <EmptyState message="No activity to display" />
+      ) : (
+        <div className="flex flex-col gap-1">
+          {visible.map((activity) => (
+            <ActivityItem key={activity.id} activity={activity} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/ActivityFeed/ActivityItem.test.tsx
+++ b/src/components/ActivityFeed/ActivityItem.test.tsx
@@ -49,8 +49,8 @@ describe("ActivityItem", () => {
     render(<ActivityItem activity={makeActivity({ message: longMessage })} />);
 
     const body = screen.getByTestId("activity-body");
-    expect(body).toHaveTextContent(`${"A".repeat(80)}…`);
-    expect((body.textContent ?? "").length).toBe(81);
+    expect(body).toHaveTextContent(`${"A".repeat(79)}…`);
+    expect((body.textContent ?? "").length).toBe(80);
   });
 
   it("should show different icons when activity types differ", () => {

--- a/src/components/ActivityFeed/ActivityItem.test.tsx
+++ b/src/components/ActivityFeed/ActivityItem.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { Activity } from "../../lib/types";
+import { ActivityItem } from "./ActivityItem";
+
+function makeActivity(overrides: Partial<Activity> = {}): Activity {
+  return {
+    id: "act-1",
+    activityType: "comment_added",
+    actor: "alice",
+    repoId: "org/repo",
+    pullRequestId: "pr-42",
+    issueId: null,
+    message: "Looks good, just one small nit on the error handling path",
+    createdAt: "2026-03-28T10:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("ActivityItem", () => {
+  it("should render icon when activity type is review_submitted", () => {
+    render(<ActivityItem activity={makeActivity({ activityType: "review_submitted" })} />);
+
+    expect(screen.getByTestId("activity-icon")).toBeInTheDocument();
+  });
+
+  it("should render actor in bold when actor is provided", () => {
+    render(<ActivityItem activity={makeActivity({ actor: "bob" })} />);
+
+    const actor = screen.getByTestId("activity-actor");
+    expect(actor).toHaveTextContent("bob");
+    expect(actor.className).toContain("font-bold");
+  });
+
+  it("should render repo name when repoId is set", () => {
+    render(<ActivityItem activity={makeActivity({ repoId: "my-org/my-repo" })} />);
+
+    expect(screen.getByText("my-org/my-repo")).toBeInTheDocument();
+  });
+
+  it("should render relative time when createdAt is provided", () => {
+    render(<ActivityItem activity={makeActivity()} />);
+
+    expect(screen.getByTestId("activity-time")).toBeInTheDocument();
+  });
+
+  it("should truncate body when message exceeds 80 characters", () => {
+    const longMessage = "A".repeat(200);
+    render(<ActivityItem activity={makeActivity({ message: longMessage })} />);
+
+    const body = screen.getByTestId("activity-body");
+    expect((body.textContent ?? "").length).toBeLessThan(200);
+  });
+
+  it("should show different icons when activity types differ", () => {
+    const { rerender } = render(
+      <ActivityItem activity={makeActivity({ activityType: "pr_opened" })} />,
+    );
+    const iconPrOpened = screen.getByTestId("activity-icon").textContent;
+
+    rerender(
+      <ActivityItem activity={makeActivity({ activityType: "ci_completed" })} />,
+    );
+    const iconCi = screen.getByTestId("activity-icon").textContent;
+
+    expect(iconPrOpened).not.toBe(iconCi);
+  });
+
+  it("should render action text when activity type is pr_merged", () => {
+    render(<ActivityItem activity={makeActivity({ activityType: "pr_merged" })} />);
+
+    expect(screen.getByTestId("activity-action")).toHaveTextContent(/merged/i);
+  });
+});

--- a/src/components/ActivityFeed/ActivityItem.test.tsx
+++ b/src/components/ActivityFeed/ActivityItem.test.tsx
@@ -49,7 +49,8 @@ describe("ActivityItem", () => {
     render(<ActivityItem activity={makeActivity({ message: longMessage })} />);
 
     const body = screen.getByTestId("activity-body");
-    expect((body.textContent ?? "").length).toBeLessThan(200);
+    expect(body).toHaveTextContent(`${"A".repeat(80)}…`);
+    expect((body.textContent ?? "").length).toBe(81);
   });
 
   it("should show different icons when activity types differ", () => {

--- a/src/components/ActivityFeed/ActivityItem.tsx
+++ b/src/components/ActivityFeed/ActivityItem.tsx
@@ -1,0 +1,68 @@
+import type { ReactElement } from "react";
+import { timeAgo } from "../../lib/timeAgo";
+import type { Activity, ActivityType } from "../../lib/types";
+
+interface ActivityItemProps {
+  readonly activity: Activity;
+}
+
+const ACTIVITY_ICON = {
+  pr_opened: "↗",
+  pr_merged: "⇌",
+  pr_closed: "✕",
+  review_submitted: "✓",
+  comment_added: "💬",
+  ci_completed: "⚙",
+  issue_opened: "◉",
+  issue_closed: "◎",
+} satisfies Record<ActivityType, string>;
+
+const ACTIVITY_ACTION = {
+  pr_opened: "opened a PR",
+  pr_merged: "merged a PR",
+  pr_closed: "closed a PR",
+  review_submitted: "submitted a review",
+  comment_added: "commented",
+  ci_completed: "CI completed",
+  issue_opened: "opened an issue",
+  issue_closed: "closed an issue",
+} satisfies Record<ActivityType, string>;
+
+const MAX_BODY_LENGTH = 80;
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return `${text.slice(0, max)}…`;
+}
+
+export function ActivityItem({ activity }: ActivityItemProps): ReactElement {
+  return (
+    <div data-testid="activity-item" className="flex items-start gap-2 rounded border border-border px-3 py-2">
+      <span data-testid="activity-icon" className="shrink-0 text-sm text-dim">
+        {ACTIVITY_ICON[activity.activityType]}
+      </span>
+
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-1 text-sm">
+          <span data-testid="activity-actor" className="font-bold text-foreground">
+            {activity.actor}
+          </span>
+          <span data-testid="activity-action" className="text-dim">
+            {ACTIVITY_ACTION[activity.activityType]}
+          </span>
+        </div>
+
+        {activity.message.length > 0 && (
+          <p data-testid="activity-body" className="mt-0.5 text-xs text-dim">
+            {truncate(activity.message, MAX_BODY_LENGTH)}
+          </p>
+        )}
+
+        <div className="mt-0.5 flex items-center gap-2 text-xs text-dim">
+          <span>{activity.repoId}</span>
+          <span data-testid="activity-time">{timeAgo(activity.createdAt)}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ActivityFeed/ActivityItem.tsx
+++ b/src/components/ActivityFeed/ActivityItem.tsx
@@ -32,7 +32,8 @@ const MAX_BODY_LENGTH = 80;
 
 function truncate(text: string, max: number): string {
   if (text.length <= max) return text;
-  return `${text.slice(0, max)}…`;
+  if (max <= 1) return "…";
+  return `${text.slice(0, max - 1)}…`;
 }
 
 export function ActivityItem({ activity }: ActivityItemProps): ReactElement {

--- a/src/components/ActivityFeed/ActivityItem.tsx
+++ b/src/components/ActivityFeed/ActivityItem.tsx
@@ -38,7 +38,7 @@ function truncate(text: string, max: number): string {
 export function ActivityItem({ activity }: ActivityItemProps): ReactElement {
   return (
     <div data-testid="activity-item" className="flex items-start gap-2 rounded border border-border px-3 py-2">
-      <span data-testid="activity-icon" className="shrink-0 text-sm text-dim">
+      <span data-testid="activity-icon" aria-hidden="true" className="shrink-0 text-sm text-dim">
         {ACTIVITY_ICON[activity.activityType]}
       </span>
 

--- a/src/components/ActivityFeed/index.tsx
+++ b/src/components/ActivityFeed/index.tsx
@@ -1,3 +1,2 @@
-export function ActivityFeed() {
-  return <section data-testid="activity-feed">ActivityFeed</section>;
-}
+export { ActivityItem } from "./ActivityItem";
+export { ActivityFeed } from "./ActivityFeed";


### PR DESCRIPTION
## Summary

• Create `ActivityItem` component displaying activity with icon, actor, action, and truncated message
• Create `ActivityFeed` page with filter tabs (all/comment/review/ci/mention/other)
• Add "Mark all read" action button
• Implement type-safe icon and action mappings with `satisfies` exhaustiveness checking
• Full test coverage: 13 tests for both components, all passing

## Test Plan

- [x] ActivityItem renders with correct icon per activity type
- [x] ActivityItem truncates long messages (>80 chars)
- [x] ActivityFeed filters by activity type
- [x] ActivityFeed shows empty state when no activities match filter
- [x] Mark all read callback fires correctly
- [x] All 240 project tests passing
- [x] oxlint clean (0 warnings/errors)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `ActivityItem` and an `ActivityFeed` page with filters and a “Mark all read” action, fulfilling Linear T-056.

- **New Features**
  - `ActivityItem`: per-type icon and action via type-safe maps, bold actor, 80-char truncation (incl. ellipsis), repo + relative time.
  - `ActivityFeed`: accepts `activities` and `onMarkAllRead`, filter tabs (all/comment/review/ci/mention/other) with accessible buttons, mention filter detects “@” in comments, empty state, header shows filtered count.

<sup>Written for commit fbf4a6f5265473b426891051520e418772d6a17b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Activity feed UI with client-side filtering (comments, reviews, CI, mentions, All)
  * Activity count in the feed header and a "Mark all read" action
  * Per-item rows with icons, actor/repo/time, truncated messages, and empty-state messaging

* **Bug Fixes**
  * Feed view now consistently renders the Activity feed (shows empty state until activities load)

* **Tests**
  * Added comprehensive tests for filtering, counts, empty state, "Mark all read", item rendering, icons, and truncation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->