### PR TITLE
feat(workspace): create WorkspaceSwitcher component with tabs

### DIFF
--- a/src/components/Workspace/WorkspaceSwitcher.test.tsx
+++ b/src/components/Workspace/WorkspaceSwitcher.test.tsx
@@ -299,4 +299,21 @@ describe("WorkspaceSwitcher", () => {
     expect(activeTab).toHaveAttribute("tabindex", "0");
     expect(inactiveTab).toHaveAttribute("tabindex", "-1");
   });
+
+  it("should fallback first tab to tabIndex 0 when activeWorkspaceId is null", () => {
+    useWorkspacesStore.setState({ activeWorkspaceId: null });
+
+    render(
+      <WorkspaceSwitcher
+        workspaces={WORKSPACES}
+        onBackToDashboard={vi.fn()}
+      />,
+    );
+
+    const firstTab = screen.getByTestId("tab-ws-1");
+    const secondTab = screen.getByTestId("tab-ws-2");
+
+    expect(firstTab).toHaveAttribute("tabindex", "0");
+    expect(secondTab).toHaveAttribute("tabindex", "-1");
+  });
 });

--- a/src/components/Workspace/WorkspaceSwitcher.test.tsx
+++ b/src/components/Workspace/WorkspaceSwitcher.test.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { WorkspaceSwitcher } from "./WorkspaceSwitcher";
+import type { Workspace } from "../../lib/types";
+import { useWorkspacesStore } from "../../stores/workspaces";
+
+// ── Mock data ───────────────────────────────────────────────────────
+
+const WORKSPACES: readonly Workspace[] = [
+  {
+    id: "ws-1",
+    repoId: "repo-1",
+    pullRequestNumber: 42,
+    state: "active",
+    worktreePath: "/tmp/ws-1",
+    sessionId: null,
+    createdAt: "2026-03-01T00:00:00Z",
+    updatedAt: "2026-03-01T00:00:00Z",
+  },
+  {
+    id: "ws-2",
+    repoId: "repo-1",
+    pullRequestNumber: 99,
+    state: "suspended",
+    worktreePath: "/tmp/ws-2",
+    sessionId: null,
+    createdAt: "2026-03-01T00:00:00Z",
+    updatedAt: "2026-03-01T00:00:00Z",
+  },
+  {
+    id: "ws-3",
+    repoId: "repo-2",
+    pullRequestNumber: 7,
+    state: "active",
+    worktreePath: "/tmp/ws-3",
+    sessionId: null,
+    createdAt: "2026-03-01T00:00:00Z",
+    updatedAt: "2026-03-01T00:00:00Z",
+  },
+] as const;
+
+function resetStore() {
+  useWorkspacesStore.setState({
+    activeWorkspaceId: "ws-1",
+  });
+}
+
+describe("WorkspaceSwitcher", () => {
+  beforeEach(() => {
+    resetStore();
+  });
+
+  it("should render all workspace tabs", () => {
+    render(
+      <WorkspaceSwitcher
+        workspaces={WORKSPACES}
+        onBackToDashboard={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("#42")).toBeInTheDocument();
+    expect(screen.getByText("#99")).toBeInTheDocument();
+    expect(screen.getByText("#7")).toBeInTheDocument();
+  });
+
+  it("should highlight active tab", () => {
+    render(
+      <WorkspaceSwitcher
+        workspaces={WORKSPACES}
+        onBackToDashboard={vi.fn()}
+      />,
+    );
+
+    const activeTab = screen.getByTestId("tab-ws-1");
+    const inactiveTab = screen.getByTestId("tab-ws-2");
+
+    expect(activeTab.getAttribute("data-active")).toBe("true");
+    expect(inactiveTab.getAttribute("data-active")).toBe("false");
+  });
+
+  it("should switch workspace on click", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <WorkspaceSwitcher
+        workspaces={WORKSPACES}
+        onBackToDashboard={vi.fn()}
+      />,
+    );
+
+    const tab = screen.getByTestId("tab-ws-2");
+    await user.click(tab);
+
+    expect(useWorkspacesStore.getState().activeWorkspaceId).toBe("ws-2");
+  });
+
+  it("should show active count", () => {
+    render(
+      <WorkspaceSwitcher
+        workspaces={WORKSPACES}
+        onBackToDashboard={vi.fn()}
+      />,
+    );
+
+    // 2 active out of 3 max
+    expect(screen.getByText("2/3")).toBeInTheDocument();
+  });
+
+  it("should show state dot with correct color", () => {
+    render(
+      <WorkspaceSwitcher
+        workspaces={WORKSPACES}
+        onBackToDashboard={vi.fn()}
+      />,
+    );
+
+    const activeDot = screen.getByTestId("dot-ws-1");
+    const suspendedDot = screen.getByTestId("dot-ws-2");
+
+    expect(activeDot.className).toContain("bg-green");
+    expect(suspendedDot.className).toContain("bg-orange");
+  });
+
+  it("should call onBackToDashboard when back button is clicked", async () => {
+    const user = userEvent.setup();
+    const onBack = vi.fn();
+
+    render(
+      <WorkspaceSwitcher workspaces={WORKSPACES} onBackToDashboard={onBack} />,
+    );
+
+    const backBtn = screen.getByRole("button", { name: /dashboard/i });
+    await user.click(backBtn);
+
+    expect(onBack).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/Workspace/WorkspaceSwitcher.test.tsx
+++ b/src/components/Workspace/WorkspaceSwitcher.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { WorkspaceSwitcher } from "./WorkspaceSwitcher";
 import type { Workspace } from "../../lib/types";
 import { useWorkspacesStore } from "../../stores/workspaces";
+import { useSettingsStore } from "../../stores/settings";
 
 // ── Mock data ───────────────────────────────────────────────────────
 
@@ -38,17 +39,34 @@ const WORKSPACES: readonly Workspace[] = [
     createdAt: "2026-03-01T00:00:00Z",
     updatedAt: "2026-03-01T00:00:00Z",
   },
+  {
+    id: "ws-4",
+    repoId: "repo-2",
+    pullRequestNumber: 15,
+    state: "archived",
+    worktreePath: null,
+    sessionId: null,
+    createdAt: "2026-03-01T00:00:00Z",
+    updatedAt: "2026-03-01T00:00:00Z",
+  },
 ] as const;
 
-function resetStore() {
-  useWorkspacesStore.setState({
-    activeWorkspaceId: "ws-1",
+function resetStores() {
+  useWorkspacesStore.setState({ activeWorkspaceId: "ws-1" });
+  useSettingsStore.setState({
+    config: {
+      pollIntervalSecs: 300,
+      maxActiveWorkspaces: 3,
+      githubToken: null,
+      dataDir: null,
+      workspacesDir: null,
+    },
   });
 }
 
 describe("WorkspaceSwitcher", () => {
   beforeEach(() => {
-    resetStore();
+    resetStores();
   });
 
   it("should render all workspace tabs", () => {
@@ -117,9 +135,50 @@ describe("WorkspaceSwitcher", () => {
 
     const activeDot = screen.getByTestId("dot-ws-1");
     const suspendedDot = screen.getByTestId("dot-ws-2");
+    const archivedDot = screen.getByTestId("dot-ws-4");
 
     expect(activeDot.className).toContain("bg-green");
     expect(suspendedDot.className).toContain("bg-orange");
+    expect(archivedDot.className).toContain("bg-dim");
+  });
+
+  it("should use maxActiveWorkspaces from settings store", () => {
+    useSettingsStore.setState({
+      config: {
+        pollIntervalSecs: 300,
+        maxActiveWorkspaces: 5,
+        githubToken: null,
+        dataDir: null,
+        workspacesDir: null,
+      },
+    });
+
+    render(
+      <WorkspaceSwitcher
+        workspaces={WORKSPACES}
+        onBackToDashboard={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("2/5")).toBeInTheDocument();
+  });
+
+  it("should have proper ARIA tab roles", () => {
+    render(
+      <WorkspaceSwitcher
+        workspaces={WORKSPACES}
+        onBackToDashboard={vi.fn()}
+      />,
+    );
+
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs).toHaveLength(4);
+
+    const activeTab = screen.getByTestId("tab-ws-1");
+    const inactiveTab = screen.getByTestId("tab-ws-2");
+
+    expect(activeTab).toHaveAttribute("aria-selected", "true");
+    expect(inactiveTab).toHaveAttribute("aria-selected", "false");
   });
 
   it("should call onBackToDashboard when back button is clicked", async () => {

--- a/src/components/Workspace/WorkspaceSwitcher.test.tsx
+++ b/src/components/Workspace/WorkspaceSwitcher.test.tsx
@@ -194,4 +194,109 @@ describe("WorkspaceSwitcher", () => {
 
     expect(onBack).toHaveBeenCalledOnce();
   });
+
+  it("should fallback to default when maxActiveWorkspaces is invalid", () => {
+    useSettingsStore.setState({
+      config: {
+        pollIntervalSecs: 300,
+        maxActiveWorkspaces: 0,
+        githubToken: null,
+        dataDir: null,
+        workspacesDir: null,
+      },
+    });
+
+    render(
+      <WorkspaceSwitcher
+        workspaces={WORKSPACES}
+        onBackToDashboard={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("2/3")).toBeInTheDocument();
+  });
+
+  it("should navigate tabs with ArrowRight key", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <WorkspaceSwitcher
+        workspaces={WORKSPACES}
+        onBackToDashboard={vi.fn()}
+      />,
+    );
+
+    const firstTab = screen.getByTestId("tab-ws-1");
+    firstTab.focus();
+    await user.keyboard("{ArrowRight}");
+
+    expect(useWorkspacesStore.getState().activeWorkspaceId).toBe("ws-2");
+  });
+
+  it("should navigate tabs with ArrowLeft key (wrap around)", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <WorkspaceSwitcher
+        workspaces={WORKSPACES}
+        onBackToDashboard={vi.fn()}
+      />,
+    );
+
+    const firstTab = screen.getByTestId("tab-ws-1");
+    firstTab.focus();
+    await user.keyboard("{ArrowLeft}");
+
+    expect(useWorkspacesStore.getState().activeWorkspaceId).toBe("ws-4");
+  });
+
+  it("should navigate to first tab with Home key", async () => {
+    const user = userEvent.setup();
+    useWorkspacesStore.setState({ activeWorkspaceId: "ws-3" });
+
+    render(
+      <WorkspaceSwitcher
+        workspaces={WORKSPACES}
+        onBackToDashboard={vi.fn()}
+      />,
+    );
+
+    const tab = screen.getByTestId("tab-ws-3");
+    tab.focus();
+    await user.keyboard("{Home}");
+
+    expect(useWorkspacesStore.getState().activeWorkspaceId).toBe("ws-1");
+  });
+
+  it("should navigate to last tab with End key", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <WorkspaceSwitcher
+        workspaces={WORKSPACES}
+        onBackToDashboard={vi.fn()}
+      />,
+    );
+
+    const firstTab = screen.getByTestId("tab-ws-1");
+    firstTab.focus();
+    await user.keyboard("{End}");
+
+    expect(useWorkspacesStore.getState().activeWorkspaceId).toBe("ws-4");
+  });
+
+  it("should set tabIndex 0 on active tab and -1 on others", () => {
+    render(
+      <WorkspaceSwitcher
+        workspaces={WORKSPACES}
+        onBackToDashboard={vi.fn()}
+      />,
+    );
+
+    const activeTab = screen.getByTestId("tab-ws-1");
+    const inactiveTab = screen.getByTestId("tab-ws-2");
+
+    expect(activeTab).toHaveAttribute("tabindex", "0");
+    expect(inactiveTab).toHaveAttribute("tabindex", "-1");
+  });
 });

--- a/src/components/Workspace/WorkspaceSwitcher.tsx
+++ b/src/components/Workspace/WorkspaceSwitcher.tsx
@@ -32,6 +32,9 @@ export function WorkspaceSwitcher({
 
   const activeCount = workspaces.filter((w) => w.state === "active").length;
   const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const focusedId = workspaces.some((w) => w.id === activeWorkspaceId)
+    ? activeWorkspaceId
+    : workspaces[0]?.id ?? null;
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent, index: number) => {
@@ -81,7 +84,7 @@ export function WorkspaceSwitcher({
 
       <div className="flex items-center gap-1" role="tablist" aria-label="Workspaces">
         {workspaces.map((ws, i) => {
-          const isActive = ws.id === activeWorkspaceId;
+          const isActive = ws.id === focusedId;
           return (
             <button
               key={ws.id}

--- a/src/components/Workspace/WorkspaceSwitcher.tsx
+++ b/src/components/Workspace/WorkspaceSwitcher.tsx
@@ -1,18 +1,19 @@
 import { useWorkspacesStore } from "../../stores/workspaces";
-import type { Workspace } from "../../lib/types";
+import { useSettingsStore } from "../../stores/settings";
+import type { Workspace, WorkspaceState } from "../../lib/types";
 
 interface WorkspaceSwitcherProps {
   readonly workspaces: readonly Workspace[];
   readonly onBackToDashboard: () => void;
 }
 
-const MAX_ACTIVE = 3;
+const DEFAULT_MAX_ACTIVE = 3;
 
-const STATE_DOT_CLASS: Record<string, string> = {
+const STATE_DOT_CLASS = {
   active: "bg-green",
   suspended: "bg-orange",
   archived: "bg-dim",
-};
+} satisfies Record<WorkspaceState, string>;
 
 export function WorkspaceSwitcher({
   workspaces,
@@ -20,6 +21,8 @@ export function WorkspaceSwitcher({
 }: WorkspaceSwitcherProps) {
   const activeWorkspaceId = useWorkspacesStore((s) => s.activeWorkspaceId);
   const setActiveWorkspace = useWorkspacesStore((s) => s.setActiveWorkspace);
+  const maxActiveWorkspaces =
+    useSettingsStore((s) => s.config?.maxActiveWorkspaces) ?? DEFAULT_MAX_ACTIVE;
 
   const activeCount = workspaces.filter((w) => w.state === "active").length;
 
@@ -36,13 +39,15 @@ export function WorkspaceSwitcher({
         Dashboard
       </button>
 
-      <div className="flex items-center gap-1">
+      <div className="flex items-center gap-1" role="tablist" aria-label="Workspaces">
         {workspaces.map((ws) => {
           const isActive = ws.id === activeWorkspaceId;
           return (
             <button
               key={ws.id}
               type="button"
+              role="tab"
+              aria-selected={isActive}
               data-testid={`tab-${ws.id}`}
               data-active={isActive ? "true" : "false"}
               onClick={() => setActiveWorkspace(ws.id)}
@@ -54,7 +59,7 @@ export function WorkspaceSwitcher({
             >
               <span
                 data-testid={`dot-${ws.id}`}
-                className={`inline-block h-1.5 w-1.5 rounded-full ${STATE_DOT_CLASS[ws.state] ?? "bg-dim"}`}
+                className={`inline-block h-1.5 w-1.5 rounded-full ${STATE_DOT_CLASS[ws.state]}`}
               />
               #{ws.pullRequestNumber}
             </button>
@@ -63,7 +68,7 @@ export function WorkspaceSwitcher({
       </div>
 
       <span className="ml-auto text-xs text-muted">
-        {activeCount}/{MAX_ACTIVE}
+        {activeCount}/{maxActiveWorkspaces}
       </span>
     </nav>
   );

--- a/src/components/Workspace/WorkspaceSwitcher.tsx
+++ b/src/components/Workspace/WorkspaceSwitcher.tsx
@@ -1,0 +1,70 @@
+import { useWorkspacesStore } from "../../stores/workspaces";
+import type { Workspace } from "../../lib/types";
+
+interface WorkspaceSwitcherProps {
+  readonly workspaces: readonly Workspace[];
+  readonly onBackToDashboard: () => void;
+}
+
+const MAX_ACTIVE = 3;
+
+const STATE_DOT_CLASS: Record<string, string> = {
+  active: "bg-green",
+  suspended: "bg-orange",
+  archived: "bg-dim",
+};
+
+export function WorkspaceSwitcher({
+  workspaces,
+  onBackToDashboard,
+}: WorkspaceSwitcherProps) {
+  const activeWorkspaceId = useWorkspacesStore((s) => s.activeWorkspaceId);
+  const setActiveWorkspace = useWorkspacesStore((s) => s.setActiveWorkspace);
+
+  const activeCount = workspaces.filter((w) => w.state === "active").length;
+
+  return (
+    <nav
+      className="flex items-center gap-1 border-b border-border bg-surface px-2 py-1"
+      data-testid="workspace-switcher"
+    >
+      <button
+        type="button"
+        onClick={onBackToDashboard}
+        className="mr-2 rounded px-2 py-1 text-xs text-dim hover:bg-surface-hover hover:text-text"
+      >
+        Dashboard
+      </button>
+
+      <div className="flex items-center gap-1">
+        {workspaces.map((ws) => {
+          const isActive = ws.id === activeWorkspaceId;
+          return (
+            <button
+              key={ws.id}
+              type="button"
+              data-testid={`tab-${ws.id}`}
+              data-active={isActive ? "true" : "false"}
+              onClick={() => setActiveWorkspace(ws.id)}
+              className={`flex items-center gap-1.5 rounded px-2.5 py-1 text-xs transition-colors ${
+                isActive
+                  ? "bg-surface-hover text-accent"
+                  : "text-dim hover:bg-surface-hover hover:text-text"
+              }`}
+            >
+              <span
+                data-testid={`dot-${ws.id}`}
+                className={`inline-block h-1.5 w-1.5 rounded-full ${STATE_DOT_CLASS[ws.state] ?? "bg-dim"}`}
+              />
+              #{ws.pullRequestNumber}
+            </button>
+          );
+        })}
+      </div>
+
+      <span className="ml-auto text-xs text-muted">
+        {activeCount}/{MAX_ACTIVE}
+      </span>
+    </nav>
+  );
+}

--- a/src/components/Workspace/WorkspaceSwitcher.tsx
+++ b/src/components/Workspace/WorkspaceSwitcher.tsx
@@ -1,3 +1,4 @@
+import { useRef, useCallback } from "react";
 import { useWorkspacesStore } from "../../stores/workspaces";
 import { useSettingsStore } from "../../stores/settings";
 import type { Workspace, WorkspaceState } from "../../lib/types";
@@ -15,16 +16,55 @@ const STATE_DOT_CLASS = {
   archived: "bg-dim",
 } satisfies Record<WorkspaceState, string>;
 
+function sanitizeMax(value: number | undefined | null): number {
+  return Number.isFinite(value) && value! > 0 ? value! : DEFAULT_MAX_ACTIVE;
+}
+
 export function WorkspaceSwitcher({
   workspaces,
   onBackToDashboard,
 }: WorkspaceSwitcherProps) {
   const activeWorkspaceId = useWorkspacesStore((s) => s.activeWorkspaceId);
   const setActiveWorkspace = useWorkspacesStore((s) => s.setActiveWorkspace);
-  const maxActiveWorkspaces =
-    useSettingsStore((s) => s.config?.maxActiveWorkspaces) ?? DEFAULT_MAX_ACTIVE;
+  const maxActiveWorkspaces = sanitizeMax(
+    useSettingsStore((s) => s.config?.maxActiveWorkspaces),
+  );
 
   const activeCount = workspaces.filter((w) => w.state === "active").length;
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent, index: number) => {
+      const count = workspaces.length;
+      if (count === 0) return;
+
+      let next: number | null = null;
+      switch (e.key) {
+        case "ArrowRight":
+          next = (index + 1) % count;
+          break;
+        case "ArrowLeft":
+          next = (index - 1 + count) % count;
+          break;
+        case "Home":
+          next = 0;
+          break;
+        case "End":
+          next = count - 1;
+          break;
+        default:
+          return;
+      }
+
+      e.preventDefault();
+      const ws = workspaces[next];
+      if (ws) {
+        setActiveWorkspace(ws.id);
+        tabRefs.current[next]?.focus();
+      }
+    },
+    [workspaces, setActiveWorkspace],
+  );
 
   return (
     <nav
@@ -40,17 +80,20 @@ export function WorkspaceSwitcher({
       </button>
 
       <div className="flex items-center gap-1" role="tablist" aria-label="Workspaces">
-        {workspaces.map((ws) => {
+        {workspaces.map((ws, i) => {
           const isActive = ws.id === activeWorkspaceId;
           return (
             <button
               key={ws.id}
+              ref={(el) => { tabRefs.current[i] = el; }}
               type="button"
               role="tab"
               aria-selected={isActive}
+              tabIndex={isActive ? 0 : -1}
               data-testid={`tab-${ws.id}`}
               data-active={isActive ? "true" : "false"}
               onClick={() => setActiveWorkspace(ws.id)}
+              onKeyDown={(e) => handleKeyDown(e, i)}
               className={`flex items-center gap-1.5 rounded px-2.5 py-1 text-xs transition-colors ${
                 isActive
                   ? "bg-surface-hover text-accent"


### PR DESCRIPTION
## Summary

• Create WorkspaceSwitcher tab bar component for workspace navigation
• Render all workspaces with PR number, state indicator (active/suspended/archived)
• Support workspace switching via tab click with Zustand store integration
• Display active count (X/3 max workspaces) and back-to-dashboard button
• Full test coverage (6 tests: render, highlight, switch, count, colors, back button)

## Type

feat(workspace)

## Test Results

✓ 360 tests passing
✓ No regressions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an accessible WorkspaceSwitcher tab bar for PR workspaces. Supports keyboard navigation, validates the `maxActiveWorkspaces` setting, and falls back focus to the first tab when no workspace is active.

- **New Features**
  - Tabs render all workspaces with PR numbers and colored state dots; supports keyboard navigation (Arrow, Home/End).
  - Shows active count and a “Dashboard” button.

- **Bug Fixes**
  - `maxActiveWorkspaces` is read from settings and sanitized; falls back to 3 when invalid.
  - Added ARIA `tablist`/`tab` roles with `aria-selected`; roving `tabIndex` defaults to the first tab when no active workspace.
  - Typed state-to-color map for state dots.

<sup>Written for commit 311b82df5024319c89685883d671188c65597f9a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace switcher: tabbed navigation to select workspaces, back-to-dashboard button, visual state indicators, and an active/count display with a safe fallback when the configured max is invalid.

* **Accessibility**
  * ARIA tab semantics, keyboard navigation (ArrowLeft/ArrowRight wrap, Home/End), and correct focus/tabindex behavior.

* **Tests**
  * Unit tests covering rendering, state indicators, counter fallback, selection changes, keyboard navigation, and back-button action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->