### PR TITLE
feat(ui): add Settings component (T-060)

### DIFF
--- a/src/components/Settings/Settings.test.tsx
+++ b/src/components/Settings/Settings.test.tsx
@@ -1,5 +1,5 @@
 import { type ReactElement } from "react";
-import { render, screen, within } from "@testing-library/react";
+import { render, screen, within, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { describe, expect, it, vi, beforeEach } from "vitest";
@@ -87,7 +87,7 @@ function setupMocks(
 let Settings: () => ReactElement;
 
 beforeEach(async () => {
-  vi.restoreAllMocks();
+  vi.clearAllMocks();
   const mod = await import("./Settings");
   Settings = mod.Settings;
 });
@@ -156,6 +156,16 @@ describe("Settings", () => {
     expect(await screen.findByText(/not connected/i)).toBeInTheDocument();
   });
 
+  it("should show checking state while auth is loading", async () => {
+    mockedGetConfig.mockResolvedValue(makeConfig());
+    mockedListRepos.mockResolvedValue([]);
+    mockedAuthGetStatus.mockReturnValue(new Promise(() => {}));
+
+    renderWithProviders(<Settings />);
+
+    expect(await screen.findByText(/checking/i)).toBeInTheDocument();
+  });
+
   it("should call config_set on poll interval change", async () => {
     const user = userEvent.setup();
     const updatedConfig = makeConfig({ pollIntervalSecs: 120 });
@@ -170,6 +180,21 @@ describe("Settings", () => {
     await user.tab();
 
     expect(mockedSetConfig).toHaveBeenCalledWith({ pollIntervalSecs: 120 });
+  });
+
+  it("should reject values below minimum", async () => {
+    const user = userEvent.setup();
+    setupMocks();
+
+    renderWithProviders(<Settings />);
+
+    const input = await screen.findByLabelText(/poll interval/i);
+    await user.clear(input);
+    await user.type(input, "0");
+    await user.tab();
+
+    expect(mockedSetConfig).not.toHaveBeenCalled();
+    expect(input).toHaveValue(300);
   });
 
   it("should call config_set on max workspaces change", async () => {
@@ -228,5 +253,56 @@ describe("Settings", () => {
     renderWithProviders(<Settings />);
 
     expect(await screen.findByText(/failed to load/i)).toBeInTheDocument();
+  });
+
+  it("should show loading state for repos section while fetching", async () => {
+    mockedGetConfig.mockResolvedValue(makeConfig());
+    mockedListRepos.mockReturnValue(new Promise(() => {}));
+    mockedAuthGetStatus.mockResolvedValue(makeAuthStatus());
+
+    renderWithProviders(<Settings />);
+
+    expect(await screen.findByText(/loading repositories/i)).toBeInTheDocument();
+  });
+
+  it("should show error when repos fetch fails", async () => {
+    mockedGetConfig.mockResolvedValue(makeConfig());
+    mockedListRepos.mockRejectedValue(new Error("Network error"));
+    mockedAuthGetStatus.mockResolvedValue(makeAuthStatus());
+
+    renderWithProviders(<Settings />);
+
+    expect(await screen.findByText(/failed to load repositories/i)).toBeInTheDocument();
+  });
+
+  it("should show save error when config mutation fails", async () => {
+    const user = userEvent.setup();
+    setupMocks();
+    mockedSetConfig.mockRejectedValue(new Error("DB locked"));
+
+    renderWithProviders(<Settings />);
+
+    const input = await screen.findByLabelText(/poll interval/i);
+    await user.clear(input);
+    await user.type(input, "120");
+    await user.tab();
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/failed to save/i);
+  });
+
+  it("should reset draft to original value when config mutation fails", async () => {
+    const user = userEvent.setup();
+    setupMocks(makeConfig({ pollIntervalSecs: 300 }));
+    mockedSetConfig.mockRejectedValue(new Error("DB locked"));
+
+    renderWithProviders(<Settings />);
+
+    const input = await screen.findByLabelText(/poll interval/i);
+    await user.clear(input);
+    await user.type(input, "120");
+    await user.tab();
+
+    await screen.findByRole("alert");
+    await waitFor(() => expect(input).toHaveValue(300));
   });
 });

--- a/src/components/Settings/Settings.test.tsx
+++ b/src/components/Settings/Settings.test.tsx
@@ -1,0 +1,232 @@
+import { type ReactElement } from "react";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { AppConfig, AuthStatus, Repo } from "../../lib/types";
+
+vi.mock("../../lib/tauri", () => ({
+  getConfig: vi.fn(),
+  setConfig: vi.fn(),
+  listRepos: vi.fn(),
+  setRepoEnabled: vi.fn(),
+  authGetStatus: vi.fn(),
+}));
+
+import {
+  getConfig,
+  setConfig,
+  listRepos,
+  setRepoEnabled,
+  authGetStatus,
+} from "../../lib/tauri";
+
+const mockedGetConfig = vi.mocked(getConfig);
+const mockedSetConfig = vi.mocked(setConfig);
+const mockedListRepos = vi.mocked(listRepos);
+const mockedSetRepoEnabled = vi.mocked(setRepoEnabled);
+const mockedAuthGetStatus = vi.mocked(authGetStatus);
+
+function renderWithProviders(ui: ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  );
+}
+
+function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
+  return {
+    pollIntervalSecs: 300,
+    maxActiveWorkspaces: 3,
+    githubToken: "test-token",
+    dataDir: null,
+    workspacesDir: null,
+    ...overrides,
+  };
+}
+
+function makeAuthStatus(overrides: Partial<AuthStatus> = {}): AuthStatus {
+  return {
+    connected: true,
+    username: "matvei",
+    error: null,
+    ...overrides,
+  };
+}
+
+function makeRepo(n: number, overrides: Partial<Repo> = {}): Repo {
+  return {
+    id: `repo-${n}`,
+    org: "org",
+    name: `repo-${n}`,
+    fullName: `org/repo-${n}`,
+    url: `https://github.com/org/repo-${n}`,
+    defaultBranch: "main",
+    isArchived: false,
+    enabled: true,
+    localPath: null,
+    lastSyncAt: null,
+    ...overrides,
+  };
+}
+
+function setupMocks(
+  config: AppConfig = makeConfig(),
+  repos: Repo[] = [makeRepo(1), makeRepo(2)],
+  auth: AuthStatus = makeAuthStatus(),
+) {
+  mockedGetConfig.mockResolvedValue(config);
+  mockedListRepos.mockResolvedValue(repos);
+  mockedAuthGetStatus.mockResolvedValue(auth);
+  mockedSetConfig.mockResolvedValue(config);
+}
+
+// Lazy import so mocks are set up before module loads
+let Settings: () => ReactElement;
+
+beforeEach(async () => {
+  vi.restoreAllMocks();
+  const mod = await import("./Settings");
+  Settings = mod.Settings;
+});
+
+describe("Settings", () => {
+  it("should render all config sections", async () => {
+    setupMocks();
+
+    renderWithProviders(<Settings />);
+
+    expect(await screen.findByTestId("settings-github")).toBeInTheDocument();
+    expect(screen.getByTestId("settings-workspaces")).toBeInTheDocument();
+    expect(screen.getByTestId("settings-repos")).toBeInTheDocument();
+  });
+
+  it("should show loading state while config is fetching", () => {
+    mockedGetConfig.mockReturnValue(new Promise(() => {}));
+    mockedListRepos.mockReturnValue(new Promise(() => {}));
+    mockedAuthGetStatus.mockReturnValue(new Promise(() => {}));
+
+    renderWithProviders(<Settings />);
+
+    expect(screen.getByText(/loading/i)).toBeInTheDocument();
+  });
+
+  it("should display poll interval value from config", async () => {
+    setupMocks(makeConfig({ pollIntervalSecs: 600 }));
+
+    renderWithProviders(<Settings />);
+
+    const input = await screen.findByLabelText(/poll interval/i);
+    expect(input).toHaveValue(600);
+  });
+
+  it("should display max active workspaces from config", async () => {
+    setupMocks(makeConfig({ maxActiveWorkspaces: 5 }));
+
+    renderWithProviders(<Settings />);
+
+    const input = await screen.findByLabelText(/max active/i);
+    expect(input).toHaveValue(5);
+  });
+
+  it("should display auth status when connected", async () => {
+    setupMocks(
+      makeConfig(),
+      [],
+      makeAuthStatus({ connected: true, username: "alice" }),
+    );
+
+    renderWithProviders(<Settings />);
+
+    expect(await screen.findByText(/alice/)).toBeInTheDocument();
+    expect(screen.getByText(/connected/i)).toBeInTheDocument();
+  });
+
+  it("should display disconnected auth status", async () => {
+    setupMocks(
+      makeConfig({ githubToken: null }),
+      [],
+      makeAuthStatus({ connected: false, username: null }),
+    );
+
+    renderWithProviders(<Settings />);
+
+    expect(await screen.findByText(/not connected/i)).toBeInTheDocument();
+  });
+
+  it("should call config_set on poll interval change", async () => {
+    const user = userEvent.setup();
+    const updatedConfig = makeConfig({ pollIntervalSecs: 120 });
+    setupMocks();
+    mockedSetConfig.mockResolvedValue(updatedConfig);
+
+    renderWithProviders(<Settings />);
+
+    const input = await screen.findByLabelText(/poll interval/i);
+    await user.clear(input);
+    await user.type(input, "120");
+    await user.tab();
+
+    expect(mockedSetConfig).toHaveBeenCalledWith({ pollIntervalSecs: 120 });
+  });
+
+  it("should call config_set on max workspaces change", async () => {
+    const user = userEvent.setup();
+    const updatedConfig = makeConfig({ maxActiveWorkspaces: 5 });
+    setupMocks();
+    mockedSetConfig.mockResolvedValue(updatedConfig);
+
+    renderWithProviders(<Settings />);
+
+    const input = await screen.findByLabelText(/max active/i);
+    await user.clear(input);
+    await user.type(input, "5");
+    await user.tab();
+
+    expect(mockedSetConfig).toHaveBeenCalledWith({ maxActiveWorkspaces: 5 });
+  });
+
+  it("should show repos with toggle", async () => {
+    setupMocks(makeConfig(), [
+      makeRepo(1, { name: "frontend", enabled: true }),
+      makeRepo(2, { name: "backend", enabled: false }),
+    ]);
+
+    renderWithProviders(<Settings />);
+
+    expect(await screen.findByText("frontend")).toBeInTheDocument();
+    expect(screen.getByText("backend")).toBeInTheDocument();
+
+    const reposSection = screen.getByTestId("settings-repos");
+    const toggles = within(reposSection).getAllByRole("checkbox");
+    expect(toggles).toHaveLength(2);
+    expect(toggles[0]).toBeChecked();
+    expect(toggles[1]).not.toBeChecked();
+  });
+
+  it("should call setRepoEnabled when repo toggle is clicked", async () => {
+    const user = userEvent.setup();
+    const repo = makeRepo(1, { name: "frontend", enabled: true });
+    setupMocks(makeConfig(), [repo]);
+    mockedSetRepoEnabled.mockResolvedValue({ ...repo, enabled: false });
+
+    renderWithProviders(<Settings />);
+
+    const toggle = await screen.findByRole("checkbox");
+    await user.click(toggle);
+
+    expect(mockedSetRepoEnabled).toHaveBeenCalledWith("repo-1", false);
+  });
+
+  it("should show error state when config fetch fails", async () => {
+    mockedGetConfig.mockRejectedValue(new Error("DB error"));
+    mockedListRepos.mockResolvedValue([]);
+    mockedAuthGetStatus.mockResolvedValue(makeAuthStatus());
+
+    renderWithProviders(<Settings />);
+
+    expect(await screen.findByText(/failed to load/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -1,0 +1,178 @@
+import { useEffect, useState, type ReactElement } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  getConfig,
+  setConfig,
+  listRepos,
+  setRepoEnabled,
+  authGetStatus,
+} from "../../lib/tauri";
+import type { PartialAppConfig, Repo } from "../../lib/types";
+
+function useConfigQuery() {
+  return useQuery({ queryKey: ["config"], queryFn: getConfig });
+}
+
+function useReposQuery() {
+  return useQuery({ queryKey: ["repos"], queryFn: listRepos });
+}
+
+function useAuthQuery() {
+  return useQuery({ queryKey: ["auth", "status"], queryFn: authGetStatus });
+}
+
+interface NumberFieldProps {
+  readonly label: string;
+  readonly value: number;
+  readonly min?: number;
+  readonly onCommit: (value: number) => void;
+}
+
+function NumberField({ label, value, min = 1, onCommit }: NumberFieldProps): ReactElement {
+  const [draft, setDraft] = useState(String(value));
+
+  useEffect(() => {
+    setDraft(String(value));
+  }, [value]);
+
+  function handleBlur(): void {
+    const parsed = Number(draft);
+    if (!Number.isNaN(parsed) && parsed >= min && parsed !== value) {
+      onCommit(parsed);
+    } else {
+      setDraft(String(value));
+    }
+  }
+
+  return (
+    <label className="flex items-center justify-between gap-4">
+      <span className="text-dim text-sm">{label}</span>
+      <input
+        type="number"
+        min={min}
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={handleBlur}
+        className="bg-surface border-border w-24 rounded border px-2 py-1 font-mono text-sm text-white"
+      />
+    </label>
+  );
+}
+
+interface RepoRowProps {
+  readonly repo: Repo;
+  readonly onToggle: (repoId: string, enabled: boolean) => void;
+}
+
+function RepoRow({ repo, onToggle }: RepoRowProps): ReactElement {
+  return (
+    <label className="flex items-center justify-between gap-3 py-1">
+      <span className="min-w-0 truncate font-mono text-sm text-white">{repo.name}</span>
+      <input
+        type="checkbox"
+        checked={repo.enabled}
+        onChange={() => onToggle(repo.id, !repo.enabled)}
+        className="accent-accent h-4 w-4"
+      />
+    </label>
+  );
+}
+
+export function Settings(): ReactElement {
+  const queryClient = useQueryClient();
+  const configQuery = useConfigQuery();
+  const reposQuery = useReposQuery();
+  const authQuery = useAuthQuery();
+
+  const configMutation = useMutation({
+    mutationFn: (partial: PartialAppConfig) => setConfig(partial),
+    onSuccess: (updated) => {
+      queryClient.setQueryData(["config"], updated);
+    },
+    onError: (err: unknown) => {
+      console.error("[Settings] config update failed:", err);
+    },
+  });
+
+  const repoToggleMutation = useMutation({
+    mutationFn: ({ repoId, enabled }: { repoId: string; enabled: boolean }) =>
+      setRepoEnabled(repoId, enabled),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["repos"] });
+    },
+    onError: (err: unknown) => {
+      console.error("[Settings] repo toggle failed:", err);
+    },
+  });
+
+  if (configQuery.error && !configQuery.data) {
+    return (
+      <div data-testid="settings" className="flex h-full items-center justify-center text-dim">
+        Failed to load settings
+      </div>
+    );
+  }
+
+  if (!configQuery.data) {
+    return (
+      <div data-testid="settings" className="flex h-full items-center justify-center text-dim">
+        Loading...
+      </div>
+    );
+  }
+
+  const config = configQuery.data;
+  const repos = reposQuery.data ?? [];
+  const auth = authQuery.data;
+
+  return (
+    <section data-testid="settings" className="flex h-full flex-col gap-6 overflow-y-auto p-4">
+      <h1 className="text-lg font-semibold text-white">Settings</h1>
+
+      <div data-testid="settings-github" className="flex flex-col gap-3">
+        <h2 className="text-accent text-sm font-semibold uppercase tracking-wider">GitHub</h2>
+        <NumberField
+          label="Poll interval (seconds)"
+          value={config.pollIntervalSecs}
+          onCommit={(v) => configMutation.mutate({ pollIntervalSecs: v })}
+        />
+        <div className="flex items-center justify-between text-sm">
+          <span className="text-dim">Auth status</span>
+          {auth?.connected ? (
+            <span className="text-green-400">Connected — {auth.username}</span>
+          ) : (
+            <span className="text-red-400">Not connected</span>
+          )}
+        </div>
+      </div>
+
+      <div data-testid="settings-workspaces" className="flex flex-col gap-3">
+        <h2 className="text-accent text-sm font-semibold uppercase tracking-wider">Workspaces</h2>
+        <NumberField
+          label="Max active workspaces"
+          value={config.maxActiveWorkspaces}
+          onCommit={(v) => configMutation.mutate({ maxActiveWorkspaces: v })}
+        />
+      </div>
+
+      <div data-testid="settings-repos" className="flex flex-col gap-3">
+        <h2 className="text-accent text-sm font-semibold uppercase tracking-wider">Repositories</h2>
+        {repos.length === 0 ? (
+          <span className="text-dim text-sm">No repositories synced</span>
+        ) : (
+          <div className="flex flex-col gap-1">
+            {repos.map((repo) => (
+              <RepoRow
+                key={repo.id}
+                repo={repo}
+                onToggle={(repoId, enabled) =>
+                  repoToggleMutation.mutate({ repoId, enabled })
+                }
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -109,6 +109,7 @@ export function Settings(): ReactElement {
     mutationFn: ({ repoId, enabled }: { repoId: string; enabled: boolean }) =>
       setRepoEnabled(repoId, enabled),
     onSuccess: () => {
+      setSaveError(null);
       queryClient.invalidateQueries({ queryKey: ["repos"] });
     },
     onError: (err: unknown) => {

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -25,19 +25,20 @@ interface NumberFieldProps {
   readonly label: string;
   readonly value: number;
   readonly min?: number;
+  readonly resetKey: number;
   readonly onCommit: (value: number) => void;
 }
 
-function NumberField({ label, value, min = 1, onCommit }: NumberFieldProps): ReactElement {
+function NumberField({ label, value, min = 1, resetKey, onCommit }: NumberFieldProps): ReactElement {
   const [draft, setDraft] = useState(String(value));
 
   useEffect(() => {
     setDraft(String(value));
-  }, [value]);
+  }, [value, resetKey]);
 
   function handleBlur(): void {
     const parsed = Number(draft);
-    if (!Number.isNaN(parsed) && parsed >= min && parsed !== value) {
+    if (Number.isInteger(parsed) && parsed >= min && parsed !== value) {
       onCommit(parsed);
     } else {
       setDraft(String(value));
@@ -50,6 +51,7 @@ function NumberField({ label, value, min = 1, onCommit }: NumberFieldProps): Rea
       <input
         type="number"
         min={min}
+        step={1}
         value={draft}
         onChange={(e) => setDraft(e.target.value)}
         onBlur={handleBlur}
@@ -61,16 +63,18 @@ function NumberField({ label, value, min = 1, onCommit }: NumberFieldProps): Rea
 
 interface RepoRowProps {
   readonly repo: Repo;
+  readonly disabled: boolean;
   readonly onToggle: (repoId: string, enabled: boolean) => void;
 }
 
-function RepoRow({ repo, onToggle }: RepoRowProps): ReactElement {
+function RepoRow({ repo, disabled, onToggle }: RepoRowProps): ReactElement {
   return (
     <label className="flex items-center justify-between gap-3 py-1">
       <span className="min-w-0 truncate font-mono text-sm text-white">{repo.name}</span>
       <input
         type="checkbox"
         checked={repo.enabled}
+        disabled={disabled}
         onChange={() => onToggle(repo.id, !repo.enabled)}
         className="accent-accent h-4 w-4"
       />
@@ -83,14 +87,21 @@ export function Settings(): ReactElement {
   const configQuery = useConfigQuery();
   const reposQuery = useReposQuery();
   const authQuery = useAuthQuery();
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [resetKey, setResetKey] = useState(0);
 
   const configMutation = useMutation({
     mutationFn: (partial: PartialAppConfig) => setConfig(partial),
+    onMutate: () => {
+      setSaveError(null);
+    },
     onSuccess: (updated) => {
       queryClient.setQueryData(["config"], updated);
     },
     onError: (err: unknown) => {
       console.error("[Settings] config update failed:", err);
+      setSaveError("Failed to save setting. Please retry.");
+      setResetKey((k) => k + 1);
     },
   });
 
@@ -102,6 +113,7 @@ export function Settings(): ReactElement {
     },
     onError: (err: unknown) => {
       console.error("[Settings] repo toggle failed:", err);
+      setSaveError("Failed to toggle repository. Please retry.");
     },
   });
 
@@ -122,24 +134,29 @@ export function Settings(): ReactElement {
   }
 
   const config = configQuery.data;
-  const repos = reposQuery.data ?? [];
-  const auth = authQuery.data;
 
   return (
     <section data-testid="settings" className="flex h-full flex-col gap-6 overflow-y-auto p-4">
       <h1 className="text-lg font-semibold text-white">Settings</h1>
+
+      {saveError ? (
+        <p role="alert" className="text-sm text-red-400">{saveError}</p>
+      ) : null}
 
       <div data-testid="settings-github" className="flex flex-col gap-3">
         <h2 className="text-accent text-sm font-semibold uppercase tracking-wider">GitHub</h2>
         <NumberField
           label="Poll interval (seconds)"
           value={config.pollIntervalSecs}
+          resetKey={resetKey}
           onCommit={(v) => configMutation.mutate({ pollIntervalSecs: v })}
         />
         <div className="flex items-center justify-between text-sm">
           <span className="text-dim">Auth status</span>
-          {auth?.connected ? (
-            <span className="text-green-400">Connected — {auth.username}</span>
+          {authQuery.isLoading ? (
+            <span className="text-dim">Checking...</span>
+          ) : authQuery.data?.connected ? (
+            <span className="text-green-400">Connected — {authQuery.data.username}</span>
           ) : (
             <span className="text-red-400">Not connected</span>
           )}
@@ -151,20 +168,26 @@ export function Settings(): ReactElement {
         <NumberField
           label="Max active workspaces"
           value={config.maxActiveWorkspaces}
+          resetKey={resetKey}
           onCommit={(v) => configMutation.mutate({ maxActiveWorkspaces: v })}
         />
       </div>
 
       <div data-testid="settings-repos" className="flex flex-col gap-3">
         <h2 className="text-accent text-sm font-semibold uppercase tracking-wider">Repositories</h2>
-        {repos.length === 0 ? (
+        {reposQuery.isLoading ? (
+          <span className="text-dim text-sm">Loading repositories...</span>
+        ) : reposQuery.error ? (
+          <span className="text-sm text-red-400">Failed to load repositories</span>
+        ) : (reposQuery.data ?? []).length === 0 ? (
           <span className="text-dim text-sm">No repositories synced</span>
         ) : (
           <div className="flex flex-col gap-1">
-            {repos.map((repo) => (
+            {(reposQuery.data ?? []).map((repo) => (
               <RepoRow
                 key={repo.id}
                 repo={repo}
+                disabled={repoToggleMutation.isPending}
                 onToggle={(repoId, enabled) =>
                   repoToggleMutation.mutate({ repoId, enabled })
                 }

--- a/src/components/Settings/index.ts
+++ b/src/components/Settings/index.ts
@@ -1,0 +1,1 @@
+export { Settings } from "./Settings";

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -1,3 +1,0 @@
-export function Settings() {
-  return <section data-testid="settings">Settings</section>;
-}


### PR DESCRIPTION
## Summary
- Add `Settings` component with 3 sections: GitHub (poll interval + auth status), Workspaces (max active), Repositories (list with enable/disable toggles)
- Uses TanStack Query for data fetching (`getConfig`, `listRepos`, `authGetStatus`) and `useMutation` for updates (`setConfig`, `setRepoEnabled`)
- NumberField sub-component with edit-on-blur pattern, syncs draft state with server-confirmed values
- Proper error handling on mutations, input validation with min bounds
- Replaces stub `index.tsx` with proper `index.ts` re-export + `Settings.tsx`

## Test plan
- [x] 11 tests covering all sections rendering, config mutation calls, repo toggles, loading/error states
- [x] 298/298 tests pass (zero regressions)
- [x] TypeScript strict mode — zero errors
- [x] oxlint — zero warnings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the `Settings` component for T-060 so users can edit poll interval, set max active workspaces, and toggle repositories, with clear auth status and solid loading/error handling.

- **New Features**
  - Sections: GitHub (poll interval + auth), Workspaces (max active), Repositories (enable/disable).
  - Uses `@tanstack/react-query` to fetch `getConfig`, `listRepos`, `authGetStatus` and update via `setConfig`, `setRepoEnabled`; updates config cache and invalidates repos.
  - Number inputs save on blur with min validation; rollback and alert on failed saves.
  - Disables repo toggles while saving; explicit loading states for repos and auth (“Checking…”).

- **Bug Fixes**
  - Clear save error after a successful repo toggle retry.

<sup>Written for commit f0f11fcecae3625a2ec073f6cc7c85ca60363000. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Settings page to view/edit GitHub poll interval and max active workspaces, view auth status, and enable/disable repositories.

* **Tests**
  * Added component tests covering loading/error states, auth connected/disconnected/checking views, config input validation and save-error/reset behavior, repository list rendering and toggle behavior, and retry/error handling for mutations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->