### PR TITLE
feat(notifications): implement system tray with badge and menu (T-062)

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,7 +19,7 @@ tauri-build = { version = "2.5.6" }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
-tauri = { version = "2.10.3" }
+tauri = { version = "2.10.3", features = ["tray-icon"] }
 tauri-plugin-log = "2"
 thiserror = "2.0.18"
 sqlx = { version = "0.8.6", features = ["migrate", "runtime-tokio", "sqlite"] }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -3,5 +3,9 @@
   "identifier": "default",
   "description": "enables the default permissions",
   "windows": ["main"],
-  "permissions": ["core:default"]
+  "permissions": [
+    "core:default",
+    "core:tray:default",
+    "core:menu:default"
+  ]
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3,7 +3,7 @@ use std::sync::Mutex;
 use log::warn;
 use serde::Serialize;
 use sqlx::SqlitePool;
-use tauri::Emitter;
+use tauri::{Emitter, Manager};
 
 use crate::cache::activity::{mark_all_read, mark_read};
 use crate::cache::config::{get_config, set_config};
@@ -243,26 +243,40 @@ async fn resolve_credentials(cached: &GithubUsername) -> Result<(String, String)
 }
 
 /// Core force-sync logic shared by the IPC command and the tray handler.
+///
+/// Returns the fresh stats so callers can update the tray badge or
+/// perform other post-sync work without introducing bidirectional coupling.
 pub(crate) async fn run_force_sync(
     app_handle: &tauri::AppHandle,
     pool: &SqlitePool,
     cached: &GithubUsername,
-) -> Result<(), String> {
-    let (username, token) = resolve_credentials(cached).await?;
-    let client = GitHubClient::new(&token).map_err(|e| e.to_string())?;
+) -> Result<DashboardStats, String> {
+    use std::sync::atomic::Ordering;
 
-    let stats = sync_dashboard(&client, pool, &username)
-        .await
-        .map_err(|e| e.to_string())?;
-
-    if let Err(e) = app_handle.emit("github:updated", &stats) {
-        warn!("failed to emit github:updated after force sync: {e}");
-    }
-    if let Err(e) = crate::tray::update_tray_badge(app_handle, stats.pending_reviews) {
-        warn!("failed to update tray badge after force sync: {e}");
+    let guard = app_handle.state::<crate::SyncInFlight>();
+    if guard
+        .0
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        return Err("sync already in progress".to_string());
     }
 
-    Ok(())
+    let result = async {
+        let (username, token) = resolve_credentials(cached).await?;
+        let client = GitHubClient::new(&token).map_err(|e| e.to_string())?;
+        let stats = sync_dashboard(&client, pool, &username)
+            .await
+            .map_err(|e| e.to_string())?;
+        if let Err(e) = app_handle.emit("github:updated", &stats) {
+            warn!("failed to emit github:updated after force sync: {e}");
+        }
+        Ok(stats)
+    }
+    .await;
+
+    guard.0.store(false, Ordering::Release);
+    result
 }
 
 /// Triggers an immediate GitHub data sync, bypassing the polling timer.
@@ -277,7 +291,11 @@ pub async fn github_force_sync(
     cached: tauri::State<'_, GithubUsername>,
     app_handle: tauri::AppHandle,
 ) -> Result<(), String> {
-    run_force_sync(&app_handle, &pool, &cached).await
+    let stats = run_force_sync(&app_handle, &pool, &cached).await?;
+    if let Err(e) = crate::tray::update_tray_badge(&app_handle, stats.pending_reviews) {
+        warn!("failed to update tray badge after force sync: {e}");
+    }
+    Ok(())
 }
 
 /// Returns the full application configuration (query).

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -242,6 +242,29 @@ async fn resolve_credentials(cached: &GithubUsername) -> Result<(String, String)
     Ok((username, token))
 }
 
+/// Core force-sync logic shared by the IPC command and the tray handler.
+pub(crate) async fn run_force_sync(
+    app_handle: &tauri::AppHandle,
+    pool: &SqlitePool,
+    cached: &GithubUsername,
+) -> Result<(), String> {
+    let (username, token) = resolve_credentials(cached).await?;
+    let client = GitHubClient::new(&token).map_err(|e| e.to_string())?;
+
+    let stats = sync_dashboard(&client, pool, &username)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    if let Err(e) = app_handle.emit("github:updated", &stats) {
+        warn!("failed to emit github:updated after force sync: {e}");
+    }
+    if let Err(e) = crate::tray::update_tray_badge(app_handle, stats.pending_reviews) {
+        warn!("failed to update tray badge after force sync: {e}");
+    }
+
+    Ok(())
+}
+
 /// Triggers an immediate GitHub data sync, bypassing the polling timer.
 ///
 /// Reads the stored token and cached username in a single pass, creates
@@ -254,18 +277,7 @@ pub async fn github_force_sync(
     cached: tauri::State<'_, GithubUsername>,
     app_handle: tauri::AppHandle,
 ) -> Result<(), String> {
-    let (username, token) = resolve_credentials(&cached).await?;
-    let client = GitHubClient::new(&token).map_err(|e| e.to_string())?;
-
-    let stats = sync_dashboard(&client, &pool, &username)
-        .await
-        .map_err(|e| e.to_string())?;
-
-    if let Err(e) = app_handle.emit("github:updated", &stats) {
-        warn!("failed to emit github:updated after force sync: {e}");
-    }
-
-    Ok(())
+    run_force_sync(&app_handle, &pool, &cached).await
 }
 
 /// Returns the full application configuration (query).

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -253,30 +253,33 @@ pub(crate) async fn run_force_sync(
 ) -> Result<DashboardStats, String> {
     use std::sync::atomic::Ordering;
 
-    let guard = app_handle.state::<crate::SyncInFlight>();
-    if guard
+    /// RAII guard that resets the in-flight flag on drop (cancellation-safe).
+    struct ResetOnDrop<'a>(&'a std::sync::atomic::AtomicBool);
+    impl Drop for ResetOnDrop<'_> {
+        fn drop(&mut self) {
+            self.0.store(false, Ordering::Release);
+        }
+    }
+
+    let sync_guard = app_handle.state::<crate::SyncInFlight>();
+    if sync_guard
         .0
         .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
         .is_err()
     {
         return Err("sync already in progress".to_string());
     }
+    let _reset = ResetOnDrop(&sync_guard.0);
 
-    let result = async {
-        let (username, token) = resolve_credentials(cached).await?;
-        let client = GitHubClient::new(&token).map_err(|e| e.to_string())?;
-        let stats = sync_dashboard(&client, pool, &username)
-            .await
-            .map_err(|e| e.to_string())?;
-        if let Err(e) = app_handle.emit("github:updated", &stats) {
-            warn!("failed to emit github:updated after force sync: {e}");
-        }
-        Ok(stats)
+    let (username, token) = resolve_credentials(cached).await?;
+    let client = GitHubClient::new(&token).map_err(|e| e.to_string())?;
+    let stats = sync_dashboard(&client, pool, &username)
+        .await
+        .map_err(|e| e.to_string())?;
+    if let Err(e) = app_handle.emit("github:updated", &stats) {
+        warn!("failed to emit github:updated after force sync: {e}");
     }
-    .await;
-
-    guard.0.store(false, Ordering::Release);
-    result
+    Ok(stats)
 }
 
 /// Triggers an immediate GitHub data sync, bypassing the polling timer.
@@ -292,6 +295,7 @@ pub async fn github_force_sync(
     app_handle: tauri::AppHandle,
 ) -> Result<(), String> {
     let stats = run_force_sync(&app_handle, &pool, &cached).await?;
+    #[cfg(not(any(target_os = "android", target_os = "ios")))]
     if let Err(e) = crate::tray::update_tray_badge(&app_handle, stats.pending_reviews) {
         warn!("failed to update tray badge after force sync: {e}");
     }

--- a/src-tauri/src/github/polling.rs
+++ b/src-tauri/src/github/polling.rs
@@ -65,6 +65,9 @@ impl PollingContext for RealPollingContext {
         if let Err(e) = self.app_handle.emit("github:updated", stats) {
             warn!("failed to emit github:updated: {e}");
         }
+        if let Err(e) = crate::tray::update_tray_badge(&self.app_handle, stats.pending_reviews) {
+            warn!("failed to update tray badge: {e}");
+        }
     }
 
     fn emit_sync_error(&self, error: &str) {

--- a/src-tauri/src/github/polling.rs
+++ b/src-tauri/src/github/polling.rs
@@ -65,6 +65,7 @@ impl PollingContext for RealPollingContext {
         if let Err(e) = self.app_handle.emit("github:updated", stats) {
             warn!("failed to emit github:updated: {e}");
         }
+        #[cfg(not(any(target_os = "android", target_os = "ios")))]
         if let Err(e) = crate::tray::update_tray_badge(&self.app_handle, stats.pending_reviews) {
             warn!("failed to update tray badge: {e}");
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,9 +9,19 @@ pub mod types;
 mod workspace;
 
 use std::sync::Mutex;
+use std::sync::atomic::AtomicBool;
 
 use log::info;
 use tauri::Manager;
+
+/// Guards against concurrent force-sync invocations from the tray or IPC.
+pub(crate) struct SyncInFlight(pub(crate) AtomicBool);
+
+impl Default for SyncInFlight {
+    fn default() -> Self {
+        Self(AtomicBool::new(false))
+    }
+}
 
 /// Holds the background polling task handle for cancellation on logout/shutdown.
 ///
@@ -128,6 +138,9 @@ pub fn run() {
 
             // Polling handle — empty until credentials are verified
             app.manage(PollingHandle::default());
+
+            // Force-sync guard — prevents concurrent sync invocations
+            app.manage(SyncInFlight::default());
 
             // System tray icon with context menu
             tray::setup_tray(app).map_err(|e| e.to_string())?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod config;
 mod error;
 mod github;
 mod notifications;
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 mod tray;
 pub mod types;
 mod workspace;
@@ -142,7 +143,8 @@ pub fn run() {
             // Force-sync guard — prevents concurrent sync invocations
             app.manage(SyncInFlight::default());
 
-            // System tray icon with context menu
+            // System tray icon with context menu (desktop only)
+            #[cfg(not(any(target_os = "android", target_os = "ios")))]
             tray::setup_tray(app).map_err(|e| e.to_string())?;
 
             // Attempt to start background polling (non-blocking)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod config;
 mod error;
 mod github;
 mod notifications;
+mod tray;
 pub mod types;
 mod workspace;
 
@@ -127,6 +128,9 @@ pub fn run() {
 
             // Polling handle — empty until credentials are verified
             app.manage(PollingHandle::default());
+
+            // System tray icon with context menu
+            tray::setup_tray(app).map_err(|e| e.to_string())?;
 
             // Attempt to start background polling (non-blocking)
             let handle = app.handle().clone();

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -1,0 +1,176 @@
+use log::warn;
+use tauri::Manager;
+use tauri::menu::{Menu, MenuItem, PredefinedMenuItem};
+use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
+
+pub(crate) const TRAY_ID: &str = "prism_tray";
+pub(crate) const MENU_SHOW: &str = "show_prism";
+pub(crate) const MENU_FORCE_SYNC: &str = "force_sync";
+pub(crate) const MENU_QUIT: &str = "quit";
+
+pub(crate) const MENU_SHOW_LABEL: &str = "Show PRism";
+pub(crate) const MENU_FORCE_SYNC_LABEL: &str = "Force Sync";
+pub(crate) const MENU_QUIT_LABEL: &str = "Quit";
+
+/// Format the tray tooltip based on pending review count.
+pub fn format_tray_tooltip(pending_count: u32) -> String {
+    match pending_count {
+        0 => "PRism — No pending reviews".to_string(),
+        1 => "PRism — 1 pending review".to_string(),
+        n => format!("PRism — {n} pending reviews"),
+    }
+}
+
+/// Build and register the system tray icon with context menu.
+///
+/// Creates a tray with three menu items: Show `PRism`, Force Sync, Quit.
+/// Left-click toggles window visibility; right-click shows the menu.
+pub fn setup_tray(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
+    let show_item = MenuItem::with_id(app, MENU_SHOW, MENU_SHOW_LABEL, true, None::<&str>)?;
+    let sync_item = MenuItem::with_id(
+        app,
+        MENU_FORCE_SYNC,
+        MENU_FORCE_SYNC_LABEL,
+        true,
+        None::<&str>,
+    )?;
+    let quit_item = MenuItem::with_id(app, MENU_QUIT, MENU_QUIT_LABEL, true, None::<&str>)?;
+    let separator = PredefinedMenuItem::separator(app)?;
+
+    let menu = Menu::with_items(app, &[&show_item, &sync_item, &separator, &quit_item])?;
+
+    let tooltip = format_tray_tooltip(0);
+
+    TrayIconBuilder::with_id(TRAY_ID)
+        .icon(
+            app.default_window_icon()
+                .cloned()
+                .ok_or("no default icon")?,
+        )
+        .menu(&menu)
+        .show_menu_on_left_click(false)
+        .tooltip(tooltip)
+        .on_menu_event(handle_menu_event)
+        .on_tray_icon_event(handle_tray_icon_event)
+        .build(app)?;
+
+    Ok(())
+}
+
+/// Update the tray tooltip to reflect the current pending review count.
+pub fn update_tray_badge(app_handle: &tauri::AppHandle, pending_count: u32) -> Result<(), String> {
+    let tray = app_handle
+        .tray_by_id(TRAY_ID)
+        .ok_or_else(|| format!("tray icon '{TRAY_ID}' not found"))?;
+
+    let tooltip = format_tray_tooltip(pending_count);
+    tray.set_tooltip(Some(&tooltip))
+        .map_err(|e| format!("failed to set tooltip: {e}"))
+}
+
+#[allow(clippy::needless_pass_by_value)] // Signature imposed by Tauri on_menu_event callback
+fn handle_menu_event(app: &tauri::AppHandle, event: tauri::menu::MenuEvent) {
+    match event.id().as_ref() {
+        MENU_SHOW => {
+            if let Some(window) = app.get_webview_window("main") {
+                if let Err(e) = window.show() {
+                    warn!("tray: failed to show window: {e}");
+                }
+                if let Err(e) = window.set_focus() {
+                    warn!("tray: failed to focus window: {e}");
+                }
+            }
+        }
+        MENU_FORCE_SYNC => {
+            let handle = app.clone();
+            tauri::async_runtime::spawn(async move {
+                let pool = handle.state::<sqlx::SqlitePool>();
+                let cached = handle.state::<crate::commands::GithubUsername>();
+                if let Err(e) = crate::commands::run_force_sync(&handle, &pool, &cached).await {
+                    warn!("tray force sync failed: {e}");
+                }
+            });
+        }
+        MENU_QUIT => {
+            app.exit(0);
+        }
+        other => {
+            warn!("tray: unhandled menu event: {other}");
+        }
+    }
+}
+
+#[allow(clippy::needless_pass_by_value)] // Signature imposed by Tauri on_tray_icon_event callback
+fn handle_tray_icon_event(tray: &tauri::tray::TrayIcon, event: TrayIconEvent) {
+    if let TrayIconEvent::Click {
+        button: MouseButton::Left,
+        button_state: MouseButtonState::Up,
+        ..
+    } = event
+    {
+        let app = tray.app_handle();
+        if let Some(window) = app.get_webview_window("main") {
+            let visible = window.is_visible().unwrap_or(false);
+            if visible {
+                if let Err(e) = window.hide() {
+                    warn!("tray: failed to hide window: {e}");
+                }
+            } else {
+                if let Err(e) = window.show() {
+                    warn!("tray: failed to show window: {e}");
+                }
+                if let Err(e) = window.set_focus() {
+                    warn!("tray: failed to focus window: {e}");
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tray_menu_items_have_distinct_ids() {
+        let ids = [MENU_SHOW, MENU_FORCE_SYNC, MENU_QUIT];
+        for (i, a) in ids.iter().enumerate() {
+            for (j, b) in ids.iter().enumerate() {
+                if i != j {
+                    assert_ne!(a, b, "menu IDs must be unique");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_tray_menu_items_labels_are_correct() {
+        assert_eq!(MENU_SHOW_LABEL, "Show PRism");
+        assert_eq!(MENU_FORCE_SYNC_LABEL, "Force Sync");
+        assert_eq!(MENU_QUIT_LABEL, "Quit");
+    }
+
+    #[test]
+    fn test_tray_id_is_set() {
+        assert_eq!(TRAY_ID, "prism_tray");
+    }
+
+    #[test]
+    fn test_badge_update_zero_reviews() {
+        let tooltip = format_tray_tooltip(0);
+        assert_eq!(tooltip, "PRism — No pending reviews");
+    }
+
+    #[test]
+    fn test_badge_update_one_review() {
+        let tooltip = format_tray_tooltip(1);
+        assert_eq!(tooltip, "PRism — 1 pending review");
+    }
+
+    #[test]
+    fn test_badge_update_multiple_reviews() {
+        assert_eq!(format_tray_tooltip(5), "PRism — 5 pending reviews");
+        assert_eq!(format_tray_tooltip(42), "PRism — 42 pending reviews");
+        assert_eq!(format_tray_tooltip(100), "PRism — 100 pending reviews");
+    }
+}

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -71,8 +71,8 @@ pub fn update_tray_badge(app_handle: &tauri::AppHandle, pending_count: u32) -> R
 #[allow(clippy::needless_pass_by_value)] // Signature imposed by Tauri on_menu_event callback
 fn handle_menu_event(app: &tauri::AppHandle, event: tauri::menu::MenuEvent) {
     match event.id().as_ref() {
-        MENU_SHOW => {
-            if let Some(window) = app.get_webview_window("main") {
+        MENU_SHOW => match app.get_webview_window("main") {
+            Some(window) => {
                 if let Err(e) = window.show() {
                     warn!("tray: failed to show window: {e}");
                 }
@@ -80,14 +80,20 @@ fn handle_menu_event(app: &tauri::AppHandle, event: tauri::menu::MenuEvent) {
                     warn!("tray: failed to focus window: {e}");
                 }
             }
-        }
+            None => warn!("tray: main window not found for MENU_SHOW"),
+        },
         MENU_FORCE_SYNC => {
             let handle = app.clone();
             tauri::async_runtime::spawn(async move {
                 let pool = handle.state::<sqlx::SqlitePool>();
                 let cached = handle.state::<crate::commands::GithubUsername>();
-                if let Err(e) = crate::commands::run_force_sync(&handle, &pool, &cached).await {
-                    warn!("tray force sync failed: {e}");
+                match crate::commands::run_force_sync(&handle, &pool, &cached).await {
+                    Ok(stats) => {
+                        if let Err(e) = update_tray_badge(&handle, stats.pending_reviews) {
+                            warn!("tray: failed to update badge after sync: {e}");
+                        }
+                    }
+                    Err(e) => warn!("tray force sync failed: {e}"),
                 }
             });
         }
@@ -109,20 +115,23 @@ fn handle_tray_icon_event(tray: &tauri::tray::TrayIcon, event: TrayIconEvent) {
     } = event
     {
         let app = tray.app_handle();
-        if let Some(window) = app.get_webview_window("main") {
-            let visible = window.is_visible().unwrap_or(false);
-            if visible {
-                if let Err(e) = window.hide() {
-                    warn!("tray: failed to hide window: {e}");
-                }
-            } else {
-                if let Err(e) = window.show() {
-                    warn!("tray: failed to show window: {e}");
-                }
-                if let Err(e) = window.set_focus() {
-                    warn!("tray: failed to focus window: {e}");
+        match app.get_webview_window("main") {
+            Some(window) => {
+                let visible = window.is_visible().unwrap_or(false);
+                if visible {
+                    if let Err(e) = window.hide() {
+                        warn!("tray: failed to hide window: {e}");
+                    }
+                } else {
+                    if let Err(e) = window.show() {
+                        warn!("tray: failed to show window: {e}");
+                    }
+                    if let Err(e) = window.set_focus() {
+                        warn!("tray: failed to focus window: {e}");
+                    }
                 }
             }
+            None => warn!("tray: main window not found for tray icon click"),
         }
     }
 }


### PR DESCRIPTION
## Summary

• Implement system tray icon with Tauri 2.10 native API
• Badge tooltip displays pending review count (updated after every sync)
• Context menu: Show PRism, Force Sync, Quit
• Left-click on tray toggles main window visibility
• Extract force-sync core logic for sharing between IPC command and tray handler
• Proper error logging for window and sync operations

## Type

feat(notifications) — E-08, US-13

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a desktop system tray for PRism with a badge tooltip and quick actions. Implements T-062 and updates the tray tooltip after each poll or Force Sync.

- **New Features**
  - System tray via `tauri`; left-click toggles the main window.
  - Tooltip shows pending review count; auto-refreshes after polling and Force Sync.
  - Context menu: Show PRism, Force Sync, Quit.

- **Refactors**
  - Extracted and decoupled `run_force_sync` (emits `github:updated`, returns stats; callers update the badge).
  - Added desktop-only tray gating and a `SyncInFlight` RAII guard to prevent concurrent syncs; improved warnings when the main window is missing or window actions fail.

<sup>Written for commit 9302ce5d586423cd8d3be1e92783ea3329535a68. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added system tray with context menu (Show PRism, Force Sync, Quit) and tooltip showing pending GitHub review count; tray icon toggles the app window.

* **Bug Fixes**
  * Prevents overlapping syncs and ensures tray badge updates after polling or manual sync.

* **Chores**
  * Enabled tray/menu capabilities and updated build configuration to support the tray icon.

* **Tests**
  * Added unit tests for tray menu IDs, labels, and tooltip text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->