### PR TITLE
feat(workspace): implement workspace_cleanup command

### DIFF
--- a/src-tauri/src/cache/config.rs
+++ b/src-tauri/src/cache/config.rs
@@ -7,6 +7,8 @@ use crate::types::AppConfig;
 /// Keys used in the `config` key-value table.
 const KEY_POLL_INTERVAL: &str = "poll_interval_secs";
 const KEY_MAX_WORKSPACES: &str = "max_active_workspaces";
+const KEY_ARCHIVE_DELAY: &str = "archive_delay_hours";
+const KEY_ARCHIVE_DELAY_CLOSED: &str = "archive_delay_closed_hours";
 const KEY_GITHUB_TOKEN: &str = "github_token";
 const KEY_DATA_DIR: &str = "data_dir";
 const KEY_WORKSPACES_DIR: &str = "workspaces_dir";
@@ -74,6 +76,20 @@ pub async fn get_config(pool: &SqlitePool) -> Result<AppConfig, AppError> {
                     KEY_MAX_WORKSPACES, row.value
                 ),
             },
+            KEY_ARCHIVE_DELAY => match row.value.parse::<u64>() {
+                Ok(v) => config.archive_delay_hours = v,
+                Err(_) => warn!(
+                    "ignoring non-parseable config value for '{}': '{}', using default",
+                    KEY_ARCHIVE_DELAY, row.value
+                ),
+            },
+            KEY_ARCHIVE_DELAY_CLOSED => match row.value.parse::<u64>() {
+                Ok(v) => config.archive_delay_closed_hours = v,
+                Err(_) => warn!(
+                    "ignoring non-parseable config value for '{}': '{}', using default",
+                    KEY_ARCHIVE_DELAY_CLOSED, row.value
+                ),
+            },
             KEY_GITHUB_TOKEN => {
                 config.github_token = Some(row.value);
             }
@@ -104,6 +120,18 @@ pub async fn set_config(pool: &SqlitePool, config: &AppConfig) -> Result<AppConf
 
     upsert_key(&mut *tx, KEY_POLL_INTERVAL, &poll_interval.to_string()).await?;
     upsert_key(&mut *tx, KEY_MAX_WORKSPACES, &max_workspaces.to_string()).await?;
+    upsert_key(
+        &mut *tx,
+        KEY_ARCHIVE_DELAY,
+        &config.archive_delay_hours.to_string(),
+    )
+    .await?;
+    upsert_key(
+        &mut *tx,
+        KEY_ARCHIVE_DELAY_CLOSED,
+        &config.archive_delay_closed_hours.to_string(),
+    )
+    .await?;
 
     set_optional_key(&mut *tx, KEY_GITHUB_TOKEN, config.github_token.as_deref()).await?;
     set_optional_key(&mut *tx, KEY_DATA_DIR, config.data_dir.as_deref()).await?;
@@ -120,6 +148,8 @@ pub async fn set_config(pool: &SqlitePool, config: &AppConfig) -> Result<AppConf
     Ok(AppConfig {
         poll_interval_secs: poll_interval,
         max_active_workspaces: max_workspaces,
+        archive_delay_hours: config.archive_delay_hours,
+        archive_delay_closed_hours: config.archive_delay_closed_hours,
         github_token: config.github_token.clone(),
         data_dir: config.data_dir.clone(),
         workspaces_dir: config.workspaces_dir.clone(),
@@ -218,6 +248,8 @@ mod tests {
         let config = AppConfig {
             poll_interval_secs: 120,
             max_active_workspaces: 5,
+            archive_delay_hours: 12,
+            archive_delay_closed_hours: 72,
             github_token: Some("ghp_test".to_string()),
             data_dir: Some("/custom/data".to_string()),
             workspaces_dir: Some("/custom/ws".to_string()),

--- a/src-tauri/src/cache/config.rs
+++ b/src-tauri/src/cache/config.rs
@@ -258,6 +258,8 @@ mod tests {
         let result = set_config(&pool, &config).await.unwrap();
         assert_eq!(result.poll_interval_secs, 120);
         assert_eq!(result.max_active_workspaces, 5);
+        assert_eq!(result.archive_delay_hours, 12);
+        assert_eq!(result.archive_delay_closed_hours, 72);
         assert_eq!(result.github_token.as_deref(), Some("ghp_test"));
         assert_eq!(result.data_dir.as_deref(), Some("/custom/data"));
         assert_eq!(result.workspaces_dir.as_deref(), Some("/custom/ws"));

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -868,24 +868,33 @@ pub async fn workspace_archive(
 // ── Workspace cleanup (T-071) ────────────────────────────────────
 
 /// Archives workspaces whose PR is merged (> `archive_delay_hours`) or
-/// closed (> `archive_delay_closed_hours`). Returns the number archived.
+/// closed (> `archive_delay_closed_hours`). Returns the IDs of archived
+/// workspaces so the caller can emit per-workspace events.
 ///
 /// Accepts delay values as parameters so tests can control timing.
+/// Delay values are capped at ~100 years to avoid `Duration` overflow.
 pub(crate) async fn workspace_cleanup_inner(
     pool: &SqlitePool,
     pty_state: &PtyManagerState,
     archive_delay_hours: u64,
     archive_delay_closed_hours: u64,
-) -> Result<u32, AppError> {
+) -> Result<Vec<String>, AppError> {
     use chrono::{Duration, SecondsFormat, Utc};
 
+    // Cap at ~100 years to avoid Duration::hours overflow (i64 * 3_600_000_000_000 ns).
+    const MAX_DELAY_HOURS: i64 = 365 * 24 * 100;
+
     let now = Utc::now();
-    let merged_cutoff = (now
-        - Duration::hours(i64::try_from(archive_delay_hours).unwrap_or(i64::MAX)))
-    .to_rfc3339_opts(SecondsFormat::Millis, true);
-    let closed_cutoff = (now
-        - Duration::hours(i64::try_from(archive_delay_closed_hours).unwrap_or(i64::MAX)))
-    .to_rfc3339_opts(SecondsFormat::Millis, true);
+    let delay_merged = i64::try_from(archive_delay_hours)
+        .unwrap_or(MAX_DELAY_HOURS)
+        .min(MAX_DELAY_HOURS);
+    let delay_closed = i64::try_from(archive_delay_closed_hours)
+        .unwrap_or(MAX_DELAY_HOURS)
+        .min(MAX_DELAY_HOURS);
+    let merged_cutoff =
+        (now - Duration::hours(delay_merged)).to_rfc3339_opts(SecondsFormat::Millis, true);
+    let closed_cutoff =
+        (now - Duration::hours(delay_closed)).to_rfc3339_opts(SecondsFormat::Millis, true);
 
     // Find workspace IDs eligible for cleanup via a single JOIN query.
     let ids: Vec<(String,)> = sqlx::query_as(
@@ -902,7 +911,7 @@ pub(crate) async fn workspace_cleanup_inner(
     .fetch_all(pool)
     .await?;
 
-    let mut archived_count = 0u32;
+    let mut archived_ids = Vec::new();
     for (ws_id,) in &ids {
         let Some(ws) = crate::cache::workspaces::get_workspace(pool, ws_id).await? else {
             continue;
@@ -918,30 +927,46 @@ pub(crate) async fn workspace_cleanup_inner(
             };
 
         match workspace_archive_inner(pool, pty_state, &ws, local_path.as_deref()).await {
-            Ok(_) => archived_count += 1,
+            Ok(_) => archived_ids.push(ws.id.clone()),
             Err(e) => log::warn!("cleanup: failed to archive workspace '{}': {e}", ws.id),
         }
     }
 
-    Ok(archived_count)
+    Ok(archived_ids)
 }
 
 /// Auto-archives workspaces whose PR has been merged or closed past the
 /// configured delay. Returns the number of workspaces archived.
+///
+/// Emits `workspace:state_changed` for each archived workspace so the
+/// frontend stays in sync.
 #[tauri::command]
 pub async fn workspace_cleanup(
     pool: tauri::State<'_, SqlitePool>,
     pty_state: tauri::State<'_, PtyManagerState>,
+    app_handle: tauri::AppHandle,
 ) -> Result<u32, String> {
     let config = get_config(&pool).await.map_err(|e| e.to_string())?;
-    workspace_cleanup_inner(
+    let archived_ids = workspace_cleanup_inner(
         &pool,
         &pty_state,
         config.archive_delay_hours,
         config.archive_delay_closed_hours,
     )
     .await
-    .map_err(|e| e.to_string())
+    .map_err(|e| e.to_string())?;
+
+    for ws_id in &archived_ids {
+        let payload = crate::types::WorkspaceStateChanged {
+            workspace_id: ws_id.clone(),
+            new_state: WorkspaceState::Archived,
+        };
+        if let Err(e) = app_handle.emit("workspace:state_changed", &payload) {
+            log::warn!("cleanup: failed to emit workspace:state_changed for '{ws_id}': {e}");
+        }
+    }
+
+    Ok(u32::try_from(archived_ids.len()).unwrap_or(u32::MAX))
 }
 
 /// Writes data to a PTY's stdin.
@@ -2370,10 +2395,11 @@ mod tests {
             .await
             .unwrap();
 
-        let count = workspace_cleanup_inner(&pool, &pty_state, 24, 48)
+        let archived = workspace_cleanup_inner(&pool, &pty_state, 24, 48)
             .await
             .unwrap();
-        assert_eq!(count, 1, "should archive 1 workspace");
+        assert_eq!(archived.len(), 1, "should archive 1 workspace");
+        assert_eq!(archived[0], "ws-1");
 
         let ws = crate::cache::workspaces::get_workspace(&pool, "ws-1")
             .await
@@ -2405,10 +2431,15 @@ mod tests {
             .await
             .unwrap();
 
-        let count = workspace_cleanup_inner(&pool, &pty_state, 24, 48)
+        let archived = workspace_cleanup_inner(&pool, &pty_state, 24, 48)
             .await
             .unwrap();
-        assert_eq!(count, 1, "should archive 1 workspace for closed PR");
+        assert_eq!(
+            archived.len(),
+            1,
+            "should archive 1 workspace for closed PR"
+        );
+        assert_eq!(archived[0], "ws-2");
 
         let ws = crate::cache::workspaces::get_workspace(&pool, "ws-2")
             .await
@@ -2434,10 +2465,13 @@ mod tests {
             .await
             .unwrap();
 
-        let count = workspace_cleanup_inner(&pool, &pty_state, 24, 48)
+        let archived = workspace_cleanup_inner(&pool, &pty_state, 24, 48)
             .await
             .unwrap();
-        assert_eq!(count, 0, "should not archive workspace within delay");
+        assert!(
+            archived.is_empty(),
+            "should not archive workspace within delay"
+        );
 
         let ws = crate::cache::workspaces::get_workspace(&pool, "ws-3")
             .await
@@ -2473,17 +2507,23 @@ mod tests {
             .await
             .unwrap();
 
-        let count = workspace_cleanup_inner(&pool, &pty_state, 24, 48)
+        let archived = workspace_cleanup_inner(&pool, &pty_state, 24, 48)
             .await
             .unwrap();
-        assert_eq!(count, 0, "should not archive workspace for open PR");
+        assert!(
+            archived.is_empty(),
+            "should not archive workspace for open PR"
+        );
 
         // No workspaces at all
         let (pool2, _tmp2) = test_pool().await;
-        let count = workspace_cleanup_inner(&pool2, &pty_state, 24, 48)
+        let archived = workspace_cleanup_inner(&pool2, &pty_state, 24, 48)
             .await
             .unwrap();
-        assert_eq!(count, 0, "should return 0 with no workspaces");
+        assert!(
+            archived.is_empty(),
+            "should return empty with no workspaces"
+        );
 
         pool.close().await;
         pool2.close().await;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -865,6 +865,85 @@ pub async fn workspace_archive(
     Ok(())
 }
 
+// ── Workspace cleanup (T-071) ────────────────────────────────────
+
+/// Archives workspaces whose PR is merged (> `archive_delay_hours`) or
+/// closed (> `archive_delay_closed_hours`). Returns the number archived.
+///
+/// Accepts delay values as parameters so tests can control timing.
+pub(crate) async fn workspace_cleanup_inner(
+    pool: &SqlitePool,
+    pty_state: &PtyManagerState,
+    archive_delay_hours: u64,
+    archive_delay_closed_hours: u64,
+) -> Result<u32, AppError> {
+    use chrono::{Duration, SecondsFormat, Utc};
+
+    let now = Utc::now();
+    let merged_cutoff = (now
+        - Duration::hours(i64::try_from(archive_delay_hours).unwrap_or(i64::MAX)))
+    .to_rfc3339_opts(SecondsFormat::Millis, true);
+    let closed_cutoff = (now
+        - Duration::hours(i64::try_from(archive_delay_closed_hours).unwrap_or(i64::MAX)))
+    .to_rfc3339_opts(SecondsFormat::Millis, true);
+
+    // Find workspace IDs eligible for cleanup via a single JOIN query.
+    let ids: Vec<(String,)> = sqlx::query_as(
+        "SELECT w.id FROM workspaces w \
+         JOIN pull_requests p ON w.repo_id = p.repo_id AND w.pull_request_number = p.number \
+         WHERE w.state != 'archived' \
+         AND ( \
+             (p.state = 'merged' AND p.updated_at < $1) \
+             OR (p.state = 'closed' AND p.updated_at < $2) \
+         )",
+    )
+    .bind(&merged_cutoff)
+    .bind(&closed_cutoff)
+    .fetch_all(pool)
+    .await?;
+
+    let mut archived_count = 0u32;
+    for (ws_id,) in &ids {
+        let Some(ws) = crate::cache::workspaces::get_workspace(pool, ws_id).await? else {
+            continue;
+        };
+
+        let local_path: Option<PathBuf> =
+            match crate::cache::repos::get_repo(pool, &ws.repo_id).await {
+                Ok(repo) => repo.local_path.as_deref().map(PathBuf::from),
+                Err(e) => {
+                    log::warn!("cleanup: could not fetch repo '{}': {e}", ws.repo_id);
+                    None
+                }
+            };
+
+        match workspace_archive_inner(pool, pty_state, &ws, local_path.as_deref()).await {
+            Ok(_) => archived_count += 1,
+            Err(e) => log::warn!("cleanup: failed to archive workspace '{}': {e}", ws.id),
+        }
+    }
+
+    Ok(archived_count)
+}
+
+/// Auto-archives workspaces whose PR has been merged or closed past the
+/// configured delay. Returns the number of workspaces archived.
+#[tauri::command]
+pub async fn workspace_cleanup(
+    pool: tauri::State<'_, SqlitePool>,
+    pty_state: tauri::State<'_, PtyManagerState>,
+) -> Result<u32, String> {
+    let config = get_config(&pool).await.map_err(|e| e.to_string())?;
+    workspace_cleanup_inner(
+        &pool,
+        &pty_state,
+        config.archive_delay_hours,
+        config.archive_delay_closed_hours,
+    )
+    .await
+    .map_err(|e| e.to_string())
+}
+
 /// Writes data to a PTY's stdin.
 ///
 /// Tauri 2 renames `pty_id` → `ptyId` for the JS caller.
@@ -1148,6 +1227,8 @@ mod tests {
         let config = AppConfig {
             poll_interval_secs: 120,
             max_active_workspaces: 5,
+            archive_delay_hours: 12,
+            archive_delay_closed_hours: 72,
             github_token: Some("ghp_test".into()),
             data_dir: None,
             workspaces_dir: Some("/ws".into()),
@@ -1155,6 +1236,8 @@ mod tests {
         let json = serde_json::to_value(&config).unwrap();
         assert_eq!(json["pollIntervalSecs"], 120);
         assert_eq!(json["maxActiveWorkspaces"], 5);
+        assert_eq!(json["archiveDelayHours"], 12);
+        assert_eq!(json["archiveDelayClosedHours"], 72);
         assert_eq!(json["githubToken"], "ghp_test");
         assert!(json["dataDir"].is_null());
         assert_eq!(json["workspacesDir"], "/ws");
@@ -1202,6 +1285,8 @@ mod tests {
         let base = AppConfig {
             poll_interval_secs: 300,
             max_active_workspaces: 3,
+            archive_delay_hours: 24,
+            archive_delay_closed_hours: 48,
             github_token: None,
             data_dir: None,
             workspaces_dir: None,
@@ -1209,6 +1294,8 @@ mod tests {
         let partial = PartialAppConfig {
             poll_interval_secs: Some(60),
             max_active_workspaces: None,
+            archive_delay_hours: None,
+            archive_delay_closed_hours: None,
             github_token: None,
             data_dir: None,
             workspaces_dir: None,
@@ -1223,6 +1310,8 @@ mod tests {
         let base = AppConfig {
             poll_interval_secs: 300,
             max_active_workspaces: 3,
+            archive_delay_hours: 24,
+            archive_delay_closed_hours: 48,
             github_token: Some("ghp_old".into()),
             data_dir: Some("/data".into()),
             workspaces_dir: None,
@@ -1231,6 +1320,8 @@ mod tests {
         let partial = PartialAppConfig {
             poll_interval_secs: None,
             max_active_workspaces: None,
+            archive_delay_hours: None,
+            archive_delay_closed_hours: None,
             github_token: Some(None), // clear it
             data_dir: None,           // leave as-is
             workspaces_dir: None,
@@ -1720,6 +1811,8 @@ mod tests {
             &crate::types::AppConfig {
                 poll_interval_secs: 300,
                 max_active_workspaces: 3,
+                archive_delay_hours: 24,
+                archive_delay_closed_hours: 48,
                 github_token: None,
                 data_dir: None,
                 workspaces_dir: Some(ws_base.path().to_string_lossy().to_string()),
@@ -1772,6 +1865,8 @@ mod tests {
             &crate::types::AppConfig {
                 poll_interval_secs: 300,
                 max_active_workspaces: 1,
+                archive_delay_hours: 24,
+                archive_delay_closed_hours: 48,
                 github_token: None,
                 data_dir: None,
                 workspaces_dir: Some(ws_base.path().to_string_lossy().to_string()),
@@ -1845,6 +1940,8 @@ mod tests {
             &crate::types::AppConfig {
                 poll_interval_secs: 300,
                 max_active_workspaces: 3,
+                archive_delay_hours: 24,
+                archive_delay_closed_hours: 48,
                 github_token: None,
                 data_dir: None,
                 workspaces_dir: Some(ws_base.path().to_string_lossy().to_string()),
@@ -1896,6 +1993,8 @@ mod tests {
             &crate::types::AppConfig {
                 poll_interval_secs: 300,
                 max_active_workspaces: 3,
+                archive_delay_hours: 24,
+                archive_delay_closed_hours: 48,
                 github_token: None,
                 data_dir: None,
                 workspaces_dir: Some(ws_base.path().to_string_lossy().to_string()),
@@ -1963,6 +2062,8 @@ mod tests {
             &crate::types::AppConfig {
                 poll_interval_secs: 300,
                 max_active_workspaces: 3,
+                archive_delay_hours: 24,
+                archive_delay_closed_hours: 48,
                 github_token: None,
                 data_dir: None,
                 workspaces_dir: Some(ws_base.path().to_string_lossy().to_string()),
@@ -2031,6 +2132,8 @@ mod tests {
             &crate::types::AppConfig {
                 poll_interval_secs: 300,
                 max_active_workspaces: 3,
+                archive_delay_hours: 24,
+                archive_delay_closed_hours: 48,
                 github_token: None,
                 data_dir: None,
                 workspaces_dir: Some(ws_base.path().to_string_lossy().to_string()),
@@ -2097,6 +2200,8 @@ mod tests {
             &crate::types::AppConfig {
                 poll_interval_secs: 300,
                 max_active_workspaces: 3,
+                archive_delay_hours: 24,
+                archive_delay_closed_hours: 48,
                 github_token: None,
                 data_dir: None,
                 workspaces_dir: Some(ws_base.path().to_string_lossy().to_string()),
@@ -2191,5 +2296,196 @@ mod tests {
         assert!(result.is_ok(), "resize should succeed: {result:?}");
 
         pty_state.manager.kill(&pty_id).unwrap();
+    }
+
+    // -- Workspace cleanup (T-071) --
+
+    /// Helper: inserts a PR into the DB for cleanup tests.
+    async fn insert_test_pr(
+        pool: &SqlitePool,
+        id: &str,
+        number: u32,
+        state: crate::types::PrState,
+        updated_at: &str,
+    ) {
+        use crate::types::{CiStatus, Priority, PullRequest};
+        let pr = PullRequest {
+            id: id.to_string(),
+            number,
+            title: format!("PR #{number}"),
+            author: "alice".to_string(),
+            state,
+            ci_status: CiStatus::Success,
+            priority: Priority::Medium,
+            repo_id: "repo-1".to_string(),
+            url: format!("https://github.com/mpiton/prism/pull/{number}"),
+            labels: vec![],
+            additions: 10,
+            deletions: 5,
+            created_at: "2026-03-01T00:00:00Z".to_string(),
+            updated_at: updated_at.to_string(),
+        };
+        crate::cache::pull_requests::upsert_pull_request(pool, &pr)
+            .await
+            .unwrap();
+    }
+
+    /// Helper: inserts a workspace for cleanup tests (no real worktree).
+    fn sample_cleanup_workspace(
+        id: &str,
+        pr_number: u32,
+        state: WorkspaceState,
+    ) -> crate::types::Workspace {
+        crate::types::Workspace {
+            id: id.to_string(),
+            repo_id: "repo-1".to_string(),
+            pull_request_number: pr_number,
+            state,
+            worktree_path: None,
+            session_id: None,
+            created_at: "2026-03-20T10:00:00Z".to_string(),
+            updated_at: "2026-03-20T10:00:00Z".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_merged_pr() {
+        let (pool, _tmp) = test_pool().await;
+        insert_test_repo(&pool, None).await;
+        let pty_state = PtyManagerState::new();
+
+        // Merged PR with old updated_at (well past 24h delay)
+        insert_test_pr(
+            &pool,
+            "pr-1",
+            42,
+            crate::types::PrState::Merged,
+            "2026-03-01T00:00:00Z",
+        )
+        .await;
+
+        // Workspace linked to this PR
+        let ws = sample_cleanup_workspace("ws-1", 42, WorkspaceState::Active);
+        crate::cache::workspaces::create_workspace(&pool, &ws)
+            .await
+            .unwrap();
+
+        let count = workspace_cleanup_inner(&pool, &pty_state, 24, 48)
+            .await
+            .unwrap();
+        assert_eq!(count, 1, "should archive 1 workspace");
+
+        let ws = crate::cache::workspaces::get_workspace(&pool, "ws-1")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(ws.state, WorkspaceState::Archived);
+
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_closed_pr() {
+        let (pool, _tmp) = test_pool().await;
+        insert_test_repo(&pool, None).await;
+        let pty_state = PtyManagerState::new();
+
+        // Closed PR with old updated_at (well past 48h delay)
+        insert_test_pr(
+            &pool,
+            "pr-2",
+            99,
+            crate::types::PrState::Closed,
+            "2026-03-01T00:00:00Z",
+        )
+        .await;
+
+        let ws = sample_cleanup_workspace("ws-2", 99, WorkspaceState::Suspended);
+        crate::cache::workspaces::create_workspace(&pool, &ws)
+            .await
+            .unwrap();
+
+        let count = workspace_cleanup_inner(&pool, &pty_state, 24, 48)
+            .await
+            .unwrap();
+        assert_eq!(count, 1, "should archive 1 workspace for closed PR");
+
+        let ws = crate::cache::workspaces::get_workspace(&pool, "ws-2")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(ws.state, WorkspaceState::Archived);
+
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_respects_delay() {
+        let (pool, _tmp) = test_pool().await;
+        insert_test_repo(&pool, None).await;
+        let pty_state = PtyManagerState::new();
+
+        // Merged PR with very recent updated_at (within delay)
+        let recent = chrono::Utc::now().to_rfc3339();
+        insert_test_pr(&pool, "pr-3", 10, crate::types::PrState::Merged, &recent).await;
+
+        let ws = sample_cleanup_workspace("ws-3", 10, WorkspaceState::Active);
+        crate::cache::workspaces::create_workspace(&pool, &ws)
+            .await
+            .unwrap();
+
+        let count = workspace_cleanup_inner(&pool, &pty_state, 24, 48)
+            .await
+            .unwrap();
+        assert_eq!(count, 0, "should not archive workspace within delay");
+
+        let ws = crate::cache::workspaces::get_workspace(&pool, "ws-3")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            ws.state,
+            WorkspaceState::Active,
+            "workspace should remain active"
+        );
+
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_nothing_to_clean() {
+        let (pool, _tmp) = test_pool().await;
+        insert_test_repo(&pool, None).await;
+        let pty_state = PtyManagerState::new();
+
+        // Open PR — should never be cleaned up
+        insert_test_pr(
+            &pool,
+            "pr-4",
+            50,
+            crate::types::PrState::Open,
+            "2026-03-01T00:00:00Z",
+        )
+        .await;
+
+        let ws = sample_cleanup_workspace("ws-4", 50, WorkspaceState::Active);
+        crate::cache::workspaces::create_workspace(&pool, &ws)
+            .await
+            .unwrap();
+
+        let count = workspace_cleanup_inner(&pool, &pty_state, 24, 48)
+            .await
+            .unwrap();
+        assert_eq!(count, 0, "should not archive workspace for open PR");
+
+        // No workspaces at all
+        let (pool2, _tmp2) = test_pool().await;
+        let count = workspace_cleanup_inner(&pool2, &pty_state, 24, 48)
+            .await
+            .unwrap();
+        assert_eq!(count, 0, "should return 0 with no workspaces");
+
+        pool.close().await;
+        pool2.close().await;
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -178,6 +178,7 @@ pub fn run() {
             commands::workspace_suspend,
             commands::workspace_resume,
             commands::workspace_archive,
+            commands::workspace_cleanup,
             commands::pty_write,
             commands::pty_resize,
             commands::pty_kill,

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -317,6 +317,10 @@ pub struct AppConfig {
     pub poll_interval_secs: u64,
     /// Maximum number of simultaneously active workspaces (LRU eviction).
     pub max_active_workspaces: u32,
+    /// Hours after a PR is merged before its workspace is auto-archived (default 24).
+    pub archive_delay_hours: u64,
+    /// Hours after a PR is closed before its workspace is auto-archived (default 48).
+    pub archive_delay_closed_hours: u64,
     /// GitHub personal access token or OAuth token. `None` means not yet configured.
     pub github_token: Option<String>,
     /// Override for the `SQLite` data directory (`~/.local/share/prism/` by default).
@@ -330,6 +334,11 @@ impl fmt::Debug for AppConfig {
         f.debug_struct("AppConfig")
             .field("poll_interval_secs", &self.poll_interval_secs)
             .field("max_active_workspaces", &self.max_active_workspaces)
+            .field("archive_delay_hours", &self.archive_delay_hours)
+            .field(
+                "archive_delay_closed_hours",
+                &self.archive_delay_closed_hours,
+            )
             .field(
                 "github_token",
                 &self.github_token.as_ref().map(|_| "<redacted>"),
@@ -345,6 +354,8 @@ impl Default for AppConfig {
         Self {
             poll_interval_secs: 300,
             max_active_workspaces: 3,
+            archive_delay_hours: 24,
+            archive_delay_closed_hours: 48,
             github_token: None,
             data_dir: None,
             workspaces_dir: None,
@@ -388,6 +399,8 @@ where
 pub struct PartialAppConfig {
     pub poll_interval_secs: Option<u64>,
     pub max_active_workspaces: Option<u32>,
+    pub archive_delay_hours: Option<u64>,
+    pub archive_delay_closed_hours: Option<u64>,
     #[serde(deserialize_with = "deserialize_double_option", default)]
     pub github_token: Option<Option<String>>,
     #[serde(deserialize_with = "deserialize_double_option", default)]
@@ -407,6 +420,12 @@ pub fn merge_partial_config(base: &AppConfig, partial: &PartialAppConfig) -> App
         max_active_workspaces: partial
             .max_active_workspaces
             .unwrap_or(base.max_active_workspaces),
+        archive_delay_hours: partial
+            .archive_delay_hours
+            .unwrap_or(base.archive_delay_hours),
+        archive_delay_closed_hours: partial
+            .archive_delay_closed_hours
+            .unwrap_or(base.archive_delay_closed_hours),
         github_token: match &partial.github_token {
             Some(v) => v.clone(),
             None => base.github_token.clone(),
@@ -1002,6 +1021,8 @@ mod tests {
         let config = AppConfig {
             poll_interval_secs: 120,
             max_active_workspaces: 5,
+            archive_delay_hours: 12,
+            archive_delay_closed_hours: 72,
             github_token: Some("test-token".to_string()),
             data_dir: Some("/custom/data".to_string()),
             workspaces_dir: None,
@@ -1009,6 +1030,8 @@ mod tests {
         let json = serde_json::to_string(&config).unwrap();
         assert!(json.contains("\"pollIntervalSecs\""));
         assert!(json.contains("\"maxActiveWorkspaces\""));
+        assert!(json.contains("\"archiveDelayHours\""));
+        assert!(json.contains("\"archiveDelayClosedHours\""));
         assert!(json.contains("\"githubToken\""));
         assert!(json.contains("\"dataDir\""));
         assert!(json.contains("\"workspacesDir\":null"));
@@ -1021,6 +1044,8 @@ mod tests {
         let config = AppConfig::default();
         assert_eq!(config.poll_interval_secs, 300);
         assert_eq!(config.max_active_workspaces, 3);
+        assert_eq!(config.archive_delay_hours, 24);
+        assert_eq!(config.archive_delay_closed_hours, 48);
         assert!(config.github_token.is_none());
         assert!(config.data_dir.is_none());
         assert!(config.workspaces_dir.is_none());


### PR DESCRIPTION
## Summary
- Add `workspace_cleanup` Tauri command that auto-archives workspaces whose PR is merged (> `archive_delay_hours`) or closed (> `archive_delay_closed_hours`)
- Add `archive_delay_hours` (default 24) and `archive_delay_closed_hours` (default 48) config fields to `AppConfig`
- Single optimized JOIN query to find eligible workspaces, reuses `workspace_archive_inner` for archival

## Test plan
- [x] `test_cleanup_merged_pr` — archives workspace for merged PR past delay
- [x] `test_cleanup_closed_pr` — archives workspace for closed PR past delay
- [x] `test_cleanup_respects_delay` — skips workspaces within delay window
- [x] `test_cleanup_nothing_to_clean` — handles open PRs and empty DB
- [x] All 275 existing tests pass
- [x] Clippy clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `workspace_cleanup` command to auto-archive workspaces after a configurable delay when their PR is merged or closed. Emits `workspace:state_changed` for each archived workspace to keep the UI in sync; implements T‑071.

- **New Features**
  - `workspace_cleanup`: archives workspaces for merged PRs older than `archive_delay_hours` (24h default) or closed PRs older than `archive_delay_closed_hours` (48h default); returns the number archived.
  - Adds `archive_delay_hours` and `archive_delay_closed_hours` to `AppConfig`, persisted via config KV and used by `get_config`/`set_config`.
  - Single JOIN query to find eligible workspaces; reuses `workspace_archive_inner` for archival.

- **Bug Fixes**
  - Caps delay values to ~100 years to avoid `Duration` overflow and uses a safe `u32` conversion for the archived count.

<sup>Written for commit 837c864d518a9341cab96fd6f07a05ea979a0bb3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic workspace cleanup that archives workspaces when their pull requests exceed configurable age thresholds.
  * New configuration options to set archive delays for merged (default 24h) and closed (default 48h) PRs.
  * Cleanup action emits workspace state change notifications and reports the number of workspaces archived.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->