### PR TITLE
feat(ui): review queue filters — priority + repo (T-065)

### DIFF
--- a/src/components/ReviewQueue/ReviewQueue.test.tsx
+++ b/src/components/ReviewQueue/ReviewQueue.test.tsx
@@ -1,7 +1,8 @@
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { PullRequestWithReview } from "../../lib/types";
+import { useDashboardStore } from "../../stores/dashboard";
 import { ReviewQueue } from "./ReviewQueue";
 
 function makePr(
@@ -64,9 +65,29 @@ const lowPr = makePr({
   url: "https://github.com/org/repo/pull/40",
 });
 
+const repo2HighPr = makePr({
+  number: 50,
+  title: "Repo2 high task",
+  priority: "high",
+  repoId: "repo-2",
+  url: "https://github.com/org/repo2/pull/50",
+});
+
+const repo2LowPr = makePr({
+  number: 60,
+  title: "Repo2 low task",
+  priority: "low",
+  repoId: "repo-2",
+  url: "https://github.com/org/repo2/pull/60",
+});
+
 const allReviews = [lowPr, criticalPr, mediumPr, highPr];
+const multiRepoReviews = [...allReviews, repo2HighPr, repo2LowPr];
 
 describe("ReviewQueue", () => {
+  beforeEach(() => {
+    useDashboardStore.setState({ activeFilters: {} });
+  });
   it("should render PRs sorted by priority", () => {
     render(<ReviewQueue reviews={allReviews} onOpen={vi.fn()} />);
 
@@ -147,6 +168,49 @@ describe("ReviewQueue", () => {
     expect(handleOpen).toHaveBeenCalledWith(
       "https://github.com/org/repo/pull/20",
     );
+  });
+
+  it("should filter by repo", async () => {
+    const user = userEvent.setup();
+    render(<ReviewQueue reviews={multiRepoReviews} onOpen={vi.fn()} />);
+
+    await user.selectOptions(
+      screen.getByRole("combobox", { name: /filter by repo/i }),
+      "repo-2",
+    );
+
+    const cards = screen.getAllByRole("link");
+    expect(cards).toHaveLength(2);
+    expect(screen.getByText("Repo2 high task")).toBeInTheDocument();
+    expect(screen.getByText("Repo2 low task")).toBeInTheDocument();
+    expect(screen.queryByText("Critical fix")).not.toBeInTheDocument();
+  });
+
+  it("should combine filters", async () => {
+    const user = userEvent.setup();
+    render(<ReviewQueue reviews={multiRepoReviews} onOpen={vi.fn()} />);
+
+    await user.click(screen.getByRole("button", { name: /^high$/i }));
+    await user.selectOptions(
+      screen.getByRole("combobox", { name: /filter by repo/i }),
+      "repo-2",
+    );
+
+    const cards = screen.getAllByRole("link");
+    expect(cards).toHaveLength(1);
+    expect(screen.getByText("Repo2 high task")).toBeInTheDocument();
+  });
+
+  it("should show count after filtering by repo", async () => {
+    const user = userEvent.setup();
+    render(<ReviewQueue reviews={multiRepoReviews} onOpen={vi.fn()} />);
+
+    await user.selectOptions(
+      screen.getByRole("combobox", { name: /filter by repo/i }),
+      "repo-1",
+    );
+
+    expect(screen.getByText("4")).toBeInTheDocument();
   });
 
   it("should forward onWorkspaceAction to ReviewCard", async () => {

--- a/src/components/ReviewQueue/ReviewQueue.test.tsx
+++ b/src/components/ReviewQueue/ReviewQueue.test.tsx
@@ -213,6 +213,25 @@ describe("ReviewQueue", () => {
     expect(screen.getByText("4")).toBeInTheDocument();
   });
 
+  it("should clear stale repo filter when selected repo disappears from reviews", async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <ReviewQueue reviews={multiRepoReviews} onOpen={vi.fn()} />,
+    );
+
+    await user.selectOptions(
+      screen.getByRole("combobox", { name: /filter by repo/i }),
+      "repo-2",
+    );
+    expect(screen.getAllByRole("link")).toHaveLength(2);
+
+    // Re-render with only repo-1 PRs — repo-2 no longer exists
+    rerender(<ReviewQueue reviews={allReviews} onOpen={vi.fn()} />);
+
+    // Should show all repo-1 PRs, not an empty list
+    expect(screen.getAllByRole("link")).toHaveLength(4);
+  });
+
   it("should forward onWorkspaceAction to ReviewCard", async () => {
     const prWithWorkspace = makePr({
       number: 99,

--- a/src/components/ReviewQueue/ReviewQueue.tsx
+++ b/src/components/ReviewQueue/ReviewQueue.tsx
@@ -52,16 +52,21 @@ export function ReviewQueue({
 }: ReviewQueueProps): ReactElement {
   const activeFilters = useDashboardStore((s) => s.activeFilters);
   const setFilter = useDashboardStore((s) => s.setFilter);
-  const clearFilters = useDashboardStore((s) => s.clearFilters);
 
   useEffect(() => {
-    return () => clearFilters();
-  }, [clearFilters]);
+    return () => setFilter({ priority: undefined, repo: undefined });
+  }, [setFilter]);
 
   const priorityFilter: PriorityFilter = activeFilters.priority ?? "all";
   const repoFilter = activeFilters.repo ?? "";
 
   const repos = useMemo(() => getUniqueRepos(reviews), [reviews]);
+
+  useEffect(() => {
+    if (repoFilter && !repos.includes(repoFilter)) {
+      setFilter({ repo: undefined });
+    }
+  }, [repos, repoFilter, setFilter]);
 
   const filtered = reviews.filter((r) => {
     if (priorityFilter !== "all" && r.pullRequest.priority !== priorityFilter) {

--- a/src/components/ReviewQueue/ReviewQueue.tsx
+++ b/src/components/ReviewQueue/ReviewQueue.tsx
@@ -50,23 +50,26 @@ export function ReviewQueue({
   onOpen,
   onWorkspaceAction,
 }: ReviewQueueProps): ReactElement {
-  const activeFilters = useDashboardStore((s) => s.activeFilters);
+  const storePriority = useDashboardStore((s) => s.activeFilters.priority);
+  const storeRepo = useDashboardStore((s) => s.activeFilters.repo);
   const setFilter = useDashboardStore((s) => s.setFilter);
 
   useEffect(() => {
     return () => setFilter({ priority: undefined, repo: undefined });
   }, [setFilter]);
 
-  const priorityFilter: PriorityFilter = activeFilters.priority ?? "all";
-  const repoFilter = activeFilters.repo ?? "";
-
+  const priorityFilter: PriorityFilter = storePriority ?? "all";
   const repos = useMemo(() => getUniqueRepos(reviews), [reviews]);
 
+  // Derive effective repo filter synchronously — avoids flash when stale repo disappears
+  const repoFilter = storeRepo && repos.includes(storeRepo) ? storeRepo : "";
+
+  // Sync store when the derived value diverges (stale repo removed from reviews)
   useEffect(() => {
-    if (repoFilter && !repos.includes(repoFilter)) {
+    if (storeRepo && !repos.includes(storeRepo)) {
       setFilter({ repo: undefined });
     }
-  }, [repos, repoFilter, setFilter]);
+  }, [repos, storeRepo, setFilter]);
 
   const filtered = reviews.filter((r) => {
     if (priorityFilter !== "all" && r.pullRequest.priority !== priorityFilter) {

--- a/src/components/ReviewQueue/ReviewQueue.tsx
+++ b/src/components/ReviewQueue/ReviewQueue.tsx
@@ -1,5 +1,6 @@
-import { type ReactElement, useState } from "react";
+import type { ReactElement } from "react";
 import type { Priority, PullRequestWithReview } from "../../lib/types";
+import { useDashboardStore } from "../../stores/dashboard";
 import { EmptyState } from "../atoms/EmptyState";
 import { SectionHead } from "../atoms/SectionHead";
 import { ReviewCard } from "./ReviewCard";
@@ -19,7 +20,7 @@ const PRIORITY_ORDER: Record<Priority, number> = {
 
 type PriorityFilter = "all" | Priority;
 
-const FILTERS: readonly PriorityFilter[] = [
+const PRIORITY_FILTERS: readonly PriorityFilter[] = [
   "all",
   "critical",
   "high",
@@ -38,17 +39,33 @@ function sortByPriority(
   );
 }
 
+function getUniqueRepos(
+  reviews: readonly PullRequestWithReview[],
+): readonly string[] {
+  return [...new Set(reviews.map((r) => r.pullRequest.repoId))].sort();
+}
+
 export function ReviewQueue({
   reviews,
   onOpen,
   onWorkspaceAction,
 }: ReviewQueueProps): ReactElement {
-  const [filter, setFilter] = useState<PriorityFilter>("all");
+  const { activeFilters, setFilter } = useDashboardStore();
 
-  const filtered =
-    filter === "all"
-      ? reviews
-      : reviews.filter((r) => r.pullRequest.priority === filter);
+  const priorityFilter: PriorityFilter = activeFilters.priority ?? "all";
+  const repoFilter = activeFilters.repo ?? "";
+
+  const repos = getUniqueRepos(reviews);
+
+  const filtered = reviews.filter((r) => {
+    if (priorityFilter !== "all" && r.pullRequest.priority !== priorityFilter) {
+      return false;
+    }
+    if (repoFilter && r.pullRequest.repoId !== repoFilter) {
+      return false;
+    }
+    return true;
+  });
 
   const sorted = sortByPriority(filtered);
 
@@ -56,22 +73,44 @@ export function ReviewQueue({
     <section data-testid="review-queue" className="flex flex-col gap-2">
       <SectionHead title="Reviews" count={sorted.length} />
 
-      <div className="flex gap-1" role="group" aria-label="Filter by priority">
-        {FILTERS.map((f) => (
-          <button
-            key={f}
-            type="button"
-            aria-pressed={filter === f}
-            onClick={() => setFilter(f)}
-            className={`rounded px-2 py-0.5 text-xs ${
-              filter === f
-                ? "bg-accent text-white"
-                : "text-dim hover:text-foreground"
-            }`}
+      <div className="flex items-center gap-3">
+        <div className="flex gap-1" role="group" aria-label="Filter by priority">
+          {PRIORITY_FILTERS.map((f) => (
+            <button
+              key={f}
+              type="button"
+              aria-pressed={priorityFilter === f}
+              onClick={() =>
+                setFilter({ priority: f === "all" ? undefined : f })
+              }
+              className={`rounded px-2 py-0.5 text-xs ${
+                priorityFilter === f
+                  ? "bg-accent text-white"
+                  : "text-dim hover:text-foreground"
+              }`}
+            >
+              {f}
+            </button>
+          ))}
+        </div>
+
+        {repos.length > 1 && (
+          <select
+            aria-label="Filter by repo"
+            value={repoFilter}
+            onChange={(e) =>
+              setFilter({ repo: e.target.value || undefined })
+            }
+            className="rounded border border-border bg-surface px-2 py-0.5 text-xs text-foreground"
           >
-            {f}
-          </button>
-        ))}
+            <option value="">All repos</option>
+            {repos.map((id) => (
+              <option key={id} value={id}>
+                {id}
+              </option>
+            ))}
+          </select>
+        )}
       </div>
 
       {sorted.length === 0 ? (

--- a/src/components/ReviewQueue/ReviewQueue.tsx
+++ b/src/components/ReviewQueue/ReviewQueue.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement } from "react";
+import { type ReactElement, useEffect, useMemo } from "react";
 import type { Priority, PullRequestWithReview } from "../../lib/types";
 import { useDashboardStore } from "../../stores/dashboard";
 import { EmptyState } from "../atoms/EmptyState";
@@ -50,12 +50,18 @@ export function ReviewQueue({
   onOpen,
   onWorkspaceAction,
 }: ReviewQueueProps): ReactElement {
-  const { activeFilters, setFilter } = useDashboardStore();
+  const activeFilters = useDashboardStore((s) => s.activeFilters);
+  const setFilter = useDashboardStore((s) => s.setFilter);
+  const clearFilters = useDashboardStore((s) => s.clearFilters);
+
+  useEffect(() => {
+    return () => clearFilters();
+  }, [clearFilters]);
 
   const priorityFilter: PriorityFilter = activeFilters.priority ?? "all";
   const repoFilter = activeFilters.repo ?? "";
 
-  const repos = getUniqueRepos(reviews);
+  const repos = useMemo(() => getUniqueRepos(reviews), [reviews]);
 
   const filtered = reviews.filter((r) => {
     if (priorityFilter !== "all" && r.pullRequest.priority !== priorityFilter) {

--- a/src/stores/dashboard.ts
+++ b/src/stores/dashboard.ts
@@ -35,9 +35,14 @@ export const useDashboardStore = create<DashboardState>((set) => ({
   setView: (view) => set({ currentView: view }),
   setFilter: (filter) =>
     set((state) => {
-      const merged = { ...state.activeFilters, ...filter };
+      const prev = state.activeFilters;
+      const next: DashboardFilters = {
+        repo: "repo" in filter ? filter.repo : prev.repo,
+        priority: "priority" in filter ? filter.priority : prev.priority,
+        ciStatus: "ciStatus" in filter ? filter.ciStatus : prev.ciStatus,
+      };
       const cleaned = Object.fromEntries(
-        Object.entries(merged).filter(([, v]) => v !== undefined),
+        Object.entries(next).filter(([, v]) => v !== undefined),
       ) as DashboardFilters;
       return { activeFilters: cleaned };
     }),


### PR DESCRIPTION
## Summary
- Migrated priority filter from local `useState` to dashboard Zustand store (`activeFilters.priority`)
- Added repo dropdown filter (auto-populated from unique repoIds in reviews, hidden when single repo)
- Filters combine with AND logic — priority AND repo must both match
- Count in section header updates dynamically after filtering

## Test plan
- [x] `it("should filter by priority")` — existing test still passes with store migration
- [x] `it("should filter by repo")` — new: selects repo-2 dropdown, verifies only matching PRs shown
- [x] `it("should combine filters")` — new: priority=high + repo=repo-2 → single result
- [x] `it("should show count after filtering by repo")` — new: verifies header count reflects filtered results
- [x] All 328 existing tests pass (no regressions)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds priority and repo filters to the Review Queue (Linear T-065). Filter state moves to the dashboard `zustand` store with memoized repos, scoped selectors for `priority`/`repo`, scoped unmount cleanup, and synchronous repo filtering to avoid empty-list flashes.

- **New Features**
  - Repo dropdown auto-populated from unique repo IDs; hidden when only one repo.
  - Priority and repo filters use AND logic.
  - Section header count updates as you filter.

- **Bug Fixes**
  - Clear stale repo selections and avoid brief empty-list flashes when repos change.
  - Unmount cleanup only clears priority/repo filters; `ciStatus` stays.

<sup>Written for commit 3029b235f9b2f3421d18f70b2bffef0bbb2867c3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repository-based filtering added to the Review Queue with a repo selector (shown when multiple repos exist); repo + priority can be combined.

* **Bug Fixes**
  * Filters now clear or adjust when the selected repository is no longer present, preventing empty results after data updates. Filters are managed at the dashboard level for consistent behavior across views.

* **Tests**
  * Added tests covering repo filtering, combined repo+priority scenarios, header counts, and filter reset behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->