### PR TITLE
feat(ui): integrate cmdk command palette (T-064)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@fontsource/ibm-plex-sans": "^5.2.8",
         "@tanstack/react-query": "^5.95.2",
         "@tauri-apps/api": "^2.10.1",
+        "cmdk": "^1.1.1",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "zustand": "^5.0.12"
@@ -1310,6 +1311,447 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
+      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
+      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
+      "integrity": "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
+      "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
+      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.11",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.11.tgz",
@@ -2252,7 +2694,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -2447,6 +2889,18 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/aria-query": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
@@ -2555,6 +3009,22 @@
         "node": ">=18"
       }
     },
+    "node_modules/cmdk": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+      "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "^1.1.1",
+        "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-id": "^1.1.0",
+        "@radix-ui/react-primitive": "^2.0.2"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -2648,6 +3118,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
     },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
@@ -2769,6 +3245,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/graceful-fs": {
@@ -3561,6 +4046,75 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -3844,9 +4398,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/typescript": {
       "version": "6.0.2",
@@ -3901,6 +4453,49 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@fontsource/ibm-plex-sans": "^5.2.8",
     "@tanstack/react-query": "^5.95.2",
     "@tauri-apps/api": "^2.10.1",
+    "cmdk": "^1.1.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "zustand": "^5.0.12"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement } from "react";
+import { useState, type ReactElement } from "react";
 import { Sidebar } from "./components/Sidebar";
 import { Overview } from "./components/Overview";
 import { ReviewQueue } from "./components/ReviewQueue";
@@ -8,6 +8,8 @@ import { ActivityFeed } from "./components/ActivityFeed";
 import { Workspace } from "./components/Workspace";
 import { Settings } from "./components/Settings";
 import { Toast } from "./components/Toast";
+import { CommandPalette } from "./components/CommandPalette";
+import { useKeyboard } from "./hooks/useKeyboard";
 import { useDashboardStore } from "./stores/dashboard";
 import type { DashboardView } from "./stores/dashboard";
 
@@ -41,6 +43,16 @@ function MainContent({ view }: MainContentProps): ReactElement {
 function App(): ReactElement {
   const currentView = useDashboardStore((s) => s.currentView);
   const isWorkspace = currentView === "workspaces";
+  const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
+
+  useKeyboard({
+    onCommandPalette: () => setCommandPaletteOpen((prev) => !prev),
+    onNavigate: () => {},
+    onOpen: () => {},
+    onOpenWorkspace: () => {},
+    onSwitchWorkspace: () => {},
+    onEscape: () => {},
+  });
 
   return (
     <div className="flex h-screen bg-bg text-fg">
@@ -53,6 +65,10 @@ function App(): ReactElement {
       </main>
 
       <Toast />
+      <CommandPalette
+        open={commandPaletteOpen}
+        onOpenChange={setCommandPaletteOpen}
+      />
     </div>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,11 +47,6 @@ function App(): ReactElement {
 
   useKeyboard({
     onCommandPalette: () => setCommandPaletteOpen((prev) => !prev),
-    onNavigate: () => {},
-    onOpen: () => {},
-    onOpenWorkspace: () => {},
-    onSwitchWorkspace: () => {},
-    onEscape: () => {},
   });
 
   return (

--- a/src/components/CommandPalette/CommandPalette.test.tsx
+++ b/src/components/CommandPalette/CommandPalette.test.tsx
@@ -1,0 +1,269 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { CommandPalette } from "./CommandPalette";
+
+vi.mock("../../hooks/useGitHubData", () => ({
+  useGitHubData: vi.fn(),
+}));
+
+import { useGitHubData } from "../../hooks/useGitHubData";
+import type { DashboardData, PullRequestWithReview, Issue } from "../../lib/types";
+
+function makePr(overrides: Partial<PullRequestWithReview> = {}): PullRequestWithReview {
+  return {
+    pullRequest: {
+      id: "pr-1",
+      number: 42,
+      title: "Fix login bug",
+      author: "alice",
+      state: "open",
+      ciStatus: "success",
+      priority: "high",
+      repoId: "repo-1",
+      url: "https://github.com/org/repo/pull/42",
+      labels: [],
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+    },
+    reviewSummary: {
+      totalReviews: 1,
+      approved: 0,
+      changesRequested: 0,
+      pending: 1,
+      reviewers: ["bob"],
+    },
+    workspace: null,
+    ...overrides,
+  };
+}
+
+function makeIssue(overrides: Partial<Issue> = {}): Issue {
+  return {
+    id: "issue-1",
+    number: 99,
+    title: "Dashboard crashes on empty data",
+    author: "carol",
+    state: "open",
+    priority: "medium",
+    repoId: "repo-1",
+    url: "https://github.com/org/repo/issues/99",
+    labels: [],
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeDashboard(
+  overrides: Partial<DashboardData> = {},
+): DashboardData {
+  return {
+    reviewRequests: [],
+    myPullRequests: [],
+    assignedIssues: [],
+    recentActivity: [],
+    workspaces: [],
+    syncedAt: null,
+    ...overrides,
+  };
+}
+
+describe("CommandPalette", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    (useGitHubData as Mock).mockReturnValue({
+      dashboard: makeDashboard(),
+      stats: null,
+      isLoading: false,
+      error: null,
+      forceSync: vi.fn(),
+      isSyncing: false,
+    });
+  });
+
+  it("should not render when closed", () => {
+    render(<CommandPalette open={false} onOpenChange={() => {}} />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("should open on Cmd+K", async () => {
+    const onOpenChange = vi.fn();
+    render(<CommandPalette open={false} onOpenChange={onOpenChange} />);
+
+    // CommandPalette itself doesn't handle Cmd+K — that's useKeyboard's job.
+    // But when open=true, it should render the dialog.
+    const { rerender } = render(
+      <CommandPalette open={true} onOpenChange={onOpenChange} />,
+    );
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    // Verify search input is present and focused
+    const input = screen.getByPlaceholderText(/search/i);
+    expect(input).toBeInTheDocument();
+    rerender(<CommandPalette open={true} onOpenChange={onOpenChange} />);
+  });
+
+  it("should close on Esc", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    render(<CommandPalette open={true} onOpenChange={onOpenChange} />);
+
+    await user.keyboard("{Escape}");
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("should search PRs by title", async () => {
+    const pr1 = makePr();
+    const pr2 = makePr({
+      pullRequest: {
+        ...makePr().pullRequest,
+        id: "pr-2",
+        number: 43,
+        title: "Add search feature",
+      },
+    });
+
+    (useGitHubData as Mock).mockReturnValue({
+      dashboard: makeDashboard({
+        reviewRequests: [pr1],
+        myPullRequests: [pr2],
+      }),
+      stats: null,
+      isLoading: false,
+      error: null,
+      forceSync: vi.fn(),
+      isSyncing: false,
+    });
+
+    const user = userEvent.setup();
+    render(<CommandPalette open={true} onOpenChange={() => {}} />);
+
+    const input = screen.getByPlaceholderText(/search/i);
+    await user.type(input, "login");
+
+    // "Fix login bug" should be visible, "Add search feature" should not
+    expect(screen.getByText(/Fix login bug/)).toBeInTheDocument();
+    expect(screen.queryByText(/Add search feature/)).not.toBeInTheDocument();
+  });
+
+  it("should search issues by number", async () => {
+    const issue = makeIssue();
+
+    (useGitHubData as Mock).mockReturnValue({
+      dashboard: makeDashboard({ assignedIssues: [issue] }),
+      stats: null,
+      isLoading: false,
+      error: null,
+      forceSync: vi.fn(),
+      isSyncing: false,
+    });
+
+    const user = userEvent.setup();
+    render(<CommandPalette open={true} onOpenChange={() => {}} />);
+
+    const input = screen.getByPlaceholderText(/search/i);
+    await user.type(input, "99");
+
+    expect(screen.getByText(/Dashboard crashes on empty data/)).toBeInTheDocument();
+  });
+
+  it("should open selected item", async () => {
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+    const pr = makePr();
+
+    (useGitHubData as Mock).mockReturnValue({
+      dashboard: makeDashboard({ reviewRequests: [pr] }),
+      stats: null,
+      isLoading: false,
+      error: null,
+      forceSync: vi.fn(),
+      isSyncing: false,
+    });
+
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    render(<CommandPalette open={true} onOpenChange={onOpenChange} />);
+
+    const item = screen.getByText(/Fix login bug/);
+    await user.click(item);
+
+    expect(openSpy).toHaveBeenCalledWith(
+      "https://github.com/org/repo/pull/42",
+      "_blank",
+      "noopener,noreferrer",
+    );
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+
+    openSpy.mockRestore();
+  });
+
+  it("should show empty state when no results match", async () => {
+    const user = userEvent.setup();
+    render(<CommandPalette open={true} onOpenChange={() => {}} />);
+
+    const input = screen.getByPlaceholderText(/search/i);
+    await user.type(input, "zzzznonexistent");
+
+    expect(screen.getByText(/no results/i)).toBeInTheDocument();
+  });
+
+  it("should display PR items with number, title and repo info", () => {
+    const pr = makePr();
+
+    (useGitHubData as Mock).mockReturnValue({
+      dashboard: makeDashboard({ reviewRequests: [pr] }),
+      stats: null,
+      isLoading: false,
+      error: null,
+      forceSync: vi.fn(),
+      isSyncing: false,
+    });
+
+    render(<CommandPalette open={true} onOpenChange={() => {}} />);
+
+    expect(screen.getByText(/Fix login bug/)).toBeInTheDocument();
+    expect(screen.getByText(/#42/)).toBeInTheDocument();
+  });
+
+  it("should display issue items with number and title", () => {
+    const issue = makeIssue();
+
+    (useGitHubData as Mock).mockReturnValue({
+      dashboard: makeDashboard({ assignedIssues: [issue] }),
+      stats: null,
+      isLoading: false,
+      error: null,
+      forceSync: vi.fn(),
+      isSyncing: false,
+    });
+
+    render(<CommandPalette open={true} onOpenChange={() => {}} />);
+
+    expect(screen.getByText(/Dashboard crashes on empty data/)).toBeInTheDocument();
+    expect(screen.getByText(/#99/)).toBeInTheDocument();
+  });
+
+  it("should deduplicate PRs that appear in both review and my lists", () => {
+    const pr = makePr();
+
+    (useGitHubData as Mock).mockReturnValue({
+      dashboard: makeDashboard({
+        reviewRequests: [pr],
+        myPullRequests: [pr],
+      }),
+      stats: null,
+      isLoading: false,
+      error: null,
+      forceSync: vi.fn(),
+      isSyncing: false,
+    });
+
+    render(<CommandPalette open={true} onOpenChange={() => {}} />);
+
+    // Should only appear once
+    const items = screen.getAllByText(/Fix login bug/);
+    expect(items).toHaveLength(1);
+  });
+});

--- a/src/components/CommandPalette/CommandPalette.test.tsx
+++ b/src/components/CommandPalette/CommandPalette.test.tsx
@@ -88,21 +88,15 @@ describe("CommandPalette", () => {
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
-  it("should open on Cmd+K", async () => {
-    const onOpenChange = vi.fn();
-    render(<CommandPalette open={false} onOpenChange={onOpenChange} />);
-
-    // CommandPalette itself doesn't handle Cmd+K — that's useKeyboard's job.
-    // But when open=true, it should render the dialog.
+  it("should render dialog and search input when open", () => {
     const { rerender } = render(
-      <CommandPalette open={true} onOpenChange={onOpenChange} />,
+      <CommandPalette open={false} onOpenChange={() => {}} />,
     );
-    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
 
-    // Verify search input is present and focused
-    const input = screen.getByPlaceholderText(/search/i);
-    expect(input).toBeInTheDocument();
-    rerender(<CommandPalette open={true} onOpenChange={onOpenChange} />);
+    rerender(<CommandPalette open={true} onOpenChange={() => {}} />);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/search/i)).toBeInTheDocument();
   });
 
   it("should close on Esc", async () => {

--- a/src/components/CommandPalette/CommandPalette.tsx
+++ b/src/components/CommandPalette/CommandPalette.tsx
@@ -1,0 +1,105 @@
+import { useMemo } from "react";
+import { Command } from "cmdk";
+import { useGitHubData } from "../../hooks/useGitHubData";
+import type { PullRequestWithReview, Issue } from "../../lib/types";
+
+interface CommandPaletteProps {
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+}
+
+interface PaletteItem {
+  readonly id: string;
+  readonly type: "pr" | "issue";
+  readonly number: number;
+  readonly title: string;
+  readonly url: string;
+}
+
+function prToItem(pr: PullRequestWithReview): PaletteItem {
+  return {
+    id: pr.pullRequest.id,
+    type: "pr",
+    number: pr.pullRequest.number,
+    title: pr.pullRequest.title,
+    url: pr.pullRequest.url,
+  };
+}
+
+function issueToItem(issue: Issue): PaletteItem {
+  return {
+    id: issue.id,
+    type: "issue",
+    number: issue.number,
+    title: issue.title,
+    url: issue.url,
+  };
+}
+
+function deduplicateItems(items: readonly PaletteItem[]): readonly PaletteItem[] {
+  const seen = new Set<string>();
+  return items.filter((item) => {
+    if (seen.has(item.id)) return false;
+    seen.add(item.id);
+    return true;
+  });
+}
+
+export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
+  const { dashboard } = useGitHubData();
+
+  const items = useMemo<readonly PaletteItem[]>(() => {
+    if (!dashboard) return [];
+
+    const prItems = [
+      ...dashboard.reviewRequests.map(prToItem),
+      ...dashboard.myPullRequests.map(prToItem),
+    ];
+    const issueItems = dashboard.assignedIssues.map(issueToItem);
+
+    return deduplicateItems([...prItems, ...issueItems]);
+  }, [dashboard]);
+
+  function handleSelect(item: PaletteItem): void {
+    window.open(item.url, "_blank", "noopener,noreferrer");
+    onOpenChange(false);
+  }
+
+  return (
+    <Command.Dialog
+      open={open}
+      onOpenChange={onOpenChange}
+      label="Command palette"
+      className="fixed inset-0 z-50 flex items-start justify-center pt-[20vh]"
+    >
+      <div className="w-full max-w-lg rounded-lg border border-border bg-bg shadow-xl">
+        <Command.Input
+          placeholder="Search PRs and issues…"
+          className="w-full border-b border-border bg-transparent px-4 py-3 text-sm text-fg outline-none placeholder:text-fg/50"
+        />
+        <Command.List className="max-h-80 overflow-y-auto p-2">
+          <Command.Empty className="px-4 py-6 text-center text-sm text-fg/50">
+            No results found.
+          </Command.Empty>
+
+          {items.map((item) => (
+            <Command.Item
+              key={item.id}
+              value={`${item.number} ${item.title}`}
+              onSelect={() => handleSelect(item)}
+              className="flex cursor-pointer items-center gap-2 rounded-md px-3 py-2 text-sm text-fg aria-selected:bg-fg/10"
+            >
+              <span className="shrink-0 text-fg/50">
+                #{item.number}
+              </span>
+              <span className="truncate">{item.title}</span>
+              <span className="ml-auto shrink-0 rounded bg-fg/10 px-1.5 py-0.5 text-xs uppercase text-fg/60">
+                {item.type}
+              </span>
+            </Command.Item>
+          ))}
+        </Command.List>
+      </div>
+    </Command.Dialog>
+  );
+}

--- a/src/components/CommandPalette/index.ts
+++ b/src/components/CommandPalette/index.ts
@@ -1,0 +1,1 @@
+export { CommandPalette } from "./CommandPalette";

--- a/src/hooks/useKeyboard.test.ts
+++ b/src/hooks/useKeyboard.test.ts
@@ -136,6 +136,16 @@ describe("useKeyboard", () => {
     document.body.removeChild(div);
   });
 
+  it("should fire Cmd+K even when focused on an input element", () => {
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "k", metaKey: true, bubbles: true }),
+    );
+    expect(actions.onCommandPalette).toHaveBeenCalledOnce();
+    document.body.removeChild(input);
+  });
+
   it("should clean up listener on unmount", () => {
     hook.unmount();
     fireKey("j");

--- a/src/hooks/useKeyboard.ts
+++ b/src/hooks/useKeyboard.ts
@@ -1,12 +1,12 @@
 import { useEffect, useRef } from "react";
 
 export interface KeyboardActions {
-  readonly onNavigate: (direction: "up" | "down") => void;
-  readonly onOpen: () => void;
-  readonly onOpenWorkspace: () => void;
-  readonly onSwitchWorkspace: (index: number) => void;
-  readonly onEscape: () => void;
-  readonly onCommandPalette: () => void;
+  readonly onNavigate?: (direction: "up" | "down") => void;
+  readonly onOpen?: () => void;
+  readonly onOpenWorkspace?: () => void;
+  readonly onSwitchWorkspace?: (index: number) => void;
+  readonly onEscape?: () => void;
+  readonly onCommandPalette?: () => void;
 }
 
 const INPUT_TAGS = new Set(["INPUT", "TEXTAREA", "SELECT"]);
@@ -25,21 +25,22 @@ export function useKeyboard(actions: KeyboardActions): void {
 
   useEffect(() => {
     function handleKeyDown(event: KeyboardEvent): void {
-      if (isInputTarget(event)) return;
-
       const key = event.key.length === 1 ? event.key.toLowerCase() : event.key;
       const actionModifier = event.metaKey || event.ctrlKey;
       const anyModifier = actionModifier || event.altKey;
 
+      // Cmd+K must work regardless of focus (e.g. inside cmdk input)
       if (actionModifier && key === "k") {
         event.preventDefault();
-        actionsRef.current.onCommandPalette();
+        actionsRef.current.onCommandPalette?.();
         return;
       }
 
+      if (isInputTarget(event)) return;
+
       if (actionModifier && key >= "1" && key <= "3") {
         event.preventDefault();
-        actionsRef.current.onSwitchWorkspace(Number(key) - 1);
+        actionsRef.current.onSwitchWorkspace?.(Number(key) - 1);
         return;
       }
 
@@ -47,20 +48,19 @@ export function useKeyboard(actions: KeyboardActions): void {
 
       switch (key) {
         case "j":
-          actionsRef.current.onNavigate("down");
+          actionsRef.current.onNavigate?.("down");
           break;
         case "k":
-          actionsRef.current.onNavigate("up");
+          actionsRef.current.onNavigate?.("up");
           break;
         case "Enter":
-          actionsRef.current.onOpen();
+          actionsRef.current.onOpen?.();
           break;
         case "w":
-          actionsRef.current.onOpenWorkspace();
+          actionsRef.current.onOpenWorkspace?.();
           break;
         case "Escape":
-          event.preventDefault();
-          actionsRef.current.onEscape();
+          actionsRef.current.onEscape?.();
           break;
       }
     }

--- a/src/hooks/useKeyboard.ts
+++ b/src/hooks/useKeyboard.ts
@@ -30,17 +30,22 @@ export function useKeyboard(actions: KeyboardActions): void {
       const anyModifier = actionModifier || event.altKey;
 
       // Cmd+K must work regardless of focus (e.g. inside cmdk input)
-      if (actionModifier && key === "k") {
+      if (actionModifier && key === "k" && actionsRef.current.onCommandPalette) {
         event.preventDefault();
-        actionsRef.current.onCommandPalette?.();
+        actionsRef.current.onCommandPalette();
         return;
       }
 
       if (isInputTarget(event)) return;
 
-      if (actionModifier && key >= "1" && key <= "3") {
+      if (
+        actionModifier &&
+        key >= "1" &&
+        key <= "3" &&
+        actionsRef.current.onSwitchWorkspace
+      ) {
         event.preventDefault();
-        actionsRef.current.onSwitchWorkspace?.(Number(key) - 1);
+        actionsRef.current.onSwitchWorkspace(Number(key) - 1);
         return;
       }
 

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -2,6 +2,18 @@ import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
 import { afterEach } from "vitest";
 
+if (typeof globalThis.ResizeObserver === "undefined") {
+  globalThis.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}
+
+if (typeof Element.prototype.scrollIntoView === "undefined") {
+  Element.prototype.scrollIntoView = function () {};
+}
+
 afterEach(() => {
   cleanup();
 });


### PR DESCRIPTION
## Summary
- Install `cmdk` and create `CommandPalette` component listing all PRs and assigned issues
- Search by title or issue number with built-in fuzzy filtering
- `Cmd+K` / `Ctrl+K` toggles the palette (wired via existing `useKeyboard` hook), `Esc` closes
- Selecting an item opens its GitHub URL in the browser (`noopener,noreferrer`)
- Deduplicates PRs appearing in both review and personal lists
- Added `ResizeObserver` and `scrollIntoView` polyfills to test setup for cmdk compatibility

## Test plan
- [x] 10 unit tests covering open/close, search by title, search by number, item selection, empty state, deduplication
- [x] 324/324 full test suite passing
- [x] TypeScript strict check clean
- [x] oxlint clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `cmdk` command palette to quickly find and open PRs and assigned issues. Implements T-064 command palette.

- **New Features**
  - Lists review PRs, my PRs, and assigned issues; removes duplicates.
  - Fuzzy search by title or number.
  - Cmd+K / Ctrl+K toggles; Esc closes.
  - Selecting an item opens its GitHub URL in a new tab with noopener,noreferrer.
  - Wired into `App.tsx`. Added tests plus `ResizeObserver` and `scrollIntoView` polyfills for compatibility.

- **Bug Fixes**
  - Cmd+K works even when focus is inside inputs by handling the shortcut before the input guard.
  - Made `useKeyboard` handlers optional and only call preventDefault when a handler exists to avoid swallowing native shortcuts; removed no-op handlers in `App.tsx`.
  - Added a test to verify Cmd+K fires from within an input.

<sup>Written for commit e17cb580587f2f367c8cec84d1015dc4cdff7dfe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Command palette added — open with keyboard shortcut to search PRs and issues by title or number and open results in a new tab.

* **Bug Fixes**
  * Shortcut now triggers even when typing in inputs; Escape closes the palette. Results deduplicated and show empty-state when nothing matches.

* **Tests**
  * Comprehensive tests for palette rendering, search, interactions, and deduplication added.

* **Chores**
  * Added UI library dependency and test fallbacks for ResizeObserver/scrollIntoView.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->