### PR TITLE
feat(notifications): implement notification emission module (T-061)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -98,6 +98,137 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,6 +370,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -969,6 +1113,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "env_filter"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1024,6 +1195,16 @@ checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
  "concurrent-queue",
  "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
  "pin-project-lite",
 ]
 
@@ -1207,6 +1388,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1686,6 +1880,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2322,6 +2522,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
+name = "mac-notification-sys"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29a16783dd1a47849b8c8133c9cd3eb2112cfbc6901670af3dba47c8bbfb07d3"
+dependencies = [
+ "cc",
+ "objc2",
+ "objc2-foundation",
+ "time",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2504,6 +2716,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
+name = "notify-rust"
+version = "4.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21af20a1b50be5ac5861f74af1a863da53a11c38684d9818d82f1c42f7fdc6c2"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
+]
+
+[[package]]
 name = "num-bigint-dig"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2656,6 +2882,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2726,6 +2953,16 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "pango"
@@ -2996,6 +3233,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3036,7 +3284,7 @@ checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.13.0",
- "quick-xml",
+ "quick-xml 0.38.4",
  "serde",
  "time",
 ]
@@ -3052,6 +3300,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3103,6 +3365,7 @@ dependencies = [
  "keyring",
  "log",
  "mockito",
+ "notify-rust",
  "reqwest",
  "serde",
  "serde_json",
@@ -3202,6 +3465,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -4095,6 +4367,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4894,6 +5176,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-winrt-notification"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
+dependencies = [
+ "quick-xml 0.37.5",
+ "thiserror 2.0.18",
+ "windows",
+ "windows-version",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5307,6 +5601,17 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unic-char-property"
@@ -6310,6 +6615,9 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"
@@ -6522,6 +6830,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca82f95dbd3943a40a53cfded6c2d0a2ca26192011846a1810c4256ef92c60bc"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 0.7.15",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897e79616e84aac4b2c46e9132a4f63b93105d54fe8c0e8f6bffc21fa8d49222"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
+dependencies = [
+ "serde",
+ "winnow 0.7.15",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6606,3 +6975,43 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zvariant"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5708299b21903bbe348e94729f22c49c55d04720a004aa350f1f9c122fd2540b"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 0.7.15",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b59b012ebe9c46656f9cc08d8da8b4c726510aef12559da3e5f1bf72780752c"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f75c23a64ef8f40f13a6989991e643554d9bef1d682a281160cf0c1bc389c5e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
+ "winnow 0.7.15",
+]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,6 +29,7 @@ keyring = "3.6.3"
 reqwest = { version = "0.13.2", features = ["json"] }
 tokio = { version = "1.50.0", features = ["rt", "time"] }
 graphql_client = { version = "0.16.0", features = ["graphql_query_derive"] }
+notify-rust = "4.12.0"
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/src-tauri/src/cache/notifications.rs
+++ b/src-tauri/src/cache/notifications.rs
@@ -50,6 +50,57 @@ pub async fn mark_notified(
     Ok(())
 }
 
+/// Atomically claim a notification slot.
+///
+/// Inserts into `notification_log` with `ON CONFLICT DO NOTHING` and
+/// returns `true` if the row was newly inserted (i.e. the caller "won"
+/// the claim). Returns `false` if the event was already recorded.
+///
+/// This eliminates the TOCTOU race between `has_been_notified` and
+/// `mark_notified` — a single INSERT is atomic at the `SQLite` level.
+#[allow(dead_code)] // Called from notifications module; call-site integration deferred
+pub async fn try_claim_notification(
+    pool: &SqlitePool,
+    event_type: &str,
+    event_id: &str,
+) -> Result<bool, AppError> {
+    let id = Uuid::new_v4().to_string();
+    let now = Utc::now().to_rfc3339();
+
+    let result = sqlx::query(
+        "INSERT INTO notification_log (id, event_type, event_id, notified_at) \
+         VALUES ($1, $2, $3, $4) \
+         ON CONFLICT(event_type, event_id) DO NOTHING",
+    )
+    .bind(&id)
+    .bind(event_type)
+    .bind(event_id)
+    .bind(&now)
+    .execute(pool)
+    .await?;
+
+    Ok(result.rows_affected() > 0)
+}
+
+/// Remove a notification entry, allowing the event to re-trigger.
+///
+/// Used for transient events like CI failures that can recur after
+/// the underlying condition is resolved and then re-appears.
+#[allow(dead_code)] // Called from notifications module; call-site integration deferred
+pub async fn clear_notification(
+    pool: &SqlitePool,
+    event_type: &str,
+    event_id: &str,
+) -> Result<(), AppError> {
+    sqlx::query("DELETE FROM notification_log WHERE event_type = $1 AND event_id = $2")
+        .bind(event_type)
+        .bind(event_id)
+        .execute(pool)
+        .await?;
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -121,6 +172,47 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(count.0, 1, "dedup should prevent duplicate rows");
+
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_try_claim_notification_returns_true_on_first_insert() {
+        let (pool, _tmp) = test_pool().await;
+
+        let claimed = try_claim_notification(&pool, "review_request", "pr-1")
+            .await
+            .unwrap();
+        assert!(claimed, "first claim should succeed");
+
+        let claimed_again = try_claim_notification(&pool, "review_request", "pr-1")
+            .await
+            .unwrap();
+        assert!(!claimed_again, "second claim should return false");
+
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_clear_notification_allows_reclaim() {
+        let (pool, _tmp) = test_pool().await;
+
+        // Claim
+        let claimed = try_claim_notification(&pool, "ci_failure", "pr-1")
+            .await
+            .unwrap();
+        assert!(claimed);
+
+        // Clear
+        clear_notification(&pool, "ci_failure", "pr-1")
+            .await
+            .unwrap();
+
+        // Re-claim should succeed
+        let reclaimed = try_claim_notification(&pool, "ci_failure", "pr-1")
+            .await
+            .unwrap();
+        assert!(reclaimed, "should be able to reclaim after clearing");
 
         pool.close().await;
     }

--- a/src-tauri/src/cache/notifications.rs
+++ b/src-tauri/src/cache/notifications.rs
@@ -5,7 +5,6 @@ use uuid::Uuid;
 use crate::error::AppError;
 
 /// Check whether a notification has already been sent for the given event.
-#[allow(dead_code)]
 pub async fn has_been_notified(
     pool: &SqlitePool,
     event_type: &str,
@@ -26,7 +25,6 @@ pub async fn has_been_notified(
 /// Deduplication is enforced by the `UNIQUE(event_type, event_id)`
 /// constraint via `ON CONFLICT ... DO NOTHING`. The PK is a random
 /// UUID to avoid any separator-collision risk with composite keys.
-#[allow(dead_code)]
 pub async fn mark_notified(
     pool: &SqlitePool,
     event_type: &str,

--- a/src-tauri/src/cache/notifications.rs
+++ b/src-tauri/src/cache/notifications.rs
@@ -5,6 +5,7 @@ use uuid::Uuid;
 use crate::error::AppError;
 
 /// Check whether a notification has already been sent for the given event.
+#[allow(dead_code)] // Called from notifications module; call-site integration deferred
 pub async fn has_been_notified(
     pool: &SqlitePool,
     event_type: &str,
@@ -25,6 +26,7 @@ pub async fn has_been_notified(
 /// Deduplication is enforced by the `UNIQUE(event_type, event_id)`
 /// constraint via `ON CONFLICT ... DO NOTHING`. The PK is a random
 /// UUID to avoid any separator-collision risk with composite keys.
+#[allow(dead_code)] // Called from notifications module; call-site integration deferred
 pub async fn mark_notified(
     pool: &SqlitePool,
     event_type: &str,

--- a/src-tauri/src/cache/notifications.rs
+++ b/src-tauri/src/cache/notifications.rs
@@ -101,6 +101,43 @@ pub async fn clear_notification(
     Ok(())
 }
 
+/// Remove all notification entries of a given type whose `event_id` is NOT
+/// in the provided set of current IDs.
+///
+/// Used to clear stale `review_request` entries when PRs leave the
+/// review queue, so re-requests naturally re-trigger notifications.
+#[allow(dead_code)] // Called from notifications module; call-site integration deferred
+pub async fn clear_stale_notifications(
+    pool: &SqlitePool,
+    event_type: &str,
+    current_ids: &[&str],
+) -> Result<(), AppError> {
+    if current_ids.is_empty() {
+        // No active items — clear all entries of this type.
+        sqlx::query("DELETE FROM notification_log WHERE event_type = $1")
+            .bind(event_type)
+            .execute(pool)
+            .await?;
+    } else {
+        // Build a parameterised IN-clause. SQLite supports up to 999
+        // parameters; review_request lists are far smaller.
+        let placeholders: Vec<String> = (0..current_ids.len())
+            .map(|i| format!("${}", i + 2)) // $1 is event_type
+            .collect();
+        let sql = format!(
+            "DELETE FROM notification_log WHERE event_type = $1 AND event_id NOT IN ({})",
+            placeholders.join(", ")
+        );
+        let mut query = sqlx::query(&sql).bind(event_type);
+        for id in current_ids {
+            query = query.bind(*id);
+        }
+        query.execute(pool).await?;
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -213,6 +250,81 @@ mod tests {
             .await
             .unwrap();
         assert!(reclaimed, "should be able to reclaim after clearing");
+
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_clear_stale_notifications() {
+        let (pool, _tmp) = test_pool().await;
+
+        // Claim three review_request entries
+        try_claim_notification(&pool, "review_request", "pr-1")
+            .await
+            .unwrap();
+        try_claim_notification(&pool, "review_request", "pr-2")
+            .await
+            .unwrap();
+        try_claim_notification(&pool, "review_request", "pr-3")
+            .await
+            .unwrap();
+
+        // Only pr-1 and pr-3 are still in the queue
+        clear_stale_notifications(&pool, "review_request", &["pr-1", "pr-3"])
+            .await
+            .unwrap();
+
+        // pr-2 should be cleared (can reclaim)
+        assert!(
+            !has_been_notified(&pool, "review_request", "pr-2")
+                .await
+                .unwrap(),
+            "stale entry should be cleared"
+        );
+
+        // pr-1 and pr-3 should still be claimed
+        assert!(
+            has_been_notified(&pool, "review_request", "pr-1")
+                .await
+                .unwrap(),
+            "active entry should remain"
+        );
+        assert!(
+            has_been_notified(&pool, "review_request", "pr-3")
+                .await
+                .unwrap(),
+            "active entry should remain"
+        );
+
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_clear_stale_notifications_empty_list_clears_all() {
+        let (pool, _tmp) = test_pool().await;
+
+        try_claim_notification(&pool, "review_request", "pr-1")
+            .await
+            .unwrap();
+        try_claim_notification(&pool, "review_request", "pr-2")
+            .await
+            .unwrap();
+
+        // Empty current list → clear all review_request entries
+        clear_stale_notifications(&pool, "review_request", &[])
+            .await
+            .unwrap();
+
+        assert!(
+            !has_been_notified(&pool, "review_request", "pr-1")
+                .await
+                .unwrap()
+        );
+        assert!(
+            !has_been_notified(&pool, "review_request", "pr-2")
+                .await
+                .unwrap()
+        );
 
         pool.close().await;
     }

--- a/src-tauri/src/notifications.rs
+++ b/src-tauri/src/notifications.rs
@@ -1,15 +1,18 @@
-use log::info;
+#![allow(dead_code)] // Call-site integration deferred to polling loop wiring task
+
+use log::{info, warn};
 use serde::Serialize;
 use sqlx::SqlitePool;
+use tauri::Emitter;
 
 use crate::cache::notifications::{has_been_notified, mark_notified};
 use crate::error::AppError;
-use crate::types::{CiStatus, DashboardData, DashboardStats, PullRequest};
+use crate::types::{CiStatus, DashboardData, PullRequest};
 
 /// Payload emitted with each notification Tauri event.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct NotificationPayload {
+pub(crate) struct NotificationPayload {
     pub pr_number: u32,
     pub pr_title: String,
     pub repo_id: String,
@@ -47,47 +50,44 @@ impl TauriNotificationSender {
         Self { app_handle }
     }
 
-    fn send_native(&self, title: &str, body: &str) {
+    fn send_native(title: &str, body: &str) {
         if let Err(e) = notify_rust::Notification::new()
             .appname("PRism")
             .summary(title)
             .body(body)
             .show()
         {
-            log::warn!("failed to show native notification: {e}");
+            warn!("failed to show native notification: {e}");
         }
     }
 }
 
 impl NotificationSender for TauriNotificationSender {
     fn emit_review_request(&self, payload: &NotificationPayload) {
-        use tauri::Emitter;
         if let Err(e) = self.app_handle.emit("notification:review_request", payload) {
-            log::warn!("failed to emit notification:review_request: {e}");
+            warn!("failed to emit notification:review_request: {e}");
         }
-        self.send_native(
+        Self::send_native(
             "New Review Request",
             &format!("PR #{}: {}", payload.pr_number, payload.pr_title),
         );
     }
 
     fn emit_ci_failure(&self, payload: &NotificationPayload) {
-        use tauri::Emitter;
         if let Err(e) = self.app_handle.emit("notification:ci_failure", payload) {
-            log::warn!("failed to emit notification:ci_failure: {e}");
+            warn!("failed to emit notification:ci_failure: {e}");
         }
-        self.send_native(
+        Self::send_native(
             "CI Failed",
             &format!("PR #{}: {}", payload.pr_number, payload.pr_title),
         );
     }
 
     fn emit_pr_approved(&self, payload: &NotificationPayload) {
-        use tauri::Emitter;
         if let Err(e) = self.app_handle.emit("notification:pr_approved", payload) {
-            log::warn!("failed to emit notification:pr_approved: {e}");
+            warn!("failed to emit notification:pr_approved: {e}");
         }
-        self.send_native(
+        Self::send_native(
             "PR Approved",
             &format!("PR #{}: {}", payload.pr_number, payload.pr_title),
         );
@@ -96,17 +96,14 @@ impl NotificationSender for TauriNotificationSender {
 
 /// Check new dashboard data for notification-worthy events.
 ///
-/// Compares `old_stats` vs `new_stats` and scans `new_data` for events
-/// not yet recorded in `notification_log`. For each new event, emits a
-/// Tauri event + native notification and marks it as notified to prevent
-/// duplicates on subsequent syncs.
+/// Scans `new_data` for events not yet recorded in `notification_log`.
+/// For each new event, emits a Tauri event + native notification and
+/// marks it as notified to prevent duplicates on subsequent syncs.
 ///
 /// Returns the number of notifications emitted.
-pub async fn check_and_notify(
+pub(crate) async fn check_and_notify(
     pool: &SqlitePool,
     sender: &(impl NotificationSender + ?Sized),
-    _old_stats: &DashboardStats,
-    _new_stats: &DashboardStats,
     new_data: &DashboardData,
 ) -> Result<u32, AppError> {
     let mut count = 0u32;
@@ -121,9 +118,10 @@ pub async fn check_and_notify(
         }
     }
 
-    // 2. CI failures on authored PRs
+    // 2. CI failures and PR approvals on authored PRs
     for pr_with_review in &new_data.my_pull_requests {
         let pr = &pr_with_review.pull_request;
+
         if pr.ci_status == CiStatus::Failure
             && !has_been_notified(pool, "ci_failure", &pr.id).await?
         {
@@ -131,11 +129,7 @@ pub async fn check_and_notify(
             sender.emit_ci_failure(&NotificationPayload::from_pr(pr));
             count += 1;
         }
-    }
 
-    // 3. PR approvals on authored PRs
-    for pr_with_review in &new_data.my_pull_requests {
-        let pr = &pr_with_review.pull_request;
         if pr_with_review.review_summary.approved > 0
             && !has_been_notified(pool, "pr_approved", &pr.id).await?
         {
@@ -171,15 +165,24 @@ mod tests {
 
     impl NotificationSender for MockSender {
         fn emit_review_request(&self, payload: &NotificationPayload) {
-            self.review_requests.lock().unwrap().push(payload.clone());
+            self.review_requests
+                .lock()
+                .expect("MockSender lock poisoned")
+                .push(payload.clone());
         }
 
         fn emit_ci_failure(&self, payload: &NotificationPayload) {
-            self.ci_failures.lock().unwrap().push(payload.clone());
+            self.ci_failures
+                .lock()
+                .expect("MockSender lock poisoned")
+                .push(payload.clone());
         }
 
         fn emit_pr_approved(&self, payload: &NotificationPayload) {
-            self.pr_approvals.lock().unwrap().push(payload.clone());
+            self.pr_approvals
+                .lock()
+                .expect("MockSender lock poisoned")
+                .push(payload.clone());
         }
     }
 
@@ -227,38 +230,21 @@ mod tests {
         }
     }
 
-    fn zero_stats() -> DashboardStats {
-        DashboardStats {
-            pending_reviews: 0,
-            open_prs: 0,
-            open_issues: 0,
-            active_workspaces: 0,
-            unread_activity: 0,
-        }
-    }
-
     #[tokio::test]
     async fn test_notify_new_review_request() {
         let (pool, _tmp) = test_pool().await;
         let sender = MockSender::default();
 
-        let old_stats = zero_stats();
-        let new_stats = DashboardStats {
-            pending_reviews: 1,
-            ..zero_stats()
-        };
         let pr = make_pr("pr-1", 42, CiStatus::Success);
         let data = DashboardData {
             review_requests: vec![make_pr_with_review(pr, 0)],
             ..empty_data()
         };
 
-        let count = check_and_notify(&pool, &sender, &old_stats, &new_stats, &data)
-            .await
-            .unwrap();
+        let count = check_and_notify(&pool, &sender, &data).await.unwrap();
 
         assert_eq!(count, 1);
-        let notifs = sender.review_requests.lock().unwrap();
+        let notifs = sender.review_requests.lock().expect("lock poisoned");
         assert_eq!(notifs.len(), 1);
         assert_eq!(notifs[0].pr_number, 42);
 
@@ -270,11 +256,6 @@ mod tests {
         let (pool, _tmp) = test_pool().await;
         let sender = MockSender::default();
 
-        let old_stats = zero_stats();
-        let new_stats = DashboardStats {
-            pending_reviews: 1,
-            ..zero_stats()
-        };
         let pr = make_pr("pr-1", 42, CiStatus::Success);
         let data = DashboardData {
             review_requests: vec![make_pr_with_review(pr, 0)],
@@ -282,19 +263,18 @@ mod tests {
         };
 
         // First call — should notify
-        let count1 = check_and_notify(&pool, &sender, &old_stats, &new_stats, &data)
-            .await
-            .unwrap();
+        let count1 = check_and_notify(&pool, &sender, &data).await.unwrap();
         assert_eq!(count1, 1);
 
         // Second call with same data — should NOT re-notify (dedup)
-        let count2 = check_and_notify(&pool, &sender, &old_stats, &new_stats, &data)
-            .await
-            .unwrap();
+        let count2 = check_and_notify(&pool, &sender, &data).await.unwrap();
         assert_eq!(count2, 0);
 
         // Verify only one notification total
-        assert_eq!(sender.review_requests.lock().unwrap().len(), 1);
+        assert_eq!(
+            sender.review_requests.lock().expect("lock poisoned").len(),
+            1
+        );
 
         pool.close().await;
     }
@@ -304,23 +284,16 @@ mod tests {
         let (pool, _tmp) = test_pool().await;
         let sender = MockSender::default();
 
-        let old_stats = zero_stats();
-        let new_stats = DashboardStats {
-            open_prs: 1,
-            ..zero_stats()
-        };
         let pr = make_pr("pr-2", 99, CiStatus::Failure);
         let data = DashboardData {
             my_pull_requests: vec![make_pr_with_review(pr, 0)],
             ..empty_data()
         };
 
-        let count = check_and_notify(&pool, &sender, &old_stats, &new_stats, &data)
-            .await
-            .unwrap();
+        let count = check_and_notify(&pool, &sender, &data).await.unwrap();
 
         assert_eq!(count, 1);
-        let notifs = sender.ci_failures.lock().unwrap();
+        let notifs = sender.ci_failures.lock().expect("lock poisoned");
         assert_eq!(notifs.len(), 1);
         assert_eq!(notifs[0].pr_number, 99);
 
@@ -332,23 +305,16 @@ mod tests {
         let (pool, _tmp) = test_pool().await;
         let sender = MockSender::default();
 
-        let old_stats = zero_stats();
-        let new_stats = DashboardStats {
-            open_prs: 1,
-            ..zero_stats()
-        };
         let pr = make_pr("pr-3", 10, CiStatus::Success);
         let data = DashboardData {
             my_pull_requests: vec![make_pr_with_review(pr, 1)],
             ..empty_data()
         };
 
-        let count = check_and_notify(&pool, &sender, &old_stats, &new_stats, &data)
-            .await
-            .unwrap();
+        let count = check_and_notify(&pool, &sender, &data).await.unwrap();
 
         assert_eq!(count, 1);
-        let notifs = sender.pr_approvals.lock().unwrap();
+        let notifs = sender.pr_approvals.lock().expect("lock poisoned");
         assert_eq!(notifs.len(), 1);
         assert_eq!(notifs[0].pr_number, 10);
 
@@ -365,24 +331,21 @@ mod tests {
             .await
             .unwrap();
 
-        let old_stats = zero_stats();
-        let new_stats = DashboardStats {
-            pending_reviews: 1,
-            ..zero_stats()
-        };
         let pr = make_pr("pr-1", 42, CiStatus::Success);
         let data = DashboardData {
             review_requests: vec![make_pr_with_review(pr, 0)],
             ..empty_data()
         };
 
-        let count = check_and_notify(&pool, &sender, &old_stats, &new_stats, &data)
-            .await
-            .unwrap();
+        let count = check_and_notify(&pool, &sender, &data).await.unwrap();
 
         assert_eq!(count, 0, "should not notify for already-notified event");
         assert!(
-            sender.review_requests.lock().unwrap().is_empty(),
+            sender
+                .review_requests
+                .lock()
+                .expect("lock poisoned")
+                .is_empty(),
             "no notification should be emitted"
         );
 

--- a/src-tauri/src/notifications.rs
+++ b/src-tauri/src/notifications.rs
@@ -117,10 +117,12 @@ pub(crate) async fn check_and_notify(
 ) -> Result<u32, AppError> {
     let mut count = 0u32;
 
-    // 1. New review requests
+    // 1. New review requests — keyed on (pr.id, updated_at) so that
+    //    re-requests after a review submission get their own claim.
     for pr_with_review in &new_data.review_requests {
         let pr = &pr_with_review.pull_request;
-        if try_claim_notification(pool, "review_request", &pr.id).await? {
+        let event_id = format!("{}:{}", pr.id, pr.updated_at);
+        if try_claim_notification(pool, "review_request", &event_id).await? {
             sender.emit_review_request(&NotificationPayload::from_pr(pr));
             count += 1;
         }
@@ -141,12 +143,15 @@ pub(crate) async fn check_and_notify(
             clear_notification(pool, "ci_failure", &pr.id).await?;
         }
 
-        // PR approval (monotone — no clearing needed)
-        if pr_with_review.review_summary.approved > 0
-            && try_claim_notification(pool, "pr_approved", &pr.id).await?
-        {
-            sender.emit_pr_approved(&NotificationPayload::from_pr(pr));
-            count += 1;
+        // PR approval: clear when no longer approved so a re-approval
+        // after changes_requested can re-trigger a notification.
+        if pr_with_review.review_summary.approved > 0 {
+            if try_claim_notification(pool, "pr_approved", &pr.id).await? {
+                sender.emit_pr_approved(&NotificationPayload::from_pr(pr));
+                count += 1;
+            }
+        } else {
+            clear_notification(pool, "pr_approved", &pr.id).await?;
         }
     }
 
@@ -338,8 +343,8 @@ mod tests {
         let (pool, _tmp) = test_pool().await;
         let sender = MockSender::default();
 
-        // Pre-claim the notification slot
-        try_claim_notification(&pool, "review_request", "pr-1")
+        // Pre-claim using the composite key (pr.id:updated_at)
+        try_claim_notification(&pool, "review_request", "pr-1:2026-03-29T10:00:00Z")
             .await
             .unwrap();
 
@@ -407,6 +412,57 @@ mod tests {
         assert_eq!(count2, 1, "should re-notify after CI recovery + re-failure");
 
         assert_eq!(sender.ci_failures.lock().expect("lock poisoned").len(), 2);
+
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_pr_approved_renotifies_after_changes_requested() {
+        let (pool, _tmp) = test_pool().await;
+        let sender = MockSender::default();
+
+        // 1. PR approved → notify
+        let pr_approved = make_pr("pr-5", 60, CiStatus::Success);
+        let data_approved = DashboardData {
+            my_pull_requests: vec![make_pr_with_review(pr_approved, 1)],
+            ..empty_data()
+        };
+        let count = check_and_notify(&pool, &sender, &data_approved)
+            .await
+            .unwrap();
+        assert_eq!(count, 1);
+
+        // 2. Changes requested → approved drops to 0, clears dedup entry
+        let pr_changes = make_pr("pr-5", 60, CiStatus::Success);
+        let data_changes = DashboardData {
+            my_pull_requests: vec![make_pr_with_review(pr_changes, 0)],
+            ..empty_data()
+        };
+        check_and_notify(&pool, &sender, &data_changes)
+            .await
+            .unwrap();
+
+        // Verify entry was cleared
+        let still_notified = has_been_notified(&pool, "pr_approved", "pr-5")
+            .await
+            .unwrap();
+        assert!(
+            !still_notified,
+            "pr_approved entry should be cleared when no longer approved"
+        );
+
+        // 3. Re-approved → should re-notify
+        let pr_reapproved = make_pr("pr-5", 60, CiStatus::Success);
+        let data_reapproved = DashboardData {
+            my_pull_requests: vec![make_pr_with_review(pr_reapproved, 1)],
+            ..empty_data()
+        };
+        let count2 = check_and_notify(&pool, &sender, &data_reapproved)
+            .await
+            .unwrap();
+        assert_eq!(count2, 1, "should re-notify after re-approval");
+
+        assert_eq!(sender.pr_approvals.lock().expect("lock poisoned").len(), 2);
 
         pool.close().await;
     }

--- a/src-tauri/src/notifications.rs
+++ b/src-tauri/src/notifications.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 use sqlx::SqlitePool;
 use tauri::Emitter;
 
-use crate::cache::notifications::{has_been_notified, mark_notified};
+use crate::cache::notifications::{clear_notification, try_claim_notification};
 use crate::error::AppError;
 use crate::types::{CiStatus, DashboardData, PullRequest};
 
@@ -96,9 +96,18 @@ impl NotificationSender for TauriNotificationSender {
 
 /// Check new dashboard data for notification-worthy events.
 ///
-/// Scans `new_data` for events not yet recorded in `notification_log`.
-/// For each new event, emits a Tauri event + native notification and
-/// marks it as notified to prevent duplicates on subsequent syncs.
+/// Uses [`try_claim_notification`] for atomic deduplication — a single
+/// `INSERT ... ON CONFLICT DO NOTHING` that returns whether the caller
+/// won the claim, eliminating TOCTOU races between check and mark.
+///
+/// Delivery guarantee: **at-most-once** per `(event_type, event_id)`.
+/// The claim is persisted before emission. If the Tauri event or native
+/// notification fails after claiming, the notification will not be
+/// retried. This avoids duplicate spam at the cost of rare silent drops.
+///
+/// CI failure notifications are transient: when a PR's CI status moves
+/// away from `Failure`, the dedup entry is cleared so a future failure
+/// on the same PR can re-trigger a notification.
 ///
 /// Returns the number of notifications emitted.
 pub(crate) async fn check_and_notify(
@@ -111,8 +120,7 @@ pub(crate) async fn check_and_notify(
     // 1. New review requests
     for pr_with_review in &new_data.review_requests {
         let pr = &pr_with_review.pull_request;
-        if !has_been_notified(pool, "review_request", &pr.id).await? {
-            mark_notified(pool, "review_request", &pr.id).await?;
+        if try_claim_notification(pool, "review_request", &pr.id).await? {
             sender.emit_review_request(&NotificationPayload::from_pr(pr));
             count += 1;
         }
@@ -122,18 +130,21 @@ pub(crate) async fn check_and_notify(
     for pr_with_review in &new_data.my_pull_requests {
         let pr = &pr_with_review.pull_request;
 
-        if pr.ci_status == CiStatus::Failure
-            && !has_been_notified(pool, "ci_failure", &pr.id).await?
-        {
-            mark_notified(pool, "ci_failure", &pr.id).await?;
-            sender.emit_ci_failure(&NotificationPayload::from_pr(pr));
-            count += 1;
+        // CI failure: claim + emit. When CI is no longer failing, clear
+        // the entry so a future failure can re-notify.
+        if pr.ci_status == CiStatus::Failure {
+            if try_claim_notification(pool, "ci_failure", &pr.id).await? {
+                sender.emit_ci_failure(&NotificationPayload::from_pr(pr));
+                count += 1;
+            }
+        } else {
+            clear_notification(pool, "ci_failure", &pr.id).await?;
         }
 
+        // PR approval (monotone — no clearing needed)
         if pr_with_review.review_summary.approved > 0
-            && !has_been_notified(pool, "pr_approved", &pr.id).await?
+            && try_claim_notification(pool, "pr_approved", &pr.id).await?
         {
-            mark_notified(pool, "pr_approved", &pr.id).await?;
             sender.emit_pr_approved(&NotificationPayload::from_pr(pr));
             count += 1;
         }
@@ -147,6 +158,7 @@ pub(crate) async fn check_and_notify(
 mod tests {
     use super::*;
     use crate::cache::db::init_db;
+    use crate::cache::notifications::has_been_notified;
     use crate::types::*;
     use std::sync::{Arc, Mutex};
 
@@ -266,7 +278,7 @@ mod tests {
         let count1 = check_and_notify(&pool, &sender, &data).await.unwrap();
         assert_eq!(count1, 1);
 
-        // Second call with same data — should NOT re-notify (dedup)
+        // Second call with same data — should NOT re-notify (atomic dedup)
         let count2 = check_and_notify(&pool, &sender, &data).await.unwrap();
         assert_eq!(count2, 0);
 
@@ -326,8 +338,8 @@ mod tests {
         let (pool, _tmp) = test_pool().await;
         let sender = MockSender::default();
 
-        // Pre-mark the event as already notified
-        mark_notified(&pool, "review_request", "pr-1")
+        // Pre-claim the notification slot
+        try_claim_notification(&pool, "review_request", "pr-1")
             .await
             .unwrap();
 
@@ -339,7 +351,7 @@ mod tests {
 
         let count = check_and_notify(&pool, &sender, &data).await.unwrap();
 
-        assert_eq!(count, 0, "should not notify for already-notified event");
+        assert_eq!(count, 0, "should not notify for already-claimed event");
         assert!(
             sender
                 .review_requests
@@ -348,6 +360,53 @@ mod tests {
                 .is_empty(),
             "no notification should be emitted"
         );
+
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_ci_failure_renotifies_after_recovery() {
+        let (pool, _tmp) = test_pool().await;
+        let sender = MockSender::default();
+
+        // 1. CI fails → notify
+        let pr_fail = make_pr("pr-4", 50, CiStatus::Failure);
+        let data_fail = DashboardData {
+            my_pull_requests: vec![make_pr_with_review(pr_fail, 0)],
+            ..empty_data()
+        };
+        let count = check_and_notify(&pool, &sender, &data_fail).await.unwrap();
+        assert_eq!(count, 1);
+
+        // 2. CI passes → clears the dedup entry
+        let pr_pass = make_pr("pr-4", 50, CiStatus::Success);
+        let data_pass = DashboardData {
+            my_pull_requests: vec![make_pr_with_review(pr_pass, 0)],
+            ..empty_data()
+        };
+        check_and_notify(&pool, &sender, &data_pass).await.unwrap();
+
+        // Verify entry was cleared
+        let still_notified = has_been_notified(&pool, "ci_failure", "pr-4")
+            .await
+            .unwrap();
+        assert!(
+            !still_notified,
+            "ci_failure entry should be cleared on recovery"
+        );
+
+        // 3. CI fails again → should re-notify
+        let pr_fail_again = make_pr("pr-4", 50, CiStatus::Failure);
+        let data_fail_again = DashboardData {
+            my_pull_requests: vec![make_pr_with_review(pr_fail_again, 0)],
+            ..empty_data()
+        };
+        let count2 = check_and_notify(&pool, &sender, &data_fail_again)
+            .await
+            .unwrap();
+        assert_eq!(count2, 1, "should re-notify after CI recovery + re-failure");
+
+        assert_eq!(sender.ci_failures.lock().expect("lock poisoned").len(), 2);
 
         pool.close().await;
     }

--- a/src-tauri/src/notifications.rs
+++ b/src-tauri/src/notifications.rs
@@ -1,1 +1,391 @@
+use log::info;
+use serde::Serialize;
+use sqlx::SqlitePool;
 
+use crate::cache::notifications::{has_been_notified, mark_notified};
+use crate::error::AppError;
+use crate::types::{CiStatus, DashboardData, DashboardStats, PullRequest};
+
+/// Payload emitted with each notification Tauri event.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NotificationPayload {
+    pub pr_number: u32,
+    pub pr_title: String,
+    pub repo_id: String,
+    pub url: String,
+}
+
+impl NotificationPayload {
+    fn from_pr(pr: &PullRequest) -> Self {
+        Self {
+            pr_number: pr.number,
+            pr_title: pr.title.clone(),
+            repo_id: pr.repo_id.clone(),
+            url: pr.url.clone(),
+        }
+    }
+}
+
+/// Abstracts notification emission for testability.
+///
+/// The real implementation ([`TauriNotificationSender`]) emits Tauri events
+/// and sends native desktop notifications via `notify-rust`.
+pub(crate) trait NotificationSender: Send + Sync {
+    fn emit_review_request(&self, payload: &NotificationPayload);
+    fn emit_ci_failure(&self, payload: &NotificationPayload);
+    fn emit_pr_approved(&self, payload: &NotificationPayload);
+}
+
+/// Real implementation using Tauri events + native desktop notifications.
+pub(crate) struct TauriNotificationSender {
+    app_handle: tauri::AppHandle,
+}
+
+impl TauriNotificationSender {
+    pub fn new(app_handle: tauri::AppHandle) -> Self {
+        Self { app_handle }
+    }
+
+    fn send_native(&self, title: &str, body: &str) {
+        if let Err(e) = notify_rust::Notification::new()
+            .appname("PRism")
+            .summary(title)
+            .body(body)
+            .show()
+        {
+            log::warn!("failed to show native notification: {e}");
+        }
+    }
+}
+
+impl NotificationSender for TauriNotificationSender {
+    fn emit_review_request(&self, payload: &NotificationPayload) {
+        use tauri::Emitter;
+        if let Err(e) = self.app_handle.emit("notification:review_request", payload) {
+            log::warn!("failed to emit notification:review_request: {e}");
+        }
+        self.send_native(
+            "New Review Request",
+            &format!("PR #{}: {}", payload.pr_number, payload.pr_title),
+        );
+    }
+
+    fn emit_ci_failure(&self, payload: &NotificationPayload) {
+        use tauri::Emitter;
+        if let Err(e) = self.app_handle.emit("notification:ci_failure", payload) {
+            log::warn!("failed to emit notification:ci_failure: {e}");
+        }
+        self.send_native(
+            "CI Failed",
+            &format!("PR #{}: {}", payload.pr_number, payload.pr_title),
+        );
+    }
+
+    fn emit_pr_approved(&self, payload: &NotificationPayload) {
+        use tauri::Emitter;
+        if let Err(e) = self.app_handle.emit("notification:pr_approved", payload) {
+            log::warn!("failed to emit notification:pr_approved: {e}");
+        }
+        self.send_native(
+            "PR Approved",
+            &format!("PR #{}: {}", payload.pr_number, payload.pr_title),
+        );
+    }
+}
+
+/// Check new dashboard data for notification-worthy events.
+///
+/// Compares `old_stats` vs `new_stats` and scans `new_data` for events
+/// not yet recorded in `notification_log`. For each new event, emits a
+/// Tauri event + native notification and marks it as notified to prevent
+/// duplicates on subsequent syncs.
+///
+/// Returns the number of notifications emitted.
+pub async fn check_and_notify(
+    pool: &SqlitePool,
+    sender: &(impl NotificationSender + ?Sized),
+    _old_stats: &DashboardStats,
+    _new_stats: &DashboardStats,
+    new_data: &DashboardData,
+) -> Result<u32, AppError> {
+    let mut count = 0u32;
+
+    // 1. New review requests
+    for pr_with_review in &new_data.review_requests {
+        let pr = &pr_with_review.pull_request;
+        if !has_been_notified(pool, "review_request", &pr.id).await? {
+            mark_notified(pool, "review_request", &pr.id).await?;
+            sender.emit_review_request(&NotificationPayload::from_pr(pr));
+            count += 1;
+        }
+    }
+
+    // 2. CI failures on authored PRs
+    for pr_with_review in &new_data.my_pull_requests {
+        let pr = &pr_with_review.pull_request;
+        if pr.ci_status == CiStatus::Failure
+            && !has_been_notified(pool, "ci_failure", &pr.id).await?
+        {
+            mark_notified(pool, "ci_failure", &pr.id).await?;
+            sender.emit_ci_failure(&NotificationPayload::from_pr(pr));
+            count += 1;
+        }
+    }
+
+    // 3. PR approvals on authored PRs
+    for pr_with_review in &new_data.my_pull_requests {
+        let pr = &pr_with_review.pull_request;
+        if pr_with_review.review_summary.approved > 0
+            && !has_been_notified(pool, "pr_approved", &pr.id).await?
+        {
+            mark_notified(pool, "pr_approved", &pr.id).await?;
+            sender.emit_pr_approved(&NotificationPayload::from_pr(pr));
+            count += 1;
+        }
+    }
+
+    info!("check_and_notify: emitted {count} notification(s)");
+    Ok(count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cache::db::init_db;
+    use crate::types::*;
+    use std::sync::{Arc, Mutex};
+
+    async fn test_pool() -> (SqlitePool, tempfile::TempDir) {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let pool = init_db(&tmp.path().join("test.db")).await.unwrap();
+        (pool, tmp)
+    }
+
+    #[derive(Debug, Default, Clone)]
+    struct MockSender {
+        review_requests: Arc<Mutex<Vec<NotificationPayload>>>,
+        ci_failures: Arc<Mutex<Vec<NotificationPayload>>>,
+        pr_approvals: Arc<Mutex<Vec<NotificationPayload>>>,
+    }
+
+    impl NotificationSender for MockSender {
+        fn emit_review_request(&self, payload: &NotificationPayload) {
+            self.review_requests.lock().unwrap().push(payload.clone());
+        }
+
+        fn emit_ci_failure(&self, payload: &NotificationPayload) {
+            self.ci_failures.lock().unwrap().push(payload.clone());
+        }
+
+        fn emit_pr_approved(&self, payload: &NotificationPayload) {
+            self.pr_approvals.lock().unwrap().push(payload.clone());
+        }
+    }
+
+    fn make_pr(id: &str, number: u32, ci_status: CiStatus) -> PullRequest {
+        PullRequest {
+            id: id.to_string(),
+            number,
+            title: format!("PR #{number}"),
+            author: "mpiton".to_string(),
+            state: PrState::Open,
+            ci_status,
+            priority: Priority::Medium,
+            repo_id: "r-1".to_string(),
+            url: format!("https://github.com/test/repo/pull/{number}"),
+            labels: vec![],
+            additions: 10,
+            deletions: 5,
+            created_at: "2026-03-29T10:00:00Z".to_string(),
+            updated_at: "2026-03-29T10:00:00Z".to_string(),
+        }
+    }
+
+    fn make_pr_with_review(pr: PullRequest, approved: u32) -> PullRequestWithReview {
+        PullRequestWithReview {
+            pull_request: pr,
+            review_summary: ReviewSummary {
+                total_reviews: approved,
+                approved,
+                changes_requested: 0,
+                pending: if approved == 0 { 1 } else { 0 },
+                reviewers: vec!["reviewer".to_string()],
+            },
+            workspace: None,
+        }
+    }
+
+    fn empty_data() -> DashboardData {
+        DashboardData {
+            review_requests: vec![],
+            my_pull_requests: vec![],
+            assigned_issues: vec![],
+            recent_activity: vec![],
+            workspaces: vec![],
+            synced_at: Some("2026-03-29T10:00:00Z".to_string()),
+        }
+    }
+
+    fn zero_stats() -> DashboardStats {
+        DashboardStats {
+            pending_reviews: 0,
+            open_prs: 0,
+            open_issues: 0,
+            active_workspaces: 0,
+            unread_activity: 0,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_notify_new_review_request() {
+        let (pool, _tmp) = test_pool().await;
+        let sender = MockSender::default();
+
+        let old_stats = zero_stats();
+        let new_stats = DashboardStats {
+            pending_reviews: 1,
+            ..zero_stats()
+        };
+        let pr = make_pr("pr-1", 42, CiStatus::Success);
+        let data = DashboardData {
+            review_requests: vec![make_pr_with_review(pr, 0)],
+            ..empty_data()
+        };
+
+        let count = check_and_notify(&pool, &sender, &old_stats, &new_stats, &data)
+            .await
+            .unwrap();
+
+        assert_eq!(count, 1);
+        let notifs = sender.review_requests.lock().unwrap();
+        assert_eq!(notifs.len(), 1);
+        assert_eq!(notifs[0].pr_number, 42);
+
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_no_duplicate_notification() {
+        let (pool, _tmp) = test_pool().await;
+        let sender = MockSender::default();
+
+        let old_stats = zero_stats();
+        let new_stats = DashboardStats {
+            pending_reviews: 1,
+            ..zero_stats()
+        };
+        let pr = make_pr("pr-1", 42, CiStatus::Success);
+        let data = DashboardData {
+            review_requests: vec![make_pr_with_review(pr, 0)],
+            ..empty_data()
+        };
+
+        // First call — should notify
+        let count1 = check_and_notify(&pool, &sender, &old_stats, &new_stats, &data)
+            .await
+            .unwrap();
+        assert_eq!(count1, 1);
+
+        // Second call with same data — should NOT re-notify (dedup)
+        let count2 = check_and_notify(&pool, &sender, &old_stats, &new_stats, &data)
+            .await
+            .unwrap();
+        assert_eq!(count2, 0);
+
+        // Verify only one notification total
+        assert_eq!(sender.review_requests.lock().unwrap().len(), 1);
+
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_notify_ci_failure() {
+        let (pool, _tmp) = test_pool().await;
+        let sender = MockSender::default();
+
+        let old_stats = zero_stats();
+        let new_stats = DashboardStats {
+            open_prs: 1,
+            ..zero_stats()
+        };
+        let pr = make_pr("pr-2", 99, CiStatus::Failure);
+        let data = DashboardData {
+            my_pull_requests: vec![make_pr_with_review(pr, 0)],
+            ..empty_data()
+        };
+
+        let count = check_and_notify(&pool, &sender, &old_stats, &new_stats, &data)
+            .await
+            .unwrap();
+
+        assert_eq!(count, 1);
+        let notifs = sender.ci_failures.lock().unwrap();
+        assert_eq!(notifs.len(), 1);
+        assert_eq!(notifs[0].pr_number, 99);
+
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_notify_pr_approved() {
+        let (pool, _tmp) = test_pool().await;
+        let sender = MockSender::default();
+
+        let old_stats = zero_stats();
+        let new_stats = DashboardStats {
+            open_prs: 1,
+            ..zero_stats()
+        };
+        let pr = make_pr("pr-3", 10, CiStatus::Success);
+        let data = DashboardData {
+            my_pull_requests: vec![make_pr_with_review(pr, 1)],
+            ..empty_data()
+        };
+
+        let count = check_and_notify(&pool, &sender, &old_stats, &new_stats, &data)
+            .await
+            .unwrap();
+
+        assert_eq!(count, 1);
+        let notifs = sender.pr_approvals.lock().unwrap();
+        assert_eq!(notifs.len(), 1);
+        assert_eq!(notifs[0].pr_number, 10);
+
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_no_notification_for_existing_event() {
+        let (pool, _tmp) = test_pool().await;
+        let sender = MockSender::default();
+
+        // Pre-mark the event as already notified
+        mark_notified(&pool, "review_request", "pr-1")
+            .await
+            .unwrap();
+
+        let old_stats = zero_stats();
+        let new_stats = DashboardStats {
+            pending_reviews: 1,
+            ..zero_stats()
+        };
+        let pr = make_pr("pr-1", 42, CiStatus::Success);
+        let data = DashboardData {
+            review_requests: vec![make_pr_with_review(pr, 0)],
+            ..empty_data()
+        };
+
+        let count = check_and_notify(&pool, &sender, &old_stats, &new_stats, &data)
+            .await
+            .unwrap();
+
+        assert_eq!(count, 0, "should not notify for already-notified event");
+        assert!(
+            sender.review_requests.lock().unwrap().is_empty(),
+            "no notification should be emitted"
+        );
+
+        pool.close().await;
+    }
+}

--- a/src-tauri/src/notifications.rs
+++ b/src-tauri/src/notifications.rs
@@ -5,7 +5,9 @@ use serde::Serialize;
 use sqlx::SqlitePool;
 use tauri::Emitter;
 
-use crate::cache::notifications::{clear_notification, try_claim_notification};
+use crate::cache::notifications::{
+    clear_notification, clear_stale_notifications, try_claim_notification,
+};
 use crate::error::AppError;
 use crate::types::{CiStatus, DashboardData, PullRequest};
 
@@ -117,12 +119,19 @@ pub(crate) async fn check_and_notify(
 ) -> Result<u32, AppError> {
     let mut count = 0u32;
 
-    // 1. New review requests — keyed on (pr.id, updated_at) so that
-    //    re-requests after a review submission get their own claim.
+    // 1. New review requests — keyed on pr.id. Stale entries are
+    //    cleared for PRs that left the review queue, so re-requests
+    //    naturally re-trigger.
+    let review_pr_ids: Vec<&str> = new_data
+        .review_requests
+        .iter()
+        .map(|prwr| prwr.pull_request.id.as_str())
+        .collect();
+    clear_stale_notifications(pool, "review_request", &review_pr_ids).await?;
+
     for pr_with_review in &new_data.review_requests {
         let pr = &pr_with_review.pull_request;
-        let event_id = format!("{}:{}", pr.id, pr.updated_at);
-        if try_claim_notification(pool, "review_request", &event_id).await? {
+        if try_claim_notification(pool, "review_request", &pr.id).await? {
             sender.emit_review_request(&NotificationPayload::from_pr(pr));
             count += 1;
         }
@@ -343,8 +352,8 @@ mod tests {
         let (pool, _tmp) = test_pool().await;
         let sender = MockSender::default();
 
-        // Pre-claim using the composite key (pr.id:updated_at)
-        try_claim_notification(&pool, "review_request", "pr-1:2026-03-29T10:00:00Z")
+        // Pre-claim using pr.id
+        try_claim_notification(&pool, "review_request", "pr-1")
             .await
             .unwrap();
 


### PR DESCRIPTION
## Summary

- Implement `check_and_notify()` function that detects new review requests, CI failures, and PR approvals from dashboard data
- Uses `notification_log` table for idempotent deduplication — no duplicate notifications across sync cycles
- Emits Tauri events (`notification:review_request`, `notification:ci_failure`, `notification:pr_approved`) + native desktop notifications via `notify-rust`
- Testable architecture via `NotificationSender` trait with `MockSender` for tests and `TauriNotificationSender` for production

## Test plan

- [x] `test_notify_new_review_request` — emits notification for new review request
- [x] `test_no_duplicate_notification` — dedup via notification_log prevents re-notification
- [x] `test_notify_ci_failure` — emits notification for CI failure on authored PR
- [x] `test_notify_pr_approved` — emits notification for PR approval
- [x] `test_no_notification_for_existing_event` — pre-existing events are skipped
- [x] `cargo clippy --lib -- -D warnings` passes clean
- [x] All 8 notification-related tests pass (5 new + 3 existing cache tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the T-061 notifications module for review requests, CI failures, and PR approvals. Adds at-most-once delivery with atomic dedup, and re-notifies on re-requests, CI recovery, and re-approvals.

- **New Features**
  - Added `check_and_notify()` that scans `DashboardData` and uses atomic `try_claim_notification` (`INSERT ... ON CONFLICT DO NOTHING`) to avoid races.
  - Review requests keyed by `pr.id` with `clear_stale_notifications` to remove entries for PRs that leave the queue, so re-requests notify again without noise.
  - Clears dedup for `ci_failure` when CI passes and for `pr_approved` when approvals drop to 0, enabling future re-notifications.
  - Emits Tauri events (`notification:review_request`, `notification:ci_failure`, `notification:pr_approved`) and native desktop notifications; pluggable `NotificationSender` with `TauriNotificationSender` and `MockSender`.

- **Dependencies**
  - Added `notify-rust@4.12.0` for cross-platform desktop notifications.

<sup>Written for commit 95f6447a6506d07ef49530b34024f7407c94d1d8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Desktop notifications for PR activity (review requests, CI failures, approvals) with at‑most‑once delivery and re‑notify after recovery.
* **Bug Fixes**
  * Improved deduplication and explicit clearing so events can be retriggered when status changes.
* **Tests**
  * Unit tests covering emission counts, suppression, dedup behavior, CI recovery, and approval state changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->