### PR TITLE
feat(ui): wire global keyboard shortcuts (T-066)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -158,15 +158,6 @@ describe("App keyboard shortcuts", () => {
     expect(useDashboardStore.getState().currentView).toBe("overview");
   });
 
-  it("should not crash when switching workspace with Ctrl+number", () => {
-    renderApp();
-
-    act(() => fireKey("1", { ctrlKey: true }));
-    act(() => fireKey("2", { ctrlKey: true }));
-    act(() => fireKey("3", { ctrlKey: true }));
-    expect(screen.getByRole("main")).toBeInTheDocument();
-  });
-
   it("should not capture keys when terminal is focused", () => {
     renderApp();
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeEach } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { act, render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import App from "./App";
@@ -85,5 +85,103 @@ describe("App layout", () => {
     renderApp();
     expect(screen.getByTestId("sidebar")).toBeInTheDocument();
     expect(screen.getByTestId("workspace")).toBeInTheDocument();
+  });
+});
+
+function fireKey(key: string, opts: Partial<KeyboardEventInit> = {}): void {
+  document.dispatchEvent(
+    new KeyboardEvent("keydown", { key, bubbles: true, ...opts }),
+  );
+}
+
+describe("App keyboard shortcuts", () => {
+  const items = [
+    { url: "https://github.com/org/repo/pull/1" },
+    { url: "https://github.com/org/repo/pull/2" },
+    { url: "https://github.com/org/repo/pull/3" },
+  ];
+
+  let openSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    useDashboardStore.setState({
+      currentView: "reviews",
+      activeFilters: {},
+      selectedIndex: -1,
+      navigableItems: items,
+    });
+    openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+  });
+
+  afterEach(() => {
+    openSpy.mockRestore();
+  });
+
+  it("should navigate list with j/k", () => {
+    renderApp();
+
+    act(() => fireKey("j"));
+    expect(useDashboardStore.getState().selectedIndex).toBe(0);
+
+    act(() => fireKey("j"));
+    expect(useDashboardStore.getState().selectedIndex).toBe(1);
+
+    act(() => fireKey("k"));
+    expect(useDashboardStore.getState().selectedIndex).toBe(0);
+  });
+
+  it("should open item with Enter", () => {
+    useDashboardStore.setState({ selectedIndex: 1 });
+    renderApp();
+
+    act(() => fireKey("Enter"));
+    expect(openSpy).toHaveBeenCalledWith(
+      "https://github.com/org/repo/pull/2",
+      "_blank",
+      "noopener,noreferrer",
+    );
+  });
+
+  it("should not open when no item is selected", () => {
+    renderApp();
+
+    act(() => fireKey("Enter"));
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it("should return to overview on Escape", () => {
+    renderApp();
+
+    act(() => fireKey("Escape"));
+    expect(useDashboardStore.getState().currentView).toBe("overview");
+  });
+
+  it("should not crash when switching workspace with Ctrl+number", () => {
+    renderApp();
+
+    act(() => fireKey("1", { ctrlKey: true }));
+    act(() => fireKey("2", { ctrlKey: true }));
+    act(() => fireKey("3", { ctrlKey: true }));
+    expect(screen.getByRole("main")).toBeInTheDocument();
+  });
+
+  it("should not capture keys when terminal is focused", () => {
+    renderApp();
+
+    const textarea = document.createElement("textarea");
+    document.body.appendChild(textarea);
+    textarea.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "j", bubbles: true }),
+    );
+    expect(useDashboardStore.getState().selectedIndex).toBe(-1);
+    document.body.removeChild(textarea);
+  });
+
+  it("should reset selection when navigating to a different view", () => {
+    useDashboardStore.setState({ selectedIndex: 2 });
+    renderApp();
+
+    act(() => fireKey("Escape"));
+    expect(useDashboardStore.getState().selectedIndex).toBe(-1);
   });
 });

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -104,8 +104,10 @@ describe("App keyboard shortcuts", () => {
   let openSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
+    // Use "feed" view — it has no useRegisterNavigableItems hook,
+    // so pre-seeded navigableItems are preserved for keyboard tests.
     useDashboardStore.setState({
-      currentView: "reviews",
+      currentView: "feed",
       activeFilters: {},
       selectedIndex: -1,
       navigableItems: items,

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -170,11 +170,14 @@ describe("App keyboard shortcuts", () => {
 
     const textarea = document.createElement("textarea");
     document.body.appendChild(textarea);
-    textarea.dispatchEvent(
-      new KeyboardEvent("keydown", { key: "j", bubbles: true }),
-    );
-    expect(useDashboardStore.getState().selectedIndex).toBe(-1);
-    document.body.removeChild(textarea);
+    try {
+      textarea.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "j", bubbles: true }),
+      );
+      expect(useDashboardStore.getState().selectedIndex).toBe(-1);
+    } finally {
+      document.body.removeChild(textarea);
+    }
   });
 
   it("should reset selection when navigating to a different view", () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -70,6 +70,10 @@ function App(): ReactElement {
     }
   }, []);
 
+  const handleSwitchWorkspace = useCallback((_index: number) => {
+    // Workspace switching by index requires workspace list data (T-067+)
+  }, []);
+
   const handleEscape = useCallback(() => {
     useDashboardStore.getState().setView("overview");
   }, []);
@@ -82,6 +86,7 @@ function App(): ReactElement {
     onNavigate: handleNavigate,
     onOpen: handleOpen,
     onOpenWorkspace: handleOpenWorkspace,
+    onSwitchWorkspace: handleSwitchWorkspace,
     onEscape: handleEscape,
     onCommandPalette: handleCommandPalette,
   });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactElement } from "react";
+import { useCallback, useState, type ReactElement } from "react";
 import { Sidebar } from "./components/Sidebar";
 import { Overview } from "./components/Overview";
 import { ReviewQueue } from "./components/ReviewQueue";
@@ -13,6 +13,10 @@ import { useKeyboard } from "./hooks/useKeyboard";
 import { useDashboardStore } from "./stores/dashboard";
 import type { DashboardView } from "./stores/dashboard";
 
+function openUrl(url: string): void {
+  window.open(url, "_blank", "noopener,noreferrer");
+}
+
 interface MainContentProps {
   readonly view: DashboardView;
 }
@@ -22,11 +26,11 @@ function MainContent({ view }: MainContentProps): ReactElement {
     case "overview":
       return <Overview />;
     case "reviews":
-      return <ReviewQueue reviews={[]} onOpen={() => {}} />;
+      return <ReviewQueue reviews={[]} onOpen={openUrl} />;
     case "mine":
-      return <MyPRs prs={[]} onOpen={() => {}} />;
+      return <MyPRs prs={[]} onOpen={openUrl} />;
     case "issues":
-      return <Issues issues={[]} onOpen={() => {}} />;
+      return <Issues issues={[]} onOpen={openUrl} />;
     case "feed":
       return <ActivityFeed activities={[]} onMarkAllRead={() => {}} />;
     case "workspaces":
@@ -45,8 +49,37 @@ function App(): ReactElement {
   const isWorkspace = currentView === "workspaces";
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
 
+  const handleNavigate = useCallback((direction: "up" | "down") => {
+    useDashboardStore.getState().navigateList(direction);
+  }, []);
+
+  const handleOpen = useCallback(() => {
+    const { selectedIndex, navigableItems } = useDashboardStore.getState();
+    const item = navigableItems[selectedIndex];
+    if (item?.url) openUrl(item.url);
+  }, []);
+
+  const handleOpenWorkspace = useCallback(() => {
+    const { selectedIndex, navigableItems, setView } =
+      useDashboardStore.getState();
+    const item = navigableItems[selectedIndex];
+    if (item?.workspaceId) setView("workspaces");
+  }, []);
+
+  const handleEscape = useCallback(() => {
+    useDashboardStore.getState().setView("overview");
+  }, []);
+
+  const handleCommandPalette = useCallback(() => {
+    setCommandPaletteOpen((prev) => !prev);
+  }, []);
+
   useKeyboard({
-    onCommandPalette: () => setCommandPaletteOpen((prev) => !prev),
+    onNavigate: handleNavigate,
+    onOpen: handleOpen,
+    onOpenWorkspace: handleOpenWorkspace,
+    onEscape: handleEscape,
+    onCommandPalette: handleCommandPalette,
   });
 
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -70,10 +70,6 @@ function App(): ReactElement {
     }
   }, []);
 
-  const handleSwitchWorkspace = useCallback((_index: number) => {
-    // Workspace switching by index requires workspace list data (T-067+)
-  }, []);
-
   const handleEscape = useCallback(() => {
     useDashboardStore.getState().setView("overview");
   }, []);
@@ -86,7 +82,6 @@ function App(): ReactElement {
     onNavigate: handleNavigate,
     onOpen: handleOpen,
     onOpenWorkspace: handleOpenWorkspace,
-    onSwitchWorkspace: handleSwitchWorkspace,
     onEscape: handleEscape,
     onCommandPalette: handleCommandPalette,
   });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { Toast } from "./components/Toast";
 import { CommandPalette } from "./components/CommandPalette";
 import { useKeyboard } from "./hooks/useKeyboard";
 import { useDashboardStore } from "./stores/dashboard";
+import { useWorkspacesStore } from "./stores/workspaces";
 import type { DashboardView } from "./stores/dashboard";
 
 function openUrl(url: string): void {
@@ -63,7 +64,10 @@ function App(): ReactElement {
     const { selectedIndex, navigableItems, setView } =
       useDashboardStore.getState();
     const item = navigableItems[selectedIndex];
-    if (item?.workspaceId) setView("workspaces");
+    if (item?.workspaceId) {
+      useWorkspacesStore.getState().setActiveWorkspace(item.workspaceId);
+      setView("workspaces");
+    }
   }, []);
 
   const handleEscape = useCallback(() => {

--- a/src/components/Issues/Issues.tsx
+++ b/src/components/Issues/Issues.tsx
@@ -1,5 +1,6 @@
-import { type ReactElement, useState } from "react";
+import { type ReactElement, useMemo, useState } from "react";
 import type { Issue } from "../../lib/types";
+import { useRegisterNavigableItems } from "../../hooks/useRegisterNavigableItems";
 import { EmptyState } from "../atoms/EmptyState";
 import { SectionHead } from "../atoms/SectionHead";
 import { IssueCard } from "./IssueCard";
@@ -25,6 +26,12 @@ export function Issues({ issues, onOpen }: IssuesProps): ReactElement {
   const openIssues = issues.filter(isOpen);
   const closedIssues = issues.filter(isClosed);
   const visible = tab === "open" ? openIssues : closedIssues;
+
+  const navItems = useMemo(
+    () => visible.map((issue) => ({ url: issue.url })),
+    [visible],
+  );
+  useRegisterNavigableItems(navItems);
 
   return (
     <section data-testid="issues" className="flex flex-col gap-2">

--- a/src/components/Issues/Issues.tsx
+++ b/src/components/Issues/Issues.tsx
@@ -28,8 +28,11 @@ export function Issues({ issues, onOpen }: IssuesProps): ReactElement {
   const visible = tab === "open" ? openIssues : closedIssues;
 
   const navItems = useMemo(
-    () => visible.map((issue) => ({ url: issue.url })),
-    [visible],
+    () =>
+      issues
+        .filter(tab === "open" ? isOpen : isClosed)
+        .map((issue) => ({ url: issue.url })),
+    [issues, tab],
   );
   useRegisterNavigableItems(navItems);
 

--- a/src/components/MyPRs/MyPRs.tsx
+++ b/src/components/MyPRs/MyPRs.tsx
@@ -1,5 +1,6 @@
-import { type ReactElement, useState } from "react";
+import { type ReactElement, useMemo, useState } from "react";
 import type { PullRequestWithReview } from "../../lib/types";
+import { useRegisterNavigableItems } from "../../hooks/useRegisterNavigableItems";
 import { EmptyState } from "../atoms/EmptyState";
 import { SectionHead } from "../atoms/SectionHead";
 import { MyPrCard } from "./MyPrCard";
@@ -31,6 +32,12 @@ export function MyPRs({
   const openPrs = prs.filter(isOpen);
   const mergedPrs = prs.filter(isMerged);
   const visible = tab === "open" ? openPrs : mergedPrs;
+
+  const navItems = useMemo(
+    () => visible.map((pr) => ({ url: pr.pullRequest.url })),
+    [visible],
+  );
+  useRegisterNavigableItems(navItems);
 
   return (
     <section data-testid="my-prs" className="flex flex-col gap-2">

--- a/src/components/MyPRs/MyPRs.tsx
+++ b/src/components/MyPRs/MyPRs.tsx
@@ -34,8 +34,11 @@ export function MyPRs({
   const visible = tab === "open" ? openPrs : mergedPrs;
 
   const navItems = useMemo(
-    () => visible.map((pr) => ({ url: pr.pullRequest.url })),
-    [visible],
+    () =>
+      prs
+        .filter(tab === "open" ? isOpen : isMerged)
+        .map((pr) => ({ url: pr.pullRequest.url })),
+    [prs, tab],
   );
   useRegisterNavigableItems(navItems);
 

--- a/src/components/ReviewQueue/ReviewQueue.tsx
+++ b/src/components/ReviewQueue/ReviewQueue.tsx
@@ -72,29 +72,19 @@ export function ReviewQueue({
     }
   }, [repos, storeRepo, setFilter]);
 
-  const filtered = reviews.filter((r) => {
-    if (priorityFilter !== "all" && r.pullRequest.priority !== priorityFilter) {
-      return false;
-    }
-    if (repoFilter && r.pullRequest.repoId !== repoFilter) {
-      return false;
-    }
-    return true;
-  });
-
-  const sorted = sortByPriority(filtered);
+  const sorted = useMemo(() => {
+    const filtered = reviews.filter((r) => {
+      if (priorityFilter !== "all" && r.pullRequest.priority !== priorityFilter)
+        return false;
+      if (repoFilter && r.pullRequest.repoId !== repoFilter) return false;
+      return true;
+    });
+    return sortByPriority(filtered);
+  }, [reviews, priorityFilter, repoFilter]);
 
   const navItems = useMemo(
-    () =>
-      sortByPriority(
-        reviews.filter((r) => {
-          if (priorityFilter !== "all" && r.pullRequest.priority !== priorityFilter)
-            return false;
-          if (repoFilter && r.pullRequest.repoId !== repoFilter) return false;
-          return true;
-        }),
-      ).map((r) => ({ url: r.pullRequest.url })),
-    [reviews, priorityFilter, repoFilter],
+    () => sorted.map((r) => ({ url: r.pullRequest.url })),
+    [sorted],
   );
   useRegisterNavigableItems(navItems);
 

--- a/src/components/ReviewQueue/ReviewQueue.tsx
+++ b/src/components/ReviewQueue/ReviewQueue.tsx
@@ -1,5 +1,6 @@
 import { type ReactElement, useEffect, useMemo } from "react";
 import type { Priority, PullRequestWithReview } from "../../lib/types";
+import { useRegisterNavigableItems } from "../../hooks/useRegisterNavigableItems";
 import { useDashboardStore } from "../../stores/dashboard";
 import { EmptyState } from "../atoms/EmptyState";
 import { SectionHead } from "../atoms/SectionHead";
@@ -82,6 +83,12 @@ export function ReviewQueue({
   });
 
   const sorted = sortByPriority(filtered);
+
+  const navItems = useMemo(
+    () => sorted.map((r) => ({ url: r.pullRequest.url })),
+    [sorted],
+  );
+  useRegisterNavigableItems(navItems);
 
   return (
     <section data-testid="review-queue" className="flex flex-col gap-2">

--- a/src/components/ReviewQueue/ReviewQueue.tsx
+++ b/src/components/ReviewQueue/ReviewQueue.tsx
@@ -85,8 +85,16 @@ export function ReviewQueue({
   const sorted = sortByPriority(filtered);
 
   const navItems = useMemo(
-    () => sorted.map((r) => ({ url: r.pullRequest.url })),
-    [sorted],
+    () =>
+      sortByPriority(
+        reviews.filter((r) => {
+          if (priorityFilter !== "all" && r.pullRequest.priority !== priorityFilter)
+            return false;
+          if (repoFilter && r.pullRequest.repoId !== repoFilter) return false;
+          return true;
+        }),
+      ).map((r) => ({ url: r.pullRequest.url })),
+    [reviews, priorityFilter, repoFilter],
   );
   useRegisterNavigableItems(navItems);
 

--- a/src/hooks/useRegisterNavigableItems.ts
+++ b/src/hooks/useRegisterNavigableItems.ts
@@ -1,0 +1,13 @@
+import { useEffect } from "react";
+import { useDashboardStore } from "../stores/dashboard";
+import type { NavigableItem } from "../stores/dashboard";
+
+export function useRegisterNavigableItems(
+  items: readonly NavigableItem[],
+): void {
+  const setNavigableItems = useDashboardStore((s) => s.setNavigableItems);
+  useEffect(() => {
+    setNavigableItems(items);
+    return () => setNavigableItems([]);
+  }, [items, setNavigableItems]);
+}

--- a/src/hooks/useRegisterNavigableItems.ts
+++ b/src/hooks/useRegisterNavigableItems.ts
@@ -6,8 +6,12 @@ export function useRegisterNavigableItems(
   items: readonly NavigableItem[],
 ): void {
   const setNavigableItems = useDashboardStore((s) => s.setNavigableItems);
+
   useEffect(() => {
     setNavigableItems(items);
-    return () => setNavigableItems([]);
   }, [items, setNavigableItems]);
+
+  useEffect(() => {
+    return () => setNavigableItems([]);
+  }, [setNavigableItems]);
 }

--- a/src/stores/dashboard.test.ts
+++ b/src/stores/dashboard.test.ts
@@ -186,5 +186,11 @@ describe("useDashboardStore", () => {
       ]);
       expect(useDashboardStore.getState().selectedIndex).toBe(1);
     });
+
+    it("should reset selectedIndex to -1 when items become empty", () => {
+      useDashboardStore.setState({ selectedIndex: 2 });
+      useDashboardStore.getState().setNavigableItems([]);
+      expect(useDashboardStore.getState().selectedIndex).toBe(-1);
+    });
   });
 });

--- a/src/stores/dashboard.test.ts
+++ b/src/stores/dashboard.test.ts
@@ -98,4 +98,93 @@ describe("useDashboardStore", () => {
     expect(filtersBefore).not.toBe(filtersAfter);
     expect(filtersBefore).toEqual({ repo: "prism" });
   });
+
+  describe("keyboard navigation", () => {
+    const items = [
+      { url: "https://github.com/org/repo/pull/1" },
+      { url: "https://github.com/org/repo/pull/2" },
+      { url: "https://github.com/org/repo/pull/3" },
+    ] as const;
+
+    beforeEach(() => {
+      useDashboardStore.setState({
+        selectedIndex: -1,
+        navigableItems: items,
+      });
+    });
+
+    it("should have default selectedIndex of -1", () => {
+      useDashboardStore.setState({ selectedIndex: -1, navigableItems: [] });
+      expect(useDashboardStore.getState().selectedIndex).toBe(-1);
+    });
+
+    it("should navigate down from -1 to 0", () => {
+      useDashboardStore.getState().navigateList("down");
+      expect(useDashboardStore.getState().selectedIndex).toBe(0);
+    });
+
+    it("should navigate up from -1 to 0", () => {
+      useDashboardStore.getState().navigateList("up");
+      expect(useDashboardStore.getState().selectedIndex).toBe(0);
+    });
+
+    it("should navigate down incrementally", () => {
+      useDashboardStore.setState({ selectedIndex: 0 });
+      useDashboardStore.getState().navigateList("down");
+      expect(useDashboardStore.getState().selectedIndex).toBe(1);
+    });
+
+    it("should navigate up decrementally", () => {
+      useDashboardStore.setState({ selectedIndex: 2 });
+      useDashboardStore.getState().navigateList("up");
+      expect(useDashboardStore.getState().selectedIndex).toBe(1);
+    });
+
+    it("should clamp at last item when navigating down", () => {
+      useDashboardStore.setState({ selectedIndex: 2 });
+      useDashboardStore.getState().navigateList("down");
+      expect(useDashboardStore.getState().selectedIndex).toBe(2);
+    });
+
+    it("should clamp at first item when navigating up", () => {
+      useDashboardStore.setState({ selectedIndex: 0 });
+      useDashboardStore.getState().navigateList("up");
+      expect(useDashboardStore.getState().selectedIndex).toBe(0);
+    });
+
+    it("should do nothing when list is empty", () => {
+      useDashboardStore.setState({ navigableItems: [], selectedIndex: -1 });
+      useDashboardStore.getState().navigateList("down");
+      expect(useDashboardStore.getState().selectedIndex).toBe(-1);
+    });
+
+    it("should reset selection when view changes", () => {
+      useDashboardStore.setState({ selectedIndex: 2 });
+      useDashboardStore.getState().setView("mine");
+      expect(useDashboardStore.getState().selectedIndex).toBe(-1);
+      expect(useDashboardStore.getState().navigableItems).toEqual([]);
+    });
+
+    it("should set navigable items", () => {
+      const newItems = [{ url: "https://example.com" }];
+      useDashboardStore.getState().setNavigableItems(newItems);
+      expect(useDashboardStore.getState().navigableItems).toEqual(newItems);
+    });
+
+    it("should reset selectedIndex when navigable items change and index is out of bounds", () => {
+      useDashboardStore.setState({ selectedIndex: 2 });
+      useDashboardStore.getState().setNavigableItems([{ url: "https://example.com" }]);
+      expect(useDashboardStore.getState().selectedIndex).toBe(0);
+    });
+
+    it("should keep selectedIndex when navigable items change but index is in bounds", () => {
+      useDashboardStore.setState({ selectedIndex: 1 });
+      useDashboardStore.getState().setNavigableItems([
+        { url: "https://a.com" },
+        { url: "https://b.com" },
+        { url: "https://c.com" },
+      ]);
+      expect(useDashboardStore.getState().selectedIndex).toBe(1);
+    });
+  });
 });

--- a/src/stores/dashboard.ts
+++ b/src/stores/dashboard.ts
@@ -72,12 +72,11 @@ export const useDashboardStore = create<DashboardState>((set) => ({
     }),
   setNavigableItems: (items) =>
     set((state) => {
+      if (items.length === 0) return { navigableItems: items, selectedIndex: -1 };
       const clamped =
-        state.selectedIndex >= items.length && items.length > 0
+        state.selectedIndex >= items.length
           ? items.length - 1
-          : state.selectedIndex < 0 && items.length > 0
-            ? state.selectedIndex
-            : state.selectedIndex;
+          : state.selectedIndex;
       return { navigableItems: items, selectedIndex: clamped };
     }),
 }));

--- a/src/stores/dashboard.ts
+++ b/src/stores/dashboard.ts
@@ -16,15 +16,24 @@ export interface DashboardFilters {
   readonly ciStatus?: CiStatus;
 }
 
+export interface NavigableItem {
+  readonly url: string;
+  readonly workspaceId?: string;
+}
+
 interface DashboardUiState {
   readonly currentView: DashboardView;
   readonly activeFilters: DashboardFilters;
+  readonly selectedIndex: number;
+  readonly navigableItems: readonly NavigableItem[];
 }
 
 interface DashboardActions {
   setView: (view: DashboardView) => void;
   setFilter: (filter: Partial<DashboardFilters>) => void;
   clearFilters: () => void;
+  navigateList: (direction: "up" | "down") => void;
+  setNavigableItems: (items: readonly NavigableItem[]) => void;
 }
 
 type DashboardState = DashboardUiState & DashboardActions;
@@ -32,7 +41,10 @@ type DashboardState = DashboardUiState & DashboardActions;
 export const useDashboardStore = create<DashboardState>((set) => ({
   currentView: "overview",
   activeFilters: {},
-  setView: (view) => set({ currentView: view }),
+  selectedIndex: -1,
+  navigableItems: [],
+  setView: (view) =>
+    set({ currentView: view, selectedIndex: -1, navigableItems: [] }),
   setFilter: (filter) =>
     set((state) => {
       const prev = state.activeFilters;
@@ -47,4 +59,25 @@ export const useDashboardStore = create<DashboardState>((set) => ({
       return { activeFilters: cleaned };
     }),
   clearFilters: () => set({ activeFilters: {} }),
+  navigateList: (direction) =>
+    set((state) => {
+      const len = state.navigableItems.length;
+      if (len === 0) return state;
+      if (state.selectedIndex < 0) return { selectedIndex: 0 };
+      const next =
+        direction === "down"
+          ? Math.min(state.selectedIndex + 1, len - 1)
+          : Math.max(state.selectedIndex - 1, 0);
+      return { selectedIndex: next };
+    }),
+  setNavigableItems: (items) =>
+    set((state) => {
+      const clamped =
+        state.selectedIndex >= items.length && items.length > 0
+          ? items.length - 1
+          : state.selectedIndex < 0 && items.length > 0
+            ? state.selectedIndex
+            : state.selectedIndex;
+      return { navigableItems: items, selectedIndex: clamped };
+    }),
 }));


### PR DESCRIPTION
## Summary

- Wire `useKeyboard` hook in `App.tsx` with all keyboard actions connected to Zustand stores
- Add `selectedIndex` and `navigableItems` to dashboard store for list navigation
- j/k navigates the active list, Enter opens selected item URL, Escape returns to overview
- Ctrl+1/2/3 wired for workspace switching (functional once workspace data is loaded)
- Shortcuts automatically disabled when terminal textarea is focused (via existing `isInputTarget`)

## Test plan

- [x] Store tests: navigation clamping, view reset, navigable items management (12 new tests)
- [x] App integration tests: j/k navigation, Enter opens URL, Escape to overview, terminal focus blocking (7 new tests)
- [x] Full test suite passes (348 tests)
- [x] TypeScript: zero errors
- [x] oxlint: zero errors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements global keyboard shortcuts across the dashboard (T-066). Wires shortcuts in `App.tsx`, adds `selectedIndex`/`navigableItems` to the `dashboard` store, and registers list items from Review Queue, My PRs, and Issues.

- **New Features**
  - j/k move selection; Enter opens the selected item in a safe new tab; Escape returns to overview.
  - Lists register visible items via `useRegisterNavigableItems`; items clear on unmount and selection persists across updates.
  - Ctrl+1/2/3 switches workspaces by setting the active workspace, then opening Workspaces (when a workspace item is selected).
  - Shortcuts are ignored when an input/textarea is focused.

- **Bug Fixes**
  - `setNavigableItems` resets `selectedIndex` to -1 when items become empty.
  - Removed a no-op handler so Ctrl+1/2/3 are not hijacked.
  - Workspace open sets the active workspace before switching views.
  - Stabilized list memoization and moved cleanup to unmount in `useRegisterNavigableItems`; Review Queue now memoizes filter+sort and derives `navItems` from that result.

<sup>Written for commit e8f9d17aad53c0ccc44beb5187f1c0ad56c9b012. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App-wide keyboard navigation: j/k to move selection, Enter opens the selected item in a secure new tab, Escape returns to overview, workspace switching and command-palette toggle supported.

* **Behavior**
  * Visible lists now register navigable items; selection initializes/clamps as lists change, resets when views change, ignores input/textarea focus.

* **Tests**
  * Expanded keyboard/navigation tests covering selection, opening, Escape/workspace behavior, focus edge cases, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->