### PR TITLE
feat(workspace): implement PtyManager (T-068)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -393,7 +393,7 @@ checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
 dependencies = [
  "borsh-derive",
  "bytes",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
 ]
 
 [[package]]
@@ -602,6 +602,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "cfg_aliases"
@@ -1039,6 +1045,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1094,7 +1106,7 @@ dependencies = [
  "rustc_version",
  "toml 0.9.12+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -1240,6 +1252,17 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
 ]
 
 [[package]]
@@ -2710,6 +2733,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases 0.1.1",
+ "libc",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3317,6 +3352,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-pty"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a596a2b3d2752d94f51fac2d4a96737b8705dddd311a32b9af47211f08671e"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix",
+ "serial2",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg 0.10.1",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3366,6 +3422,7 @@ dependencies = [
  "log",
  "mockito",
  "notify-rust",
+ "portable-pty",
  "reqwest",
  "serde",
  "serde_json",
@@ -3492,7 +3549,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
@@ -3533,7 +3590,7 @@ version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
  "socket2",
@@ -4298,6 +4355,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial2"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1401f562d358cdfdbdf8946e51a7871ede1db68bd0fd99bedc79e400241550"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "serialize-to-javascript"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4359,6 +4427,22 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -6627,6 +6711,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,6 +30,7 @@ reqwest = { version = "0.13.2", features = ["json"] }
 tokio = { version = "1.50.0", features = ["rt", "time", "process", "fs"] }
 graphql_client = { version = "0.16.0", features = ["graphql_query_derive"] }
 notify-rust = "4.12.0"
+portable-pty = "0.9.0"
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/src-tauri/src/workspace/mod.rs
+++ b/src-tauri/src/workspace/mod.rs
@@ -1,1 +1,2 @@
+pub mod pty;
 pub mod worktree;

--- a/src-tauri/src/workspace/pty.rs
+++ b/src-tauri/src/workspace/pty.rs
@@ -113,6 +113,8 @@ impl PtyManager {
         // Clone ptys Arc so the reader task can remove stale entries on EOF.
         let ptys_for_task = Arc::clone(&self.ptys);
         let id_for_task = pty_id.clone();
+        let reader_closed = Arc::new(AtomicBool::new(false));
+        let reader_closed_for_task = Arc::clone(&reader_closed);
         let reader_task = tokio::task::spawn_blocking(move || {
             let mut reader = reader;
             let mut buf = [0u8; 4096];
@@ -126,9 +128,15 @@ impl PtyManager {
                     }
                 }
             }
+            // Signal that the reader has exited (for race detection on insert).
+            reader_closed_for_task.store(true, Ordering::Release);
             // Child exited — remove stale entry from the map.
+            // Release the map lock before dropping the PtyHandle so that
+            // Drop::drop() (which may call child.kill()) runs outside the lock.
             if let Ok(mut ptys) = ptys_for_task.lock() {
-                ptys.remove(&id_for_task);
+                let removed = ptys.remove(&id_for_task);
+                drop(ptys);
+                drop(removed);
             }
         });
 
@@ -140,10 +148,18 @@ impl PtyManager {
             killed: Arc::new(AtomicBool::new(false)),
         };
 
-        self.ptys
+        // Insert the handle, then check if the reader already exited before
+        // the insert completed (immediate EOF race). If so, clean up now.
+        let mut ptys = self
+            .ptys
             .lock()
-            .map_err(|e| AppError::Pty(format!("lock poisoned: {e}")))?
-            .insert(pty_id.clone(), handle);
+            .map_err(|e| AppError::Pty(format!("lock poisoned: {e}")))?;
+        ptys.insert(pty_id.clone(), handle);
+        if reader_closed.load(Ordering::Acquire) {
+            let removed = ptys.remove(&pty_id);
+            drop(ptys);
+            drop(removed);
+        }
 
         Ok(pty_id)
     }

--- a/src-tauri/src/workspace/pty.rs
+++ b/src-tauri/src/workspace/pty.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::io::Write;
 use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use portable_pty::{CommandBuilder, MasterPty, PtySize, native_pty_system};
@@ -10,21 +11,24 @@ use crate::error::AppError;
 
 /// Handle for a single PTY session.
 ///
-/// Holds the writer (per-PTY lock), the master (for resize), the child process,
-/// and the background reader task handle.
+/// Holds the writer and master (per-PTY locks), the child process,
+/// a background reader task handle, and a `killed` flag that prevents
+/// `Drop` from issuing a redundant kill after an explicit `kill()`.
 #[allow(dead_code)]
 struct PtyHandle {
     writer: Arc<Mutex<Box<dyn Write + Send>>>,
-    master: Box<dyn MasterPty + Send>,
+    master: Arc<Mutex<Box<dyn MasterPty + Send>>>,
     child: Box<dyn portable_pty::Child + Send + Sync>,
     reader_task: tokio::task::JoinHandle<()>,
+    killed: Arc<AtomicBool>,
 }
 
 impl Drop for PtyHandle {
     fn drop(&mut self) {
         self.reader_task.abort();
-        if let Err(e) = self.child.kill() {
-            log::warn!("failed to kill pty child on drop: {e}");
+        if !self.killed.load(Ordering::Acquire) {
+            // Best-effort cleanup — only kill if not already killed explicitly.
+            let _ = self.child.kill();
         }
     }
 }
@@ -51,10 +55,17 @@ impl PtyManager {
     /// Spawns a new PTY running the user's default shell.
     ///
     /// Returns the PTY id (UUID v4). A background `spawn_blocking` task reads
-    /// stdout and forwards each chunk to `on_output(pty_id, data)`.
+    /// stdout and forwards each chunk to `on_output(pty_id, data)`. When the
+    /// child exits (reader EOF), the session is automatically removed from the
+    /// manager.
     ///
     /// The `on_output` callback must be `Send + 'static` because it is moved
     /// into the blocking reader task.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called outside a Tokio runtime context (uses
+    /// `tokio::task::spawn_blocking` internally).
     #[allow(dead_code)]
     pub fn spawn(
         &self,
@@ -74,7 +85,11 @@ impl PtyManager {
             })
             .map_err(|e| AppError::Pty(format!("failed to open pty: {e}")))?;
 
-        let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".into());
+        let shell = if cfg!(windows) {
+            std::env::var("COMSPEC").unwrap_or_else(|_| "cmd.exe".into())
+        } else {
+            std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".into())
+        };
         let mut cmd = CommandBuilder::new(&shell);
         cmd.cwd(cwd);
 
@@ -95,6 +110,8 @@ impl PtyManager {
 
         let pty_id = Uuid::new_v4().to_string();
 
+        // Clone ptys Arc so the reader task can remove stale entries on EOF.
+        let ptys_for_task = Arc::clone(&self.ptys);
         let id_for_task = pty_id.clone();
         let reader_task = tokio::task::spawn_blocking(move || {
             let mut reader = reader;
@@ -109,13 +126,18 @@ impl PtyManager {
                     }
                 }
             }
+            // Child exited — remove stale entry from the map.
+            if let Ok(mut ptys) = ptys_for_task.lock() {
+                ptys.remove(&id_for_task);
+            }
         });
 
         let handle = PtyHandle {
             writer: Arc::new(Mutex::new(writer)),
-            master: pair.master,
+            master: Arc::new(Mutex::new(pair.master)),
             child,
             reader_task,
+            killed: Arc::new(AtomicBool::new(false)),
         };
 
         self.ptys
@@ -159,19 +181,29 @@ impl PtyManager {
     }
 
     /// Resizes a PTY to new dimensions.
+    ///
+    /// Acquires only the per-PTY master lock, not the global map lock during
+    /// the `ioctl` syscall.
     #[allow(dead_code)]
     pub fn resize(&self, pty_id: &str, cols: u16, rows: u16) -> Result<(), AppError> {
-        let ptys = self
-            .ptys
+        let master = {
+            let ptys = self
+                .ptys
+                .lock()
+                .map_err(|e| AppError::Pty(format!("lock poisoned: {e}")))?;
+
+            let handle = ptys
+                .get(pty_id)
+                .ok_or_else(|| AppError::NotFound(format!("pty {pty_id}")))?;
+
+            Arc::clone(&handle.master)
+        }; // map lock released here
+
+        let master = master
             .lock()
-            .map_err(|e| AppError::Pty(format!("lock poisoned: {e}")))?;
+            .map_err(|e| AppError::Pty(format!("master lock poisoned: {e}")))?;
 
-        let handle = ptys
-            .get(pty_id)
-            .ok_or_else(|| AppError::NotFound(format!("pty {pty_id}")))?;
-
-        handle
-            .master
+        master
             .resize(PtySize {
                 rows,
                 cols,
@@ -186,8 +218,7 @@ impl PtyManager {
     /// Kills a PTY process and removes it from the manager.
     ///
     /// The map lock is released before performing the kill syscall.
-    /// The `Drop` impl on `PtyHandle` aborts the reader task and kills
-    /// the child if this method's explicit `kill()` fails.
+    /// Sets the `killed` flag so `Drop` does not issue a redundant kill.
     #[allow(dead_code)]
     pub fn kill(&self, pty_id: &str) -> Result<(), AppError> {
         let mut handle = {
@@ -206,6 +237,9 @@ impl PtyManager {
             .child
             .kill()
             .map_err(|e| AppError::Pty(format!("kill failed: {e}")))?;
+
+        // Mark as killed so Drop does not call kill() again.
+        handle.killed.store(true, Ordering::Release);
 
         Ok(())
     }
@@ -264,12 +298,16 @@ mod tests {
         let result = manager.write_pty(&pty_id, b"echo hello_pty_test\n");
         assert!(result.is_ok(), "write_pty should succeed: {result:?}");
 
+        // Accumulate output chunks and look for our marker string.
+        // PTY output may include prompts and ANSI escapes, so exact line
+        // matching is too fragile — `contains` is appropriate here.
         let mut found = false;
+        let mut output = String::new();
         let deadline = std::time::Instant::now() + Duration::from_secs(3);
         while std::time::Instant::now() < deadline {
             if let Ok(data) = rx.recv_timeout(Duration::from_millis(100)) {
-                let text = String::from_utf8_lossy(&data);
-                if text.contains("hello_pty_test") {
+                output.push_str(&String::from_utf8_lossy(&data));
+                if output.contains("hello_pty_test") {
                     found = true;
                     break;
                 }
@@ -348,5 +386,30 @@ mod tests {
 
         manager.kill(&id1).unwrap();
         manager.kill(&id3).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_exit_removes_stale_entry() {
+        let manager = PtyManager::new();
+        let (pty_id, _rx) = spawn_test_pty(&manager);
+
+        // Give the shell time to start
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // Tell the shell to exit
+        manager.write_pty(&pty_id, b"exit\n").unwrap();
+
+        // Wait for the reader task to clean up the stale entry
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        let mut removed = false;
+        while std::time::Instant::now() < deadline {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            let ptys = manager.ptys.lock().unwrap();
+            if !ptys.contains_key(&pty_id) {
+                removed = true;
+                break;
+            }
+        }
+        assert!(removed, "pty entry should be removed after shell exits");
     }
 }

--- a/src-tauri/src/workspace/pty.rs
+++ b/src-tauri/src/workspace/pty.rs
@@ -1,0 +1,352 @@
+use std::collections::HashMap;
+use std::io::Write;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use portable_pty::{CommandBuilder, MasterPty, PtySize, native_pty_system};
+use uuid::Uuid;
+
+use crate::error::AppError;
+
+/// Handle for a single PTY session.
+///
+/// Holds the writer (per-PTY lock), the master (for resize), the child process,
+/// and the background reader task handle.
+#[allow(dead_code)]
+struct PtyHandle {
+    writer: Arc<Mutex<Box<dyn Write + Send>>>,
+    master: Box<dyn MasterPty + Send>,
+    child: Box<dyn portable_pty::Child + Send + Sync>,
+    reader_task: tokio::task::JoinHandle<()>,
+}
+
+impl Drop for PtyHandle {
+    fn drop(&mut self) {
+        self.reader_task.abort();
+        if let Err(e) = self.child.kill() {
+            log::warn!("failed to kill pty child on drop: {e}");
+        }
+    }
+}
+
+/// Manages multiple PTY sessions, keyed by UUID string.
+///
+/// Thread-safe via internal `Arc<Mutex<…>>`. Clone to share across tasks.
+#[allow(dead_code)]
+#[derive(Clone)]
+pub struct PtyManager {
+    ptys: Arc<Mutex<HashMap<String, PtyHandle>>>,
+}
+
+impl PtyManager {
+    /// Creates a new, empty `PtyManager`.
+    #[allow(dead_code)]
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            ptys: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Spawns a new PTY running the user's default shell.
+    ///
+    /// Returns the PTY id (UUID v4). A background `spawn_blocking` task reads
+    /// stdout and forwards each chunk to `on_output(pty_id, data)`.
+    ///
+    /// The `on_output` callback must be `Send + 'static` because it is moved
+    /// into the blocking reader task.
+    #[allow(dead_code)]
+    pub fn spawn(
+        &self,
+        cwd: &Path,
+        cols: u16,
+        rows: u16,
+        on_output: impl Fn(&str, &[u8]) + Send + 'static,
+    ) -> Result<String, AppError> {
+        let pty_system = native_pty_system();
+
+        let pair = pty_system
+            .openpty(PtySize {
+                rows,
+                cols,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .map_err(|e| AppError::Pty(format!("failed to open pty: {e}")))?;
+
+        let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".into());
+        let mut cmd = CommandBuilder::new(&shell);
+        cmd.cwd(cwd);
+
+        let child = pair
+            .slave
+            .spawn_command(cmd)
+            .map_err(|e| AppError::Pty(format!("failed to spawn shell: {e}")))?;
+
+        let writer = pair
+            .master
+            .take_writer()
+            .map_err(|e| AppError::Pty(format!("failed to take pty writer: {e}")))?;
+
+        let reader = pair
+            .master
+            .try_clone_reader()
+            .map_err(|e| AppError::Pty(format!("failed to clone pty reader: {e}")))?;
+
+        let pty_id = Uuid::new_v4().to_string();
+
+        let id_for_task = pty_id.clone();
+        let reader_task = tokio::task::spawn_blocking(move || {
+            let mut reader = reader;
+            let mut buf = [0u8; 4096];
+            loop {
+                match std::io::Read::read(&mut reader, &mut buf) {
+                    Ok(0) => break,
+                    Ok(n) => on_output(&id_for_task, &buf[..n]),
+                    Err(e) => {
+                        log::warn!("pty reader error for {id_for_task}: {e}");
+                        break;
+                    }
+                }
+            }
+        });
+
+        let handle = PtyHandle {
+            writer: Arc::new(Mutex::new(writer)),
+            master: pair.master,
+            child,
+            reader_task,
+        };
+
+        self.ptys
+            .lock()
+            .map_err(|e| AppError::Pty(format!("lock poisoned: {e}")))?
+            .insert(pty_id.clone(), handle);
+
+        Ok(pty_id)
+    }
+
+    /// Writes data to the PTY's stdin.
+    ///
+    /// Acquires only the per-PTY writer lock, not the global map lock during I/O.
+    #[allow(dead_code)]
+    pub fn write_pty(&self, pty_id: &str, data: &[u8]) -> Result<(), AppError> {
+        let writer = {
+            let ptys = self
+                .ptys
+                .lock()
+                .map_err(|e| AppError::Pty(format!("lock poisoned: {e}")))?;
+
+            let handle = ptys
+                .get(pty_id)
+                .ok_or_else(|| AppError::NotFound(format!("pty {pty_id}")))?;
+
+            Arc::clone(&handle.writer)
+        }; // map lock released here
+
+        let mut writer = writer
+            .lock()
+            .map_err(|e| AppError::Pty(format!("writer lock poisoned: {e}")))?;
+
+        writer
+            .write_all(data)
+            .map_err(|e| AppError::Pty(format!("write failed: {e}")))?;
+        writer
+            .flush()
+            .map_err(|e| AppError::Pty(format!("flush failed: {e}")))?;
+
+        Ok(())
+    }
+
+    /// Resizes a PTY to new dimensions.
+    #[allow(dead_code)]
+    pub fn resize(&self, pty_id: &str, cols: u16, rows: u16) -> Result<(), AppError> {
+        let ptys = self
+            .ptys
+            .lock()
+            .map_err(|e| AppError::Pty(format!("lock poisoned: {e}")))?;
+
+        let handle = ptys
+            .get(pty_id)
+            .ok_or_else(|| AppError::NotFound(format!("pty {pty_id}")))?;
+
+        handle
+            .master
+            .resize(PtySize {
+                rows,
+                cols,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .map_err(|e| AppError::Pty(format!("resize failed: {e}")))?;
+
+        Ok(())
+    }
+
+    /// Kills a PTY process and removes it from the manager.
+    ///
+    /// The map lock is released before performing the kill syscall.
+    /// The `Drop` impl on `PtyHandle` aborts the reader task and kills
+    /// the child if this method's explicit `kill()` fails.
+    #[allow(dead_code)]
+    pub fn kill(&self, pty_id: &str) -> Result<(), AppError> {
+        let mut handle = {
+            let mut ptys = self
+                .ptys
+                .lock()
+                .map_err(|e| AppError::Pty(format!("lock poisoned: {e}")))?;
+
+            ptys.remove(pty_id)
+                .ok_or_else(|| AppError::NotFound(format!("pty {pty_id}")))?
+        }; // map lock released here
+
+        handle.reader_task.abort();
+
+        handle
+            .child
+            .kill()
+            .map_err(|e| AppError::Pty(format!("kill failed: {e}")))?;
+
+        Ok(())
+    }
+}
+
+impl Default for PtyManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    /// Helper: spawns a PTY in a temp dir with a channel-based output collector.
+    fn spawn_test_pty(manager: &PtyManager) -> (String, mpsc::Receiver<Vec<u8>>) {
+        let tmp = std::env::temp_dir();
+        let (tx, rx) = mpsc::channel();
+
+        let pty_id = manager
+            .spawn(&tmp, 80, 24, move |_id, data| {
+                let _ = tx.send(data.to_vec());
+            })
+            .expect("spawn_pty should succeed");
+
+        (pty_id, rx)
+    }
+
+    #[tokio::test]
+    async fn test_spawn_pty() {
+        let manager = PtyManager::new();
+        let (pty_id, _rx) = spawn_test_pty(&manager);
+
+        assert!(
+            Uuid::parse_str(&pty_id).is_ok(),
+            "pty_id should be a valid UUID: {pty_id}"
+        );
+
+        let ptys = manager.ptys.lock().unwrap();
+        assert!(ptys.contains_key(&pty_id), "manager should track the pty");
+
+        drop(ptys);
+        manager.kill(&pty_id).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_write_to_pty() {
+        let manager = PtyManager::new();
+        let (pty_id, rx) = spawn_test_pty(&manager);
+
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        let result = manager.write_pty(&pty_id, b"echo hello_pty_test\n");
+        assert!(result.is_ok(), "write_pty should succeed: {result:?}");
+
+        let mut found = false;
+        let deadline = std::time::Instant::now() + Duration::from_secs(3);
+        while std::time::Instant::now() < deadline {
+            if let Ok(data) = rx.recv_timeout(Duration::from_millis(100)) {
+                let text = String::from_utf8_lossy(&data);
+                if text.contains("hello_pty_test") {
+                    found = true;
+                    break;
+                }
+            }
+        }
+        assert!(found, "should see 'hello_pty_test' in PTY output");
+
+        manager.kill(&pty_id).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_resize_pty() {
+        let manager = PtyManager::new();
+        let (pty_id, _rx) = spawn_test_pty(&manager);
+
+        let result = manager.resize(&pty_id, 120, 40);
+        assert!(result.is_ok(), "resize should succeed: {result:?}");
+
+        manager.kill(&pty_id).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_kill_pty() {
+        let manager = PtyManager::new();
+        let (pty_id, _rx) = spawn_test_pty(&manager);
+
+        let result = manager.kill(&pty_id);
+        assert!(result.is_ok(), "kill should succeed: {result:?}");
+
+        let ptys = manager.ptys.lock().unwrap();
+        assert!(
+            !ptys.contains_key(&pty_id),
+            "pty should be removed after kill"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_kill_pty_not_found() {
+        let manager = PtyManager::new();
+
+        let result = manager.kill("nonexistent-id");
+        assert!(result.is_err(), "kill nonexistent should fail");
+
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, AppError::NotFound(_)),
+            "expected NotFound error, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_multiple_ptys() {
+        let manager = PtyManager::new();
+
+        let (id1, _rx1) = spawn_test_pty(&manager);
+        let (id2, _rx2) = spawn_test_pty(&manager);
+        let (id3, _rx3) = spawn_test_pty(&manager);
+
+        assert_ne!(id1, id2);
+        assert_ne!(id2, id3);
+        assert_ne!(id1, id3);
+
+        {
+            let ptys = manager.ptys.lock().unwrap();
+            assert_eq!(ptys.len(), 3, "should have 3 ptys");
+        }
+
+        manager.kill(&id2).unwrap();
+        {
+            let ptys = manager.ptys.lock().unwrap();
+            assert_eq!(ptys.len(), 2, "should have 2 ptys after killing one");
+            assert!(ptys.contains_key(&id1));
+            assert!(!ptys.contains_key(&id2));
+            assert!(ptys.contains_key(&id3));
+        }
+
+        manager.kill(&id1).unwrap();
+        manager.kill(&id3).unwrap();
+    }
+}


### PR DESCRIPTION
## Summary

- Add `PtyManager` struct managing multiple PTY sessions via `portable-pty` crate
- Implements `spawn` (default shell + background stdout reader), `write_pty`, `resize`, and `kill`
- Thread-safe design: `Arc<Mutex<HashMap>>` for the session map, per-PTY `Arc<Mutex<Writer>>` to avoid holding global lock during blocking I/O
- `Drop` impl on `PtyHandle` ensures child process cleanup and reader task abort
- Decoupled from Tauri via `on_output` callback pattern — testable without app handle

## Test plan

- [x] `test_spawn_pty` — spawn PTY, verify UUID and tracking
- [x] `test_write_to_pty` — write command, verify output received via callback
- [x] `test_resize_pty` — resize to new dimensions
- [x] `test_kill_pty` — kill and verify removal from manager
- [x] `test_kill_pty_not_found` — error on nonexistent ID
- [x] `test_multiple_ptys` — spawn 3, kill selectively, verify isolation
- [x] All 259 existing tests pass (no regression)
- [x] `cargo clippy -- -D warnings` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements `PtyManager` for workspace terminals to spawn, write, resize, and kill PTY sessions, streaming output via callback and cleaning up on exit. Also hardens session lifecycle with race-safe cleanup and no global lock held during process kill. Satisfies Linear T-068 with a cross-platform PTY layer decoupled from Tauri.

- **New Features**
  - Thread-safe UUID session map; background reader calls `on_output(id, data)` and removes the session on EOF.
  - Platform shell detection: `COMSPEC`/`cmd.exe` on Windows, `SHELL`/`/bin/sh` on Unix.
  - Per-PTY locks for writer and master (no global lock during I/O or `resize`).
  - APIs: `spawn` (requires Tokio runtime), `write_pty`, `resize`, `kill`; `Drop` aborts reader and avoids double-kill via flag.

- **Bug Fixes**
  - Fix immediate-EOF race on spawn and release the map lock before PTY cleanup to avoid killing under the global lock.

<sup>Written for commit 64030db405357c7194b8bd3a12c5f1d8fd5b8c8e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added terminal session management: spawn multiple concurrent terminal sessions with real-time I/O, dynamic resizing, and programmatic termination.
* **Bug Fixes**
  * Improved session cleanup to automatically remove stale sessions and prevent resource leaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->