### PR TITLE
feat(ui): add StatsBar component with 4 stats and sync time (T-058)

### DIFF
--- a/src/components/StatsBar/StatsBar.test.tsx
+++ b/src/components/StatsBar/StatsBar.test.tsx
@@ -122,7 +122,7 @@ describe("StatsBar", () => {
     expect(screen.getByText(/synced 2h ago/i)).toBeInTheDocument();
   });
 
-  it("should show 'never' when syncedAt is null", () => {
+  it("should show 'never synced' when syncedAt is null", () => {
     (useGitHubData as Mock).mockReturnValue({
       stats: MOCK_STATS,
       dashboard: { syncedAt: null },
@@ -132,6 +132,19 @@ describe("StatsBar", () => {
 
     render(<StatsBar />, { wrapper: createWrapper() });
 
-    expect(screen.getByText(/never/i)).toBeInTheDocument();
+    expect(screen.getByText(/never synced/i)).toBeInTheDocument();
+  });
+
+  it("should show 'never synced' when syncedAt is an invalid date", () => {
+    (useGitHubData as Mock).mockReturnValue({
+      stats: MOCK_STATS,
+      dashboard: { syncedAt: "not-a-date" },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<StatsBar />, { wrapper: createWrapper() });
+
+    expect(screen.getByText(/never synced/i)).toBeInTheDocument();
   });
 });

--- a/src/components/StatsBar/StatsBar.test.tsx
+++ b/src/components/StatsBar/StatsBar.test.tsx
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi, beforeEach, type Mock } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createElement, type ReactNode } from "react";
+import { StatsBar } from "./StatsBar";
+import type { DashboardStats } from "../../lib/types";
+
+vi.mock("../../hooks/useGitHubData", () => ({
+  useGitHubData: vi.fn(),
+}));
+
+import { useGitHubData } from "../../hooks/useGitHubData";
+
+const MOCK_STATS: DashboardStats = {
+  pendingReviews: 3,
+  openPrs: 5,
+  openIssues: 2,
+  activeWorkspaces: 1,
+  unreadActivity: 7,
+};
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe("StatsBar", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should render all 4 stats", () => {
+    (useGitHubData as Mock).mockReturnValue({
+      stats: MOCK_STATS,
+      dashboard: { syncedAt: "2026-03-28T10:00:00Z" },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<StatsBar />, { wrapper: createWrapper() });
+
+    expect(screen.getByText("3")).toBeInTheDocument();
+    expect(screen.getByText("5")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
+
+    expect(screen.getByText(/pending reviews/i)).toBeInTheDocument();
+    expect(screen.getByText(/open prs/i)).toBeInTheDocument();
+    expect(screen.getByText(/issues/i)).toBeInTheDocument();
+    expect(screen.getByText(/workspaces/i)).toBeInTheDocument();
+  });
+
+  it("should show synced time", () => {
+    (useGitHubData as Mock).mockReturnValue({
+      stats: MOCK_STATS,
+      dashboard: { syncedAt: new Date(Date.now() - 30_000).toISOString() },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<StatsBar />, { wrapper: createWrapper() });
+
+    expect(screen.getByText(/synced.*ago/i)).toBeInTheDocument();
+  });
+
+  it("should highlight pending reviews", () => {
+    (useGitHubData as Mock).mockReturnValue({
+      stats: MOCK_STATS,
+      dashboard: { syncedAt: "2026-03-28T10:00:00Z" },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<StatsBar />, { wrapper: createWrapper() });
+
+    const pendingValue = screen.getByTestId("stat-pending-reviews-value");
+    expect(pendingValue).toHaveClass("text-accent");
+  });
+
+  it("should show placeholder when stats are null", () => {
+    (useGitHubData as Mock).mockReturnValue({
+      stats: null,
+      dashboard: null,
+      isLoading: true,
+      error: null,
+    });
+
+    render(<StatsBar />, { wrapper: createWrapper() });
+
+    const values = screen.getAllByText("—");
+    expect(values.length).toBe(4);
+  });
+
+  it("should show minutes format when synced over 60s ago", () => {
+    (useGitHubData as Mock).mockReturnValue({
+      stats: MOCK_STATS,
+      dashboard: { syncedAt: new Date(Date.now() - 120_000).toISOString() },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<StatsBar />, { wrapper: createWrapper() });
+
+    expect(screen.getByText(/synced 2m ago/i)).toBeInTheDocument();
+  });
+
+  it("should show hours format when synced over 60m ago", () => {
+    (useGitHubData as Mock).mockReturnValue({
+      stats: MOCK_STATS,
+      dashboard: { syncedAt: new Date(Date.now() - 7_200_000).toISOString() },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<StatsBar />, { wrapper: createWrapper() });
+
+    expect(screen.getByText(/synced 2h ago/i)).toBeInTheDocument();
+  });
+
+  it("should show 'never' when syncedAt is null", () => {
+    (useGitHubData as Mock).mockReturnValue({
+      stats: MOCK_STATS,
+      dashboard: { syncedAt: null },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<StatsBar />, { wrapper: createWrapper() });
+
+    expect(screen.getByText(/never/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/StatsBar/StatsBar.tsx
+++ b/src/components/StatsBar/StatsBar.tsx
@@ -1,14 +1,17 @@
-import type { ReactElement } from "react";
+import { useState, useEffect, type ReactElement } from "react";
 import { useGitHubData } from "../../hooks/useGitHubData";
 
-function formatSyncedTime(syncedAt: string | null): string {
-  if (!syncedAt) return "never";
+const TICK_INTERVAL = 10_000;
 
-  const diffMs = Date.now() - new Date(syncedAt).getTime();
-  const diffSec = Math.floor(diffMs / 1000);
+function formatSyncedTime(syncedAt: string | null, now: number): string {
+  if (!syncedAt) return "never synced";
+
+  const syncedTime = new Date(syncedAt).getTime();
+  if (!Number.isFinite(syncedTime)) return "never synced";
+
+  const diffSec = Math.floor((now - syncedTime) / 1000);
 
   if (diffSec < 0) return "synced just now";
-
   if (diffSec < 60) return `synced ${diffSec}s ago`;
   const diffMin = Math.floor(diffSec / 60);
   if (diffMin < 60) return `synced ${diffMin}m ago`;
@@ -39,6 +42,12 @@ function StatItem({ label, value, testId, highlight }: StatItemProps): ReactElem
 
 export function StatsBar(): ReactElement {
   const { stats, dashboard } = useGitHubData();
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), TICK_INTERVAL);
+    return () => clearInterval(id);
+  }, []);
 
   const syncedAt = dashboard?.syncedAt ?? null;
 
@@ -70,7 +79,7 @@ export function StatsBar(): ReactElement {
           testId="stat-workspaces"
         />
       </div>
-      <span className="text-xs text-dim">{formatSyncedTime(syncedAt)}</span>
+      <span className="text-xs text-dim">{formatSyncedTime(syncedAt, now)}</span>
     </div>
   );
 }

--- a/src/components/StatsBar/StatsBar.tsx
+++ b/src/components/StatsBar/StatsBar.tsx
@@ -1,0 +1,76 @@
+import type { ReactElement } from "react";
+import { useGitHubData } from "../../hooks/useGitHubData";
+
+function formatSyncedTime(syncedAt: string | null): string {
+  if (!syncedAt) return "never";
+
+  const diffMs = Date.now() - new Date(syncedAt).getTime();
+  const diffSec = Math.floor(diffMs / 1000);
+
+  if (diffSec < 0) return "synced just now";
+
+  if (diffSec < 60) return `synced ${diffSec}s ago`;
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `synced ${diffMin}m ago`;
+  const diffHours = Math.floor(diffMin / 60);
+  return `synced ${diffHours}h ago`;
+}
+
+interface StatItemProps {
+  readonly label: string;
+  readonly value: number | null;
+  readonly testId: string;
+  readonly highlight?: boolean;
+}
+
+function StatItem({ label, value, testId, highlight }: StatItemProps): ReactElement {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span
+        data-testid={`${testId}-value`}
+        className={`text-lg font-bold leading-none ${highlight ? "text-accent" : "text-white"}`}
+      >
+        {value ?? "—"}
+      </span>
+      <span className="text-[10px] text-dim">{label}</span>
+    </div>
+  );
+}
+
+export function StatsBar(): ReactElement {
+  const { stats, dashboard } = useGitHubData();
+
+  const syncedAt = dashboard?.syncedAt ?? null;
+
+  return (
+    <div
+      data-testid="stats-bar"
+      className="flex items-center justify-between border-b border-border px-4 py-2"
+    >
+      <div className="flex items-center gap-6">
+        <StatItem
+          label="Pending Reviews"
+          value={stats?.pendingReviews ?? null}
+          testId="stat-pending-reviews"
+          highlight
+        />
+        <StatItem
+          label="Open PRs"
+          value={stats?.openPrs ?? null}
+          testId="stat-open-prs"
+        />
+        <StatItem
+          label="Issues"
+          value={stats?.openIssues ?? null}
+          testId="stat-issues"
+        />
+        <StatItem
+          label="Workspaces"
+          value={stats?.activeWorkspaces ?? null}
+          testId="stat-workspaces"
+        />
+      </div>
+      <span className="text-xs text-dim">{formatSyncedTime(syncedAt)}</span>
+    </div>
+  );
+}

--- a/src/components/StatsBar/index.ts
+++ b/src/components/StatsBar/index.ts
@@ -1,0 +1,1 @@
+export { StatsBar } from "./StatsBar";


### PR DESCRIPTION
## Summary

• Add new `StatsBar` component displaying 4 key stats: Pending Reviews (highlighted in accent color), Open PRs, Issues, Active Workspaces
• Display sync timestamp ("synced Xs ago") with support for seconds, minutes, and hours
• Comprehensive test coverage (7 tests) including edge cases: loading state, null syncedAt, time format transitions
• Full oxlint compliance, no TypeScript errors

## Type

feat

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new StatsBar UI that shows four dashboard stats (Pending Reviews, Open PRs, Issues, Workspaces) and a "synced X ago" timestamp.
Implements T-058 with accent highlighting for pending reviews, graceful loading, auto-refreshing sync time (every 10s), and consistent "never synced" handling for missing or invalid dates.

<sup>Written for commit edd32263e53554e7836f6fe19917e8246f3b4de7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added StatsBar showing four metrics: Pending Reviews (highlighted), Open PRs, Issues, and Workspaces.
  * Shows relative "synced" time (just now / Xm ago / Xh ago), updates live, and displays "never synced" for missing/invalid timestamps.
  * Graceful loading state with placeholder em dashes for missing data.

* **Tests**
  * Added comprehensive test suite covering rendering, sync time formatting, loading, and highlight behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->