### PR TITLE
feat(ui): add Sidebar component with navigation, workspaces and repos (T-057)

### DIFF
--- a/src/components/Sidebar/NavItem.test.tsx
+++ b/src/components/Sidebar/NavItem.test.tsx
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NavItem } from "./NavItem";
+
+describe("NavItem", () => {
+  it("should render label", () => {
+    render(
+      <NavItem label="Overview" view="overview" isActive={false} onClick={vi.fn()} />,
+    );
+    expect(screen.getByText("Overview")).toBeInTheDocument();
+  });
+
+  it("should render count when provided", () => {
+    render(
+      <NavItem label="To Review" view="reviews" count={5} isActive={false} onClick={vi.fn()} />,
+    );
+    expect(screen.getByText("5")).toBeInTheDocument();
+  });
+
+  it("should not render count when zero", () => {
+    render(
+      <NavItem label="Issues" view="issues" count={0} isActive={false} onClick={vi.fn()} />,
+    );
+    expect(screen.queryByText("0")).not.toBeInTheDocument();
+  });
+
+  it("should highlight when active", () => {
+    render(
+      <NavItem label="Overview" view="overview" isActive={true} onClick={vi.fn()} />,
+    );
+    const button = screen.getByRole("button", { name: /overview/i });
+    expect(button).toHaveAttribute("aria-current", "page");
+  });
+
+  it("should not highlight when inactive", () => {
+    render(
+      <NavItem label="Overview" view="overview" isActive={false} onClick={vi.fn()} />,
+    );
+    const button = screen.getByRole("button", { name: /overview/i });
+    expect(button).not.toHaveAttribute("aria-current");
+  });
+
+  it("should call onClick with view when clicked", async () => {
+    const handleClick = vi.fn();
+    render(
+      <NavItem label="Reviews" view="reviews" isActive={false} onClick={handleClick} />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: /reviews/i }));
+    expect(handleClick).toHaveBeenCalledWith("reviews");
+  });
+});

--- a/src/components/Sidebar/NavItem.tsx
+++ b/src/components/Sidebar/NavItem.tsx
@@ -1,0 +1,38 @@
+import type { ReactElement } from "react";
+import type { DashboardView } from "../../stores/dashboard";
+
+interface NavItemProps {
+  readonly label: string;
+  readonly view: DashboardView;
+  readonly count?: number;
+  readonly isActive: boolean;
+  readonly onClick: (view: DashboardView) => void;
+}
+
+export function NavItem({
+  label,
+  view,
+  count,
+  isActive,
+  onClick,
+}: NavItemProps): ReactElement {
+  return (
+    <button
+      type="button"
+      onClick={() => onClick(view)}
+      aria-current={isActive ? "page" : undefined}
+      className={`flex w-full items-center justify-between rounded px-2 py-1 text-left text-sm ${
+        isActive
+          ? "bg-surface text-white"
+          : "text-dim hover:bg-surface-hover hover:text-foreground"
+      }`}
+    >
+      <span>{label}</span>
+      {count !== undefined && count > 0 ? (
+        <span className="min-w-[1.25rem] rounded-full bg-accent/15 px-1.5 text-center text-xs text-accent">
+          {count}
+        </span>
+      ) : null}
+    </button>
+  );
+}

--- a/src/components/Sidebar/RepoList.test.tsx
+++ b/src/components/Sidebar/RepoList.test.tsx
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { Repo } from "../../lib/types";
+import { RepoList } from "./RepoList";
+
+const enabledRepo: Repo = {
+  id: "repo-1",
+  org: "acme",
+  name: "frontend",
+  fullName: "acme/frontend",
+  url: "https://github.com/acme/frontend",
+  defaultBranch: "main",
+  isArchived: false,
+  enabled: true,
+  localPath: "/home/user/frontend",
+  lastSyncAt: "2026-03-28T10:00:00Z",
+};
+
+const disabledRepo: Repo = {
+  id: "repo-2",
+  org: "acme",
+  name: "backend",
+  fullName: "acme/backend",
+  url: "https://github.com/acme/backend",
+  defaultBranch: "main",
+  isArchived: false,
+  enabled: false,
+  localPath: null,
+  lastSyncAt: null,
+};
+
+describe("RepoList", () => {
+  it("should render repo names", () => {
+    render(
+      <RepoList repos={[enabledRepo, disabledRepo]} onToggleRepo={vi.fn()} />,
+    );
+    expect(screen.getByText("acme/frontend")).toBeInTheDocument();
+    expect(screen.getByText("acme/backend")).toBeInTheDocument();
+  });
+
+  it("should show checkbox for each repo", () => {
+    render(
+      <RepoList repos={[enabledRepo, disabledRepo]} onToggleRepo={vi.fn()} />,
+    );
+    const checkboxes = screen.getAllByRole("checkbox");
+    expect(checkboxes).toHaveLength(2);
+  });
+
+  it("should show checked state for enabled repos", () => {
+    render(
+      <RepoList repos={[enabledRepo, disabledRepo]} onToggleRepo={vi.fn()} />,
+    );
+    const checkboxes = screen.getAllByRole("checkbox");
+    expect(checkboxes[0]).toBeChecked();
+    expect(checkboxes[1]).not.toBeChecked();
+  });
+
+  it("should call onToggleRepo when checkbox clicked", async () => {
+    const handleToggle = vi.fn();
+    render(
+      <RepoList repos={[enabledRepo]} onToggleRepo={handleToggle} />,
+    );
+    await userEvent.click(screen.getByRole("checkbox"));
+    expect(handleToggle).toHaveBeenCalledWith("repo-1", false);
+  });
+
+  it("should render empty when no repos", () => {
+    render(<RepoList repos={[]} onToggleRepo={vi.fn()} />);
+    expect(screen.queryAllByRole("checkbox")).toHaveLength(0);
+  });
+});

--- a/src/components/Sidebar/RepoList.tsx
+++ b/src/components/Sidebar/RepoList.tsx
@@ -21,6 +21,7 @@ export function RepoList({
             type="checkbox"
             checked={repo.enabled}
             onChange={() => onToggleRepo(repo.id, !repo.enabled)}
+            aria-label={`Enable ${repo.fullName} repository`}
             className="accent-accent"
           />
           <span>{repo.fullName}</span>

--- a/src/components/Sidebar/RepoList.tsx
+++ b/src/components/Sidebar/RepoList.tsx
@@ -1,0 +1,31 @@
+import type { ReactElement } from "react";
+import type { Repo } from "../../lib/types";
+
+interface RepoListProps {
+  readonly repos: readonly Repo[];
+  readonly onToggleRepo: (repoId: string, enabled: boolean) => void;
+}
+
+export function RepoList({
+  repos,
+  onToggleRepo,
+}: RepoListProps): ReactElement {
+  return (
+    <div className="flex flex-col gap-0.5">
+      {repos.map((repo) => (
+        <label
+          key={repo.id}
+          className="flex cursor-pointer items-center gap-2 rounded px-2 py-1 text-xs text-dim hover:bg-surface-hover hover:text-foreground"
+        >
+          <input
+            type="checkbox"
+            checked={repo.enabled}
+            onChange={() => onToggleRepo(repo.id, !repo.enabled)}
+            className="accent-accent"
+          />
+          <span>{repo.fullName}</span>
+        </label>
+      ))}
+    </div>
+  );
+}

--- a/src/components/Sidebar/Sidebar.test.tsx
+++ b/src/components/Sidebar/Sidebar.test.tsx
@@ -1,0 +1,172 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { Sidebar } from "./Sidebar";
+import { useDashboardStore } from "../../stores/dashboard";
+import { useWorkspacesStore } from "../../stores/workspaces";
+
+vi.mock("../../hooks/useGitHubData", () => ({
+  useGitHubData: () => ({
+    stats: {
+      pendingReviews: 3,
+      openPrs: 7,
+      openIssues: 2,
+      activeWorkspaces: 1,
+      unreadActivity: 4,
+    },
+    dashboard: {
+      reviewRequests: [],
+      myPullRequests: [],
+      assignedIssues: [],
+      recentActivity: [],
+      workspaces: [
+        {
+          id: "ws-1",
+          repoId: "repo-1",
+          pullRequestNumber: 42,
+          state: "active",
+          worktreePath: "/tmp/ws-1",
+          sessionId: "session-1",
+          createdAt: "2026-03-28T10:00:00Z",
+          updatedAt: "2026-03-28T10:00:00Z",
+        },
+        {
+          id: "ws-2",
+          repoId: "repo-2",
+          pullRequestNumber: 99,
+          state: "suspended",
+          worktreePath: "/tmp/ws-2",
+          sessionId: null,
+          createdAt: "2026-03-28T09:00:00Z",
+          updatedAt: "2026-03-28T09:00:00Z",
+        },
+      ],
+      syncedAt: "2026-03-28T10:00:00Z",
+    },
+    isLoading: false,
+    error: null,
+    forceSync: vi.fn(),
+    isSyncing: false,
+  }),
+}));
+
+vi.mock("../../lib/tauri", () => ({
+  listRepos: vi.fn().mockResolvedValue([
+    {
+      id: "repo-1",
+      org: "acme",
+      name: "frontend",
+      fullName: "acme/frontend",
+      url: "https://github.com/acme/frontend",
+      defaultBranch: "main",
+      isArchived: false,
+      enabled: true,
+      localPath: "/home/user/frontend",
+      lastSyncAt: "2026-03-28T10:00:00Z",
+    },
+  ]),
+  setRepoEnabled: vi.fn().mockResolvedValue({}),
+  authGetStatus: vi.fn().mockResolvedValue({
+    connected: true,
+    username: "matvei",
+    error: null,
+  }),
+}));
+
+function renderSidebar() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <Sidebar />
+    </QueryClientProvider>,
+  );
+}
+
+describe("Sidebar", () => {
+  beforeEach(() => {
+    useDashboardStore.setState({ currentView: "overview", activeFilters: {} });
+    useWorkspacesStore.setState({ activeWorkspaceId: null });
+  });
+
+  it("should render logo", () => {
+    renderSidebar();
+    expect(screen.getByText("PRism")).toBeInTheDocument();
+  });
+
+  it("should highlight active view", () => {
+    useDashboardStore.setState({ currentView: "reviews" });
+    renderSidebar();
+    const reviewButton = screen.getByRole("button", { name: /to review/i });
+    expect(reviewButton).toHaveAttribute("aria-current", "page");
+  });
+
+  it("should show review count", () => {
+    renderSidebar();
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("should show workspace dots with state colors", () => {
+    const { container } = renderSidebar();
+    const dots = container.querySelectorAll("[data-state]");
+    expect(dots.length).toBeGreaterThanOrEqual(2);
+    const states = Array.from(dots).map((d) => d.getAttribute("data-state"));
+    expect(states).toContain("active");
+    expect(states).toContain("suspended");
+  });
+
+  it("should toggle repos", async () => {
+    const { listRepos } = await import("../../lib/tauri");
+    vi.mocked(listRepos).mockResolvedValue([
+      {
+        id: "repo-1",
+        org: "acme",
+        name: "frontend",
+        fullName: "acme/frontend",
+        url: "https://github.com/acme/frontend",
+        defaultBranch: "main",
+        isArchived: false,
+        enabled: true,
+        localPath: "/home/user/frontend",
+        lastSyncAt: "2026-03-28T10:00:00Z",
+      },
+    ]);
+    renderSidebar();
+    // Wait for repos to load
+    const checkbox = await screen.findByRole("checkbox");
+    expect(checkbox).toBeChecked();
+  });
+
+  it("should switch to workspace on click", async () => {
+    renderSidebar();
+    const wsEntry = screen.getByText(/PR #42/);
+    await userEvent.click(wsEntry);
+
+    expect(useDashboardStore.getState().currentView).toBe("workspaces");
+    expect(useWorkspacesStore.getState().activeWorkspaceId).toBe("ws-1");
+  });
+
+  it("should render all navigation items", () => {
+    renderSidebar();
+    expect(screen.getByRole("button", { name: /overview/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /to review/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /my prs/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /issues/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /activity/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /workspaces/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /settings/i })).toBeInTheDocument();
+  });
+
+  it("should navigate when nav item is clicked", async () => {
+    renderSidebar();
+    await userEvent.click(screen.getByRole("button", { name: /issues/i }));
+    expect(useDashboardStore.getState().currentView).toBe("issues");
+  });
+
+  it("should show footer with keyboard shortcut", () => {
+    renderSidebar();
+    expect(screen.getByText(/⌘K/)).toBeInTheDocument();
+  });
+});

--- a/src/components/Sidebar/Sidebar.test.tsx
+++ b/src/components/Sidebar/Sidebar.test.tsx
@@ -87,6 +87,7 @@ function renderSidebar() {
 
 describe("Sidebar", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     useDashboardStore.setState({ currentView: "overview", activeFilters: {} });
     useWorkspacesStore.setState({ activeWorkspaceId: null });
   });
@@ -118,25 +119,13 @@ describe("Sidebar", () => {
   });
 
   it("should toggle repos", async () => {
-    const { listRepos } = await import("../../lib/tauri");
-    vi.mocked(listRepos).mockResolvedValue([
-      {
-        id: "repo-1",
-        org: "acme",
-        name: "frontend",
-        fullName: "acme/frontend",
-        url: "https://github.com/acme/frontend",
-        defaultBranch: "main",
-        isArchived: false,
-        enabled: true,
-        localPath: "/home/user/frontend",
-        lastSyncAt: "2026-03-28T10:00:00Z",
-      },
-    ]);
+    const { setRepoEnabled } = await import("../../lib/tauri");
     renderSidebar();
-    // Wait for repos to load
     const checkbox = await screen.findByRole("checkbox");
     expect(checkbox).toBeChecked();
+
+    await userEvent.click(checkbox);
+    expect(vi.mocked(setRepoEnabled)).toHaveBeenCalledWith("repo-1", false);
   });
 
   it("should switch to workspace on click", async () => {

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -1,0 +1,126 @@
+import type { ReactElement } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useDashboardStore } from "../../stores/dashboard";
+import type { DashboardView } from "../../stores/dashboard";
+import { useWorkspacesStore } from "../../stores/workspaces";
+import { useGitHubData } from "../../hooks/useGitHubData";
+import { listRepos, setRepoEnabled, authGetStatus } from "../../lib/tauri";
+import { NavItem } from "./NavItem";
+import { WorkspaceList } from "./WorkspaceList";
+import { RepoList } from "./RepoList";
+
+interface NavEntry {
+  readonly label: string;
+  readonly view: DashboardView;
+  readonly countKey?: "pendingReviews" | "openPrs" | "openIssues" | "activeWorkspaces";
+}
+
+const NAV_ITEMS: readonly NavEntry[] = [
+  { label: "Overview", view: "overview" },
+  { label: "To Review", view: "reviews", countKey: "pendingReviews" },
+  { label: "My PRs", view: "mine", countKey: "openPrs" },
+  { label: "Issues", view: "issues", countKey: "openIssues" },
+  { label: "Activity", view: "feed" },
+  { label: "Workspaces", view: "workspaces", countKey: "activeWorkspaces" },
+  { label: "Settings", view: "settings" },
+];
+
+export function Sidebar(): ReactElement {
+  const queryClient = useQueryClient();
+  const currentView = useDashboardStore((s) => s.currentView);
+  const setView = useDashboardStore((s) => s.setView);
+  const setActiveWorkspace = useWorkspacesStore((s) => s.setActiveWorkspace);
+  const { stats, dashboard } = useGitHubData();
+
+  const reposQuery = useQuery({
+    queryKey: ["repos"],
+    queryFn: listRepos,
+  });
+
+  const authQuery = useQuery({
+    queryKey: ["auth", "status"],
+    queryFn: authGetStatus,
+  });
+
+  const toggleRepoMutation = useMutation({
+    mutationFn: ({ repoId, enabled }: { repoId: string; enabled: boolean }) =>
+      setRepoEnabled(repoId, enabled),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["repos"] });
+    },
+  });
+
+  function handleNavClick(view: DashboardView) {
+    setView(view);
+  }
+
+  function handleWorkspaceClick(workspaceId: string) {
+    setActiveWorkspace(workspaceId);
+    setView("workspaces");
+  }
+
+  function handleToggleRepo(repoId: string, enabled: boolean) {
+    toggleRepoMutation.mutate({ repoId, enabled });
+  }
+
+  const workspaces = (dashboard?.workspaces ?? []).filter(
+    (ws) => ws.state !== "archived",
+  );
+  const repos = reposQuery.data ?? [];
+  const username = authQuery.data?.username ?? null;
+
+  return (
+    <nav data-testid="sidebar" aria-label="Main navigation" className="flex h-full flex-col gap-4 p-3">
+      {/* Logo */}
+      <div className="px-2 py-1">
+        <h1 className="text-sm font-bold text-white">PRism</h1>
+        <p className="text-xs text-dim">GitHub Review Dashboard</p>
+      </div>
+
+      {/* Navigation */}
+      <div className="flex flex-col gap-0.5">
+        {NAV_ITEMS.map((item) => (
+          <NavItem
+            key={item.view}
+            label={item.label}
+            view={item.view}
+            count={item.countKey && stats ? stats[item.countKey] : undefined}
+            isActive={currentView === item.view}
+            onClick={handleNavClick}
+          />
+        ))}
+      </div>
+
+      {/* Workspaces section */}
+      {workspaces.length > 0 && (
+        <div className="flex flex-col gap-1">
+          <h3 className="px-2 text-[10px] font-semibold uppercase tracking-wider text-dim">
+            Workspaces
+          </h3>
+          <WorkspaceList
+            workspaces={workspaces}
+            onWorkspaceClick={handleWorkspaceClick}
+          />
+        </div>
+      )}
+
+      {/* Repos section */}
+      {repos.length > 0 && (
+        <div className="flex flex-col gap-1">
+          <h3 className="px-2 text-[10px] font-semibold uppercase tracking-wider text-dim">
+            Repos
+          </h3>
+          <RepoList repos={repos} onToggleRepo={handleToggleRepo} />
+        </div>
+      )}
+
+      {/* Footer */}
+      <div className="mt-auto border-t border-border px-2 pt-2">
+        {username && (
+          <p className="truncate text-xs text-dim">{username}</p>
+        )}
+        <p className="text-[10px] text-dim/60">⌘K</p>
+      </div>
+    </nav>
+  );
+}

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -66,7 +66,9 @@ export function Sidebar(): ReactElement {
     toggleRepoMutation.mutate({ repoId, enabled });
   }
 
-  const workspaces = dashboard?.workspaces ?? [];
+  const workspaces = (dashboard?.workspaces ?? []).filter(
+    (ws) => ws.state !== "archived",
+  );
   const repos = reposQuery.data ?? [];
   const username = authQuery.data?.username ?? null;
 

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -12,7 +12,7 @@ import { RepoList } from "./RepoList";
 interface NavEntry {
   readonly label: string;
   readonly view: DashboardView;
-  readonly countKey?: "pendingReviews" | "openPrs" | "openIssues" | "activeWorkspaces";
+  readonly countKey?: "pendingReviews" | "openPrs" | "openIssues" | "activeWorkspaces" | "unreadActivity";
 }
 
 const NAV_ITEMS: readonly NavEntry[] = [
@@ -20,7 +20,7 @@ const NAV_ITEMS: readonly NavEntry[] = [
   { label: "To Review", view: "reviews", countKey: "pendingReviews" },
   { label: "My PRs", view: "mine", countKey: "openPrs" },
   { label: "Issues", view: "issues", countKey: "openIssues" },
-  { label: "Activity", view: "feed" },
+  { label: "Activity", view: "feed", countKey: "unreadActivity" },
   { label: "Workspaces", view: "workspaces", countKey: "activeWorkspaces" },
   { label: "Settings", view: "settings" },
 ];
@@ -48,6 +48,9 @@ export function Sidebar(): ReactElement {
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: ["repos"] });
     },
+    onError: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["repos"] });
+    },
   });
 
   function handleNavClick(view: DashboardView) {
@@ -63,9 +66,7 @@ export function Sidebar(): ReactElement {
     toggleRepoMutation.mutate({ repoId, enabled });
   }
 
-  const workspaces = (dashboard?.workspaces ?? []).filter(
-    (ws) => ws.state !== "archived",
-  );
+  const workspaces = dashboard?.workspaces ?? [];
   const repos = reposQuery.data ?? [];
   const username = authQuery.data?.username ?? null;
 

--- a/src/components/Sidebar/WorkspaceList.test.tsx
+++ b/src/components/Sidebar/WorkspaceList.test.tsx
@@ -26,17 +26,6 @@ const suspendedWs: Workspace = {
   updatedAt: "2026-03-28T09:00:00Z",
 };
 
-const archivedWs: Workspace = {
-  id: "ws-3",
-  repoId: "repo-1",
-  pullRequestNumber: 10,
-  state: "archived",
-  worktreePath: null,
-  sessionId: null,
-  createdAt: "2026-03-27T08:00:00Z",
-  updatedAt: "2026-03-27T08:00:00Z",
-};
-
 describe("WorkspaceList", () => {
   it("should render workspace entries", () => {
     render(
@@ -54,17 +43,6 @@ describe("WorkspaceList", () => {
     expect(dots).toHaveLength(2);
     expect(dots[0]).toHaveAttribute("data-state", "active");
     expect(dots[1]).toHaveAttribute("data-state", "suspended");
-  });
-
-  it("should not render archived workspaces", () => {
-    render(
-      <WorkspaceList
-        workspaces={[activeWs, archivedWs]}
-        onWorkspaceClick={vi.fn()}
-      />,
-    );
-    expect(screen.getByText(/PR #42/)).toBeInTheDocument();
-    expect(screen.queryByText(/PR #10/)).not.toBeInTheDocument();
   });
 
   it("should call onWorkspaceClick with workspace id on click", async () => {

--- a/src/components/Sidebar/WorkspaceList.test.tsx
+++ b/src/components/Sidebar/WorkspaceList.test.tsx
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { Workspace } from "../../lib/types";
+import { WorkspaceList } from "./WorkspaceList";
+
+const activeWs: Workspace = {
+  id: "ws-1",
+  repoId: "repo-1",
+  pullRequestNumber: 42,
+  state: "active",
+  worktreePath: "/tmp/ws-1",
+  sessionId: "session-1",
+  createdAt: "2026-03-28T10:00:00Z",
+  updatedAt: "2026-03-28T10:00:00Z",
+};
+
+const suspendedWs: Workspace = {
+  id: "ws-2",
+  repoId: "repo-2",
+  pullRequestNumber: 99,
+  state: "suspended",
+  worktreePath: "/tmp/ws-2",
+  sessionId: null,
+  createdAt: "2026-03-28T09:00:00Z",
+  updatedAt: "2026-03-28T09:00:00Z",
+};
+
+const archivedWs: Workspace = {
+  id: "ws-3",
+  repoId: "repo-1",
+  pullRequestNumber: 10,
+  state: "archived",
+  worktreePath: null,
+  sessionId: null,
+  createdAt: "2026-03-27T08:00:00Z",
+  updatedAt: "2026-03-27T08:00:00Z",
+};
+
+describe("WorkspaceList", () => {
+  it("should render workspace entries", () => {
+    render(
+      <WorkspaceList workspaces={[activeWs, suspendedWs]} onWorkspaceClick={vi.fn()} />,
+    );
+    expect(screen.getByText(/PR #42/)).toBeInTheDocument();
+    expect(screen.getByText(/PR #99/)).toBeInTheDocument();
+  });
+
+  it("should show workspace dots with state colors", () => {
+    const { container } = render(
+      <WorkspaceList workspaces={[activeWs, suspendedWs]} onWorkspaceClick={vi.fn()} />,
+    );
+    const dots = container.querySelectorAll("[data-state]");
+    expect(dots).toHaveLength(2);
+    expect(dots[0]).toHaveAttribute("data-state", "active");
+    expect(dots[1]).toHaveAttribute("data-state", "suspended");
+  });
+
+  it("should not render archived workspaces", () => {
+    render(
+      <WorkspaceList
+        workspaces={[activeWs, archivedWs]}
+        onWorkspaceClick={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/PR #42/)).toBeInTheDocument();
+    expect(screen.queryByText(/PR #10/)).not.toBeInTheDocument();
+  });
+
+  it("should call onWorkspaceClick with workspace id on click", async () => {
+    const handleClick = vi.fn();
+    render(
+      <WorkspaceList workspaces={[activeWs]} onWorkspaceClick={handleClick} />,
+    );
+    await userEvent.click(screen.getByText(/PR #42/));
+    expect(handleClick).toHaveBeenCalledWith("ws-1");
+  });
+
+  it("should render empty when no workspaces", () => {
+    const { container } = render(
+      <WorkspaceList workspaces={[]} onWorkspaceClick={vi.fn()} />,
+    );
+    expect(container.querySelectorAll("[data-state]")).toHaveLength(0);
+  });
+});

--- a/src/components/Sidebar/WorkspaceList.tsx
+++ b/src/components/Sidebar/WorkspaceList.tsx
@@ -16,11 +16,9 @@ export function WorkspaceList({
   workspaces,
   onWorkspaceClick,
 }: WorkspaceListProps): ReactElement {
-  const visible = workspaces.filter((ws) => ws.state !== "archived");
-
   return (
     <div className="flex flex-col gap-0.5">
-      {visible.map((ws) => (
+      {workspaces.map((ws) => (
         <button
           key={ws.id}
           type="button"

--- a/src/components/Sidebar/WorkspaceList.tsx
+++ b/src/components/Sidebar/WorkspaceList.tsx
@@ -1,0 +1,40 @@
+import type { ReactElement } from "react";
+import type { Workspace, WorkspaceState } from "../../lib/types";
+
+interface WorkspaceListProps {
+  readonly workspaces: readonly Workspace[];
+  readonly onWorkspaceClick: (workspaceId: string) => void;
+}
+
+const DOT_COLOR: Record<WorkspaceState, string> = {
+  active: "bg-green",
+  suspended: "bg-orange",
+  archived: "bg-dim",
+};
+
+export function WorkspaceList({
+  workspaces,
+  onWorkspaceClick,
+}: WorkspaceListProps): ReactElement {
+  const visible = workspaces.filter((ws) => ws.state !== "archived");
+
+  return (
+    <div className="flex flex-col gap-0.5">
+      {visible.map((ws) => (
+        <button
+          key={ws.id}
+          type="button"
+          onClick={() => onWorkspaceClick(ws.id)}
+          aria-label={`PR #${ws.pullRequestNumber} (${ws.state})`}
+          className="flex items-center gap-2 rounded px-2 py-1 text-left text-xs text-dim hover:bg-surface-hover hover:text-foreground"
+        >
+          <span
+            data-state={ws.state}
+            className={`inline-block h-2 w-2 shrink-0 rounded-full ${DOT_COLOR[ws.state]}`}
+          />
+          <span>PR #{ws.pullRequestNumber}</span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -1,3 +1,1 @@
-export function Sidebar() {
-  return <nav data-testid="sidebar">Sidebar</nav>;
-}
+export { Sidebar } from "./Sidebar";


### PR DESCRIPTION
## Summary

• 220px Sidebar with logo + tagline
• 7 navigation items (Overview, To Review, My PRs, Issues, Activity, Workspaces, Settings) with live badge counts from useGitHubData
• Workspace list with colored state dots (active=green, suspended=orange) + PR numbers; excludes archived
• Repo list with enable/disable checkboxes
• Footer with username + ⌘K shortcut

## Components

• **Sidebar.tsx**: Orchestrator with TanStack Query for repos/auth, Zustand integration for view switching
• **NavItem.tsx**: Nav button with count badge and aria-current highlighting
• **WorkspaceList.tsx**: List with colored state indicators, click to switch workspace
• **RepoList.tsx**: Checkboxes for repo enable/disable
• **index.tsx**: Barrel export

## Test Coverage

25 new tests (266 total passing)
• Rendering, click handlers, state management, accessibility
• All acceptance criteria from T-057 met

## Quality

• oxlint clean, no TypeScript errors
• Code review: no CRITICAL/HIGH issues
• Accessibility: aria-label on nav, aria-current on active item, semantic HTML

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a 220px Sidebar with navigation, live counts (including unread Activity), workspace status, repo toggles, and a footer. Meets Linear T-057 by delivering the full Sidebar UX with tested, accessible interactions.

- **New Features**
  - 7 nav items (Overview, To Review, My PRs, Issues, Activity, Workspaces, Settings) with live badges from useGitHubData; Activity shows unread count; active item uses aria-current.
  - Workspaces list with colored dots (active=green, suspended=orange); archived hidden; click selects a workspace and opens Workspaces view.
  - Repos list with enable/disable checkboxes; persists via setRepoEnabled with query invalidation using `@tanstack/react-query`.
  - Footer shows GitHub username and ⌘K; view state via `zustand`. 24 tests cover rendering and interactions.

- **Bug Fixes**
  - Added onError handling to repo toggle mutation to recover and refresh state.
  - Added aria-labels to repo checkboxes for better accessibility.
  - Centralized archived-workspace filtering in `Sidebar` to prevent empty Workspaces headers.

<sup>Written for commit 69c0cc8daf06a0e1cd27dc0ff844edd9b2442802. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a full Sidebar: navigation with active-state indicators and optional counters, workspace list with colored state dots and click-to-open behavior, repo list with enable/disable toggles, and a footer showing the signed-in user and shortcut hint.
* **Tests**
  * Added comprehensive component tests covering rendering, accessibility attributes, interactions, and repo/workspace toggles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->