### PR TITLE
feat(notifications): integrate notification events into frontend (T-063)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { Issues } from "./components/Issues";
 import { ActivityFeed } from "./components/ActivityFeed";
 import { Workspace } from "./components/Workspace";
 import { Settings } from "./components/Settings";
+import { Toast } from "./components/Toast";
 import { useDashboardStore } from "./stores/dashboard";
 import type { DashboardView } from "./stores/dashboard";
 
@@ -37,7 +38,7 @@ function MainContent({ view }: MainContentProps): ReactElement {
   }
 }
 
-function App() {
+function App(): ReactElement {
   const currentView = useDashboardStore((s) => s.currentView);
   const isWorkspace = currentView === "workspaces";
 
@@ -50,6 +51,8 @@ function App() {
       <main className={isWorkspace ? "flex-1" : "min-w-0 flex-1"}>
         <MainContent view={currentView} />
       </main>
+
+      <Toast />
     </div>
   );
 }

--- a/src/components/Toast/Toast.test.tsx
+++ b/src/components/Toast/Toast.test.tsx
@@ -107,6 +107,33 @@ describe("Toast", () => {
     expect(mockClearNotification).toHaveBeenCalledWith("notif-1");
   });
 
+  it("should not dismiss after unmount", () => {
+    (useNotifications as Mock).mockReturnValue({
+      notifications: [makeNotification()],
+      clearNotification: mockClearNotification,
+    });
+
+    const { unmount } = render(<Toast />);
+    unmount();
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    expect(mockClearNotification).not.toHaveBeenCalled();
+  });
+
+  it("should display payload summary in toast", () => {
+    (useNotifications as Mock).mockReturnValue({
+      notifications: [makeNotification()],
+      clearNotification: mockClearNotification,
+    });
+
+    render(<Toast />);
+
+    expect(screen.getByText("#42 Fix bug")).toBeInTheDocument();
+  });
+
   it("should navigate on click", async () => {
     vi.useRealTimers();
 

--- a/src/components/Toast/Toast.test.tsx
+++ b/src/components/Toast/Toast.test.tsx
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { Toast } from "./Toast";
+
+vi.mock("../../hooks/useNotifications", () => ({
+  useNotifications: vi.fn(),
+}));
+
+vi.mock("../../stores/dashboard", () => ({
+  useDashboardStore: vi.fn(),
+}));
+
+import { useNotifications } from "../../hooks/useNotifications";
+import { useDashboardStore } from "../../stores/dashboard";
+import type { Notification } from "../../hooks/useNotifications";
+
+function makeNotification(overrides: Partial<Notification> = {}): Notification {
+  return {
+    id: "notif-1",
+    type: "review_request",
+    payload: { prNumber: 42, repo: "mpiton/prism", title: "Fix bug" },
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}
+
+describe("Toast", () => {
+  const mockClearNotification = vi.fn();
+  const mockSetView = vi.fn();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+
+    (useNotifications as Mock).mockReturnValue({
+      notifications: [],
+      clearNotification: mockClearNotification,
+    });
+
+    (useDashboardStore as unknown as Mock).mockReturnValue(mockSetView);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("should show toast on review_request event", () => {
+    (useNotifications as Mock).mockReturnValue({
+      notifications: [makeNotification()],
+      clearNotification: mockClearNotification,
+    });
+
+    render(<Toast />);
+
+    expect(screen.getByText("Review Request")).toBeInTheDocument();
+  });
+
+  it("should show toast on ci_failure event", () => {
+    (useNotifications as Mock).mockReturnValue({
+      notifications: [
+        makeNotification({
+          id: "notif-ci",
+          type: "ci_failure",
+          payload: { prNumber: 10, repo: "mpiton/prism", check: "ci/build" },
+        }),
+      ],
+      clearNotification: mockClearNotification,
+    });
+
+    render(<Toast />);
+
+    expect(screen.getByText("CI Failure")).toBeInTheDocument();
+  });
+
+  it("should show toast on pr_approved event", () => {
+    (useNotifications as Mock).mockReturnValue({
+      notifications: [
+        makeNotification({
+          id: "notif-approved",
+          type: "pr_approved",
+          payload: { prNumber: 5, repo: "mpiton/prism" },
+        }),
+      ],
+      clearNotification: mockClearNotification,
+    });
+
+    render(<Toast />);
+
+    expect(screen.getByText("PR Approved")).toBeInTheDocument();
+  });
+
+  it("should auto-dismiss after 5s", () => {
+    (useNotifications as Mock).mockReturnValue({
+      notifications: [makeNotification()],
+      clearNotification: mockClearNotification,
+    });
+
+    render(<Toast />);
+
+    expect(screen.getByText("Review Request")).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    expect(mockClearNotification).toHaveBeenCalledWith("notif-1");
+  });
+
+  it("should navigate on click", async () => {
+    vi.useRealTimers();
+
+    (useNotifications as Mock).mockReturnValue({
+      notifications: [makeNotification()],
+      clearNotification: mockClearNotification,
+    });
+
+    render(<Toast />);
+
+    const toast = screen.getByRole("button");
+    const user = userEvent.setup();
+    await user.click(toast);
+
+    expect(mockSetView).toHaveBeenCalledWith("reviews");
+    expect(mockClearNotification).toHaveBeenCalledWith("notif-1");
+  });
+
+  it("should navigate to mine on ci_failure click", async () => {
+    vi.useRealTimers();
+
+    (useNotifications as Mock).mockReturnValue({
+      notifications: [
+        makeNotification({ id: "notif-ci", type: "ci_failure" }),
+      ],
+      clearNotification: mockClearNotification,
+    });
+
+    render(<Toast />);
+
+    const toast = screen.getByRole("button");
+    const user = userEvent.setup();
+    await user.click(toast);
+
+    expect(mockSetView).toHaveBeenCalledWith("mine");
+    expect(mockClearNotification).toHaveBeenCalledWith("notif-ci");
+  });
+
+  it("should render multiple toasts", () => {
+    (useNotifications as Mock).mockReturnValue({
+      notifications: [
+        makeNotification({ id: "n1", type: "review_request" }),
+        makeNotification({ id: "n2", type: "ci_failure" }),
+        makeNotification({ id: "n3", type: "pr_approved" }),
+      ],
+      clearNotification: mockClearNotification,
+    });
+
+    render(<Toast />);
+
+    expect(screen.getByText("Review Request")).toBeInTheDocument();
+    expect(screen.getByText("CI Failure")).toBeInTheDocument();
+    expect(screen.getByText("PR Approved")).toBeInTheDocument();
+  });
+
+  it("should render nothing when no notifications", () => {
+    const { container } = render(<Toast />);
+
+    expect(container.querySelector("[data-testid='toast-container']")?.children).toHaveLength(0);
+  });
+});

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -21,9 +21,23 @@ interface ToastItemProps {
   readonly onNavigate: (view: DashboardView) => void;
 }
 
+function extractPayloadSummary(payload: unknown): string | undefined {
+  if (typeof payload !== "object" || payload === null) {
+    return undefined;
+  }
+  const obj = payload as Record<string, unknown>;
+  const title = typeof obj.title === "string" ? obj.title : undefined;
+  const prNumber = typeof obj.prNumber === "number" ? `#${obj.prNumber}` : undefined;
+  if (title && prNumber) {
+    return `${prNumber} ${title}`;
+  }
+  return title ?? prNumber;
+}
+
 function ToastItem({ notification, onDismiss, onNavigate }: ToastItemProps): ReactElement {
   const timerRef = useRef<ReturnType<typeof setTimeout>>(null);
   const meta = NOTIFICATION_META[notification.type];
+  const summary = extractPayloadSummary(notification.payload);
 
   useEffect(() => {
     timerRef.current = setTimeout(() => {
@@ -48,11 +62,17 @@ function ToastItem({ notification, onDismiss, onNavigate }: ToastItemProps): Rea
   return (
     <button
       type="button"
+      aria-label={`${meta.label} — click to navigate`}
       onClick={handleClick}
       className="flex w-72 items-center gap-3 rounded-lg border border-border bg-bg-secondary p-3 shadow-lg transition-opacity hover:opacity-80"
     >
       <span className="text-lg" aria-hidden="true">{meta.icon}</span>
-      <span className="text-sm font-medium text-fg">{meta.label}</span>
+      <div className="flex flex-col items-start">
+        <span className="text-sm font-medium text-fg">{meta.label}</span>
+        {summary !== undefined && (
+          <span className="text-xs text-fg-muted">{summary}</span>
+        )}
+      </div>
     </button>
   );
 }

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -26,8 +26,12 @@ function extractPayloadSummary(payload: unknown): string | undefined {
     return undefined;
   }
   const obj = payload as Record<string, unknown>;
-  const title = typeof obj.title === "string" ? obj.title : undefined;
-  const prNumber = typeof obj.prNumber === "number" ? `#${obj.prNumber}` : undefined;
+  const rawTitle = typeof obj.title === "string" ? obj.title.trim() : "";
+  const title = rawTitle.length > 0 ? rawTitle : undefined;
+  const prNumber =
+    typeof obj.prNumber === "number" && Number.isFinite(obj.prNumber)
+      ? `#${obj.prNumber}`
+      : undefined;
   if (title && prNumber) {
     return `${prNumber} ${title}`;
   }

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -62,7 +62,7 @@ function ToastItem({ notification, onDismiss, onNavigate }: ToastItemProps): Rea
   return (
     <button
       type="button"
-      aria-label={`${meta.label} — click to navigate`}
+      aria-label={`${meta.label}${summary ? ` ${summary}` : ""} — click to navigate`}
       onClick={handleClick}
       className="flex w-72 items-center gap-3 rounded-lg border border-border bg-bg-secondary p-3 shadow-lg transition-opacity hover:opacity-80"
     >

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -1,0 +1,80 @@
+import { useCallback, useEffect, useRef, type ReactElement } from "react";
+import { useNotifications } from "../../hooks/useNotifications";
+import type { Notification } from "../../hooks/useNotifications";
+import { useDashboardStore } from "../../stores/dashboard";
+import type { DashboardView } from "../../stores/dashboard";
+
+const AUTO_DISMISS_MS = 5_000;
+
+const NOTIFICATION_META: Record<
+  Notification["type"],
+  { label: string; icon: string; view: DashboardView }
+> = {
+  review_request: { label: "Review Request", icon: "👀", view: "reviews" },
+  ci_failure: { label: "CI Failure", icon: "❌", view: "mine" },
+  pr_approved: { label: "PR Approved", icon: "✅", view: "mine" },
+};
+
+interface ToastItemProps {
+  readonly notification: Notification;
+  readonly onDismiss: (id: string) => void;
+  readonly onNavigate: (view: DashboardView) => void;
+}
+
+function ToastItem({ notification, onDismiss, onNavigate }: ToastItemProps): ReactElement {
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(null);
+  const meta = NOTIFICATION_META[notification.type];
+
+  useEffect(() => {
+    timerRef.current = setTimeout(() => {
+      onDismiss(notification.id);
+    }, AUTO_DISMISS_MS);
+
+    return () => {
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, [notification.id, onDismiss]);
+
+  const handleClick = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+    }
+    onNavigate(meta.view);
+    onDismiss(notification.id);
+  }, [notification.id, onDismiss, onNavigate, meta.view]);
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className="flex w-72 items-center gap-3 rounded-lg border border-border bg-bg-secondary p-3 shadow-lg transition-opacity hover:opacity-80"
+    >
+      <span className="text-lg" aria-hidden="true">{meta.icon}</span>
+      <span className="text-sm font-medium text-fg">{meta.label}</span>
+    </button>
+  );
+}
+
+export function Toast(): ReactElement {
+  const { notifications, clearNotification } = useNotifications();
+  const setView = useDashboardStore((s) => s.setView);
+
+  return (
+    <div
+      data-testid="toast-container"
+      aria-live="polite"
+      className="fixed bottom-4 right-4 z-50 flex flex-col gap-2"
+    >
+      {notifications.map((n) => (
+        <ToastItem
+          key={n.id}
+          notification={n}
+          onDismiss={clearNotification}
+          onNavigate={setView}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/Toast/index.ts
+++ b/src/components/Toast/index.ts
@@ -1,0 +1,1 @@
+export { Toast } from "./Toast";


### PR DESCRIPTION
## Summary

• Toast component displaying notifications (review_request, ci_failure, pr_approved)
• Auto-dismiss after 5 seconds with manual close on click
• Click navigation to relevant dashboard section (reviews or mine)
• Full accessibility support (aria-live, aria-hidden)
• 8 tests passing, oxlint clean, no TypeScript errors

## Files

- `src/components/Toast/Toast.tsx` - Toast component with timer management
- `src/components/Toast/Toast.test.tsx` - 8 comprehensive tests
- `src/App.tsx` - Toast integration into root component

## Type

feat(notifications)

## Test Coverage

All 8 test cases passing (312/312 total suite):
- Show toast on review_request, ci_failure, pr_approved events
- Auto-dismiss after 5s
- Navigate on click
- Multiple toasts support
- Unmount cleanup

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `Toast` UI to surface dashboard notification events with auto-dismiss, payload summary, and click-through navigation, now resilient to malformed payloads. Fulfills T-063 by wiring `review_request`, `ci_failure`, and `pr_approved` from `useNotifications` into the frontend.

- **New Features**
  - Mounted in `App.tsx`; one toast per event; supports multiple toasts.
  - Auto-dismiss after 5s; click navigates (`reviews` for review requests; `mine` for CI failures/approvals) and dismisses.
  - Shows payload summary (e.g., `#42 Fix bug`); a11y: `aria-live` and button `aria-label` with the summary; timers cleared on unmount.

- **Bug Fixes**
  - Hardened payload parsing for summaries and `aria-label` to ignore malformed values.

<sup>Written for commit 0ab0aed2e1baec11f1a582c818a5072c35ee200a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a global Toast notification UI (bottom-right) with multiple types, distinct labels/icons, contextual summaries (e.g., PR number + title), 5s auto-dismiss, and click-to-navigate behavior to relevant dashboard views.

* **Tests**
  * Added tests for rendering, auto-dismiss timing, click navigation behavior, multiple-toasts rendering, and empty-toast state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->