### PR TITLE
feat(workspace): create WorkspaceStatusBar component with PTY actions (T-074)

### DIFF
--- a/src/components/Workspace/WorkspaceStatusBar.test.tsx
+++ b/src/components/Workspace/WorkspaceStatusBar.test.tsx
@@ -144,11 +144,19 @@ describe("WorkspaceStatusBar", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("should disable buttons when workspace is not active", () => {
+  it("should disable buttons and github link when workspace is not active", () => {
     render(<WorkspaceStatusBar {...defaultProps} disabled />);
 
     expect(screen.getByTestId("btn-git-push")).toBeDisabled();
     expect(screen.getByTestId("btn-git-pull")).toBeDisabled();
+    expect(screen.getByTestId("btn-open-github")).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+    expect(screen.getByTestId("btn-open-github")).toHaveAttribute(
+      "tabindex",
+      "-1",
+    );
   });
 
   it("should not write to pty when disabled", async () => {

--- a/src/components/Workspace/WorkspaceStatusBar.test.tsx
+++ b/src/components/Workspace/WorkspaceStatusBar.test.tsx
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { WorkspaceStatusBar } from "./WorkspaceStatusBar";
+
+vi.mock("../../lib/tauri", () => ({
+  ptyWrite: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { ptyWrite } from "../../lib/tauri";
+import type { CiStatus } from "../../lib/types";
+
+const defaultProps = {
+  workspaceId: "ws-1",
+  branch: "feat/my-feature",
+  ahead: 2,
+  behind: 1,
+  ciStatus: "success" as CiStatus,
+  sessionName: "prism-pr-42",
+  sessionCount: 3,
+  githubUrl: "https://github.com/owner/repo/pull/42",
+};
+
+describe("WorkspaceStatusBar", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should show branch name", () => {
+    render(<WorkspaceStatusBar {...defaultProps} />);
+
+    expect(screen.getByTestId("status-branch")).toHaveTextContent(
+      "feat/my-feature",
+    );
+  });
+
+  it("should show ahead/behind counts", () => {
+    render(<WorkspaceStatusBar {...defaultProps} />);
+
+    expect(screen.getByTestId("status-ahead")).toHaveTextContent("↑2");
+    expect(screen.getByTestId("status-behind")).toHaveTextContent("↓1");
+  });
+
+  it("should hide ahead/behind when both are zero", () => {
+    render(
+      <WorkspaceStatusBar {...defaultProps} ahead={0} behind={0} />,
+    );
+
+    expect(screen.queryByTestId("status-ahead")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("status-behind")).not.toBeInTheDocument();
+  });
+
+  it("should show CI status", () => {
+    render(<WorkspaceStatusBar {...defaultProps} />);
+
+    expect(screen.getByTestId("status-ci")).toBeInTheDocument();
+  });
+
+  it("should show session name", () => {
+    render(<WorkspaceStatusBar {...defaultProps} />);
+
+    expect(screen.getByTestId("status-session")).toHaveTextContent(
+      "prism-pr-42",
+    );
+  });
+
+  it("should show session count", () => {
+    render(<WorkspaceStatusBar {...defaultProps} />);
+
+    expect(screen.getByTestId("status-session-count")).toHaveTextContent("3");
+  });
+
+  it("should write git push to pty on button click", async () => {
+    const user = userEvent.setup();
+    render(<WorkspaceStatusBar {...defaultProps} />);
+
+    await user.click(screen.getByTestId("btn-git-push"));
+
+    expect(ptyWrite).toHaveBeenCalledWith({
+      workspaceId: "ws-1",
+      data: "git push\n",
+    });
+  });
+
+  it("should write git pull to pty on button click", async () => {
+    const user = userEvent.setup();
+    render(<WorkspaceStatusBar {...defaultProps} />);
+
+    await user.click(screen.getByTestId("btn-git-pull"));
+
+    expect(ptyWrite).toHaveBeenCalledWith({
+      workspaceId: "ws-1",
+      data: "git pull\n",
+    });
+  });
+
+  it("should render open in github link with safe attributes", () => {
+    render(<WorkspaceStatusBar {...defaultProps} />);
+
+    const link = screen.getByTestId("btn-open-github");
+    expect(link).toHaveAttribute("href", defaultProps.githubUrl);
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("should sanitize non-https github URLs", () => {
+    render(
+      <WorkspaceStatusBar
+        {...defaultProps}
+        githubUrl="javascript:alert(1)"
+      />,
+    );
+
+    const link = screen.getByTestId("btn-open-github");
+    expect(link).toHaveAttribute("href", "#");
+  });
+
+  it("should show only ahead when behind is zero", () => {
+    render(<WorkspaceStatusBar {...defaultProps} ahead={3} behind={0} />);
+
+    expect(screen.getByTestId("status-ahead")).toHaveTextContent("↑3");
+    expect(screen.queryByTestId("status-behind")).not.toBeInTheDocument();
+  });
+
+  it("should show only behind when ahead is zero", () => {
+    render(<WorkspaceStatusBar {...defaultProps} ahead={0} behind={4} />);
+
+    expect(screen.queryByTestId("status-ahead")).not.toBeInTheDocument();
+    expect(screen.getByTestId("status-behind")).toHaveTextContent("↓4");
+  });
+
+  it("should handle missing session gracefully", () => {
+    render(
+      <WorkspaceStatusBar
+        {...defaultProps}
+        sessionName={null}
+        sessionCount={5}
+      />,
+    );
+
+    expect(screen.queryByTestId("status-session")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("status-session-count"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should disable buttons when workspace is not active", () => {
+    render(<WorkspaceStatusBar {...defaultProps} disabled />);
+
+    expect(screen.getByTestId("btn-git-push")).toBeDisabled();
+    expect(screen.getByTestId("btn-git-pull")).toBeDisabled();
+  });
+
+  it("should not write to pty when disabled", async () => {
+    const user = userEvent.setup();
+    render(<WorkspaceStatusBar {...defaultProps} disabled />);
+
+    await user.click(screen.getByTestId("btn-git-push"));
+
+    expect(ptyWrite).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/Workspace/WorkspaceStatusBar.tsx
+++ b/src/components/Workspace/WorkspaceStatusBar.tsx
@@ -31,84 +31,87 @@ export function WorkspaceStatusBar({
 
   function handlePtyCommand(command: string): void {
     if (disabled) return;
-    ptyWrite({ workspaceId, data: `${command}\n` }).catch(() => {});
+    ptyWrite({ workspaceId, data: `${command}\n` }).catch((err: unknown) => {
+      console.error("[WorkspaceStatusBar] ptyWrite failed:", err);
+    });
   }
 
   return (
     <div
       data-testid="workspace-statusbar"
-      role="status"
-      aria-label="Workspace status"
       className="flex items-center gap-3 border-t border-border bg-surface px-3 py-1.5 text-xs"
     >
-      {/* Branch */}
-      <span data-testid="status-branch" className="font-mono text-accent">
-        {branch}
-      </span>
-
-      {/* Ahead / Behind */}
-      {hasSync && (
-        <span className="flex gap-1 font-mono text-dim">
-          {ahead > 0 && <span data-testid="status-ahead">↑{ahead}</span>}
-          {behind > 0 && <span data-testid="status-behind">↓{behind}</span>}
+      {/* Informational live region */}
+      <span role="status" aria-label="Workspace status" className="contents">
+        <span data-testid="status-branch" className="font-mono text-accent">
+          {branch}
         </span>
-      )}
 
-      {/* CI Status */}
-      <span data-testid="status-ci">
-        <CI status={ciStatus} />
+        {hasSync && (
+          <span className="flex gap-1 font-mono text-dim">
+            {ahead > 0 && <span data-testid="status-ahead">↑{ahead}</span>}
+            {behind > 0 && <span data-testid="status-behind">↓{behind}</span>}
+          </span>
+        )}
+
+        <span data-testid="status-ci">
+          <CI status={ciStatus} />
+        </span>
+
+        {sessionName !== null && (
+          <>
+            <span data-testid="status-session" className="text-purple">
+              {sessionName}
+            </span>
+            <span
+              data-testid="status-session-count"
+              className="text-dim"
+              aria-label={`${sessionCount} sessions`}
+            >
+              {sessionCount}
+            </span>
+          </>
+        )}
       </span>
 
-      {/* Session info */}
-      {sessionName !== null && (
-        <>
-          <span data-testid="status-session" className="text-purple">
-            {sessionName}
-          </span>
-          <span
-            data-testid="status-session-count"
-            className="text-dim"
-            aria-label={`${sessionCount} sessions`}
-          >
-            {sessionCount}
-          </span>
-        </>
-      )}
-
-      {/* Spacer */}
       <span className="flex-1" />
 
-      {/* Quick action buttons */}
-      <button
-        data-testid="btn-git-push"
-        type="button"
-        aria-label="Git push"
-        disabled={disabled}
-        className="rounded px-2 py-0.5 text-muted hover:bg-surface-hover hover:text-text disabled:cursor-not-allowed disabled:opacity-40"
-        onClick={() => handlePtyCommand("git push")}
-      >
-        push
-      </button>
-      <button
-        data-testid="btn-git-pull"
-        type="button"
-        aria-label="Git pull"
-        disabled={disabled}
-        className="rounded px-2 py-0.5 text-muted hover:bg-surface-hover hover:text-text disabled:cursor-not-allowed disabled:opacity-40"
-        onClick={() => handlePtyCommand("git pull")}
-      >
-        pull
-      </button>
-      <a
-        data-testid="btn-open-github"
-        href={safeGithubUrl}
-        target="_blank"
-        rel="noopener noreferrer"
-        aria-label="Open pull request on GitHub"
-        className={`rounded px-2 py-0.5 text-muted hover:bg-surface-hover hover:text-text ${disabled ? "pointer-events-none opacity-40" : ""}`}
-      >
-        github
-      </a>
+      {/* Action buttons */}
+      <div role="toolbar" aria-label="Workspace actions" className="flex gap-1">
+        <button
+          data-testid="btn-git-push"
+          type="button"
+          aria-label="Git push"
+          disabled={disabled}
+          className="rounded px-2 py-0.5 text-muted hover:bg-surface-hover hover:text-text disabled:cursor-not-allowed disabled:opacity-40"
+          onClick={() => handlePtyCommand("git push")}
+        >
+          push
+        </button>
+        <button
+          data-testid="btn-git-pull"
+          type="button"
+          aria-label="Git pull"
+          disabled={disabled}
+          className="rounded px-2 py-0.5 text-muted hover:bg-surface-hover hover:text-text disabled:cursor-not-allowed disabled:opacity-40"
+          onClick={() => handlePtyCommand("git pull")}
+        >
+          pull
+        </button>
+        <a
+          data-testid="btn-open-github"
+          href={safeGithubUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Open pull request on GitHub"
+          aria-disabled={disabled || undefined}
+          tabIndex={disabled ? -1 : undefined}
+          onClick={disabled ? (e) => e.preventDefault() : undefined}
+          className={`rounded px-2 py-0.5 text-muted hover:bg-surface-hover hover:text-text ${disabled ? "pointer-events-none opacity-40" : ""}`}
+        >
+          github
+        </a>
+      </div>
     </div>
   );
 }

--- a/src/components/Workspace/WorkspaceStatusBar.tsx
+++ b/src/components/Workspace/WorkspaceStatusBar.tsx
@@ -1,0 +1,114 @@
+import type { ReactElement } from "react";
+import type { CiStatus } from "../../lib/types";
+import { ptyWrite } from "../../lib/tauri";
+import { CI } from "../atoms/CI";
+
+interface WorkspaceStatusBarProps {
+  readonly workspaceId: string;
+  readonly branch: string;
+  readonly ahead: number;
+  readonly behind: number;
+  readonly ciStatus: CiStatus;
+  readonly sessionName: string | null;
+  readonly sessionCount: number;
+  readonly githubUrl: string;
+  readonly disabled?: boolean;
+}
+
+export function WorkspaceStatusBar({
+  workspaceId,
+  branch,
+  ahead,
+  behind,
+  ciStatus,
+  sessionName,
+  sessionCount,
+  githubUrl,
+  disabled = false,
+}: WorkspaceStatusBarProps): ReactElement {
+  const hasSync = ahead > 0 || behind > 0;
+  const safeGithubUrl = githubUrl.startsWith("https://") ? githubUrl : "#";
+
+  function handlePtyCommand(command: string): void {
+    if (disabled) return;
+    ptyWrite({ workspaceId, data: `${command}\n` }).catch(() => {});
+  }
+
+  return (
+    <div
+      data-testid="workspace-statusbar"
+      role="status"
+      aria-label="Workspace status"
+      className="flex items-center gap-3 border-t border-border bg-surface px-3 py-1.5 text-xs"
+    >
+      {/* Branch */}
+      <span data-testid="status-branch" className="font-mono text-accent">
+        {branch}
+      </span>
+
+      {/* Ahead / Behind */}
+      {hasSync && (
+        <span className="flex gap-1 font-mono text-dim">
+          {ahead > 0 && <span data-testid="status-ahead">↑{ahead}</span>}
+          {behind > 0 && <span data-testid="status-behind">↓{behind}</span>}
+        </span>
+      )}
+
+      {/* CI Status */}
+      <span data-testid="status-ci">
+        <CI status={ciStatus} />
+      </span>
+
+      {/* Session info */}
+      {sessionName !== null && (
+        <>
+          <span data-testid="status-session" className="text-purple">
+            {sessionName}
+          </span>
+          <span
+            data-testid="status-session-count"
+            className="text-dim"
+            aria-label={`${sessionCount} sessions`}
+          >
+            {sessionCount}
+          </span>
+        </>
+      )}
+
+      {/* Spacer */}
+      <span className="flex-1" />
+
+      {/* Quick action buttons */}
+      <button
+        data-testid="btn-git-push"
+        type="button"
+        aria-label="Git push"
+        disabled={disabled}
+        className="rounded px-2 py-0.5 text-muted hover:bg-surface-hover hover:text-text disabled:cursor-not-allowed disabled:opacity-40"
+        onClick={() => handlePtyCommand("git push")}
+      >
+        push
+      </button>
+      <button
+        data-testid="btn-git-pull"
+        type="button"
+        aria-label="Git pull"
+        disabled={disabled}
+        className="rounded px-2 py-0.5 text-muted hover:bg-surface-hover hover:text-text disabled:cursor-not-allowed disabled:opacity-40"
+        onClick={() => handlePtyCommand("git pull")}
+      >
+        pull
+      </button>
+      <a
+        data-testid="btn-open-github"
+        href={safeGithubUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Open pull request on GitHub"
+        className={`rounded px-2 py-0.5 text-muted hover:bg-surface-hover hover:text-text ${disabled ? "pointer-events-none opacity-40" : ""}`}
+      >
+        github
+      </a>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Implement `WorkspaceStatusBar` component for the workspace terminal view. Displays workspace metadata and provides quick action buttons for git operations.

## Changes

• New component `WorkspaceStatusBar.tsx` — renders branch, ahead/behind counts, CI status, session info
• 15 comprehensive tests in `WorkspaceStatusBar.test.tsx` — branch display, sync indicators, PTY write, URL sanitization, accessibility
• Accessible markup with ARIA labels, role="status", aria-disabled handling
• Quick action buttons: git push, git pull, open on GitHub
• PTY integration via `ptyWrite` for git commands
• URL sanitization for GitHub links (prevents javascript: XSS)
• Tailwind styling with proper disabled states

## Test Coverage

- Branch display
- Ahead/behind visibility (shows both, one, or none)
- CI status integration
- Session info display
- PTY command execution
- Button disabled state handling
- URL sanitization
- Accessibility attributes (aria-label, role, etc.)

All 384 tests pass. Oxlint clean.

## Depends On

T-050 ✅ (atom components)
T-073 ✅ (WorkspaceSwitcher)

## Acceptance Criteria

✅ Branch name displayed
✅ CI status shown
✅ Session name and count displayed
✅ Buttons execute git commands via PTY
✅ GitHub link opens in new tab
✅ Workspace disabled state prevents button interactions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `WorkspaceStatusBar` to the workspace terminal that shows repo/session status and offers one-click git actions via PTY. Implements T-074.

- **New Features**
  - `WorkspaceStatusBar.tsx`: shows branch, ahead/behind, CI status, and session info.
  - Git actions: push/pull via `ptyWrite`; disabled state blocks interactions.
  - Safe GitHub link: https-only, `target="_blank"` with `rel="noopener noreferrer"`.
  - Tests cover display states, PTY commands, sanitization, and accessibility.

- **Bug Fixes**
  - Keyboard a11y: disabled GitHub link is unfocusable and prevented from click.
  - Scoped ARIA roles: live `role="status"` and `role="toolbar"` for actions.
  - PTY errors now logged on command failure.

<sup>Written for commit 4d59c1feb2cb3522323e194913bdb5ba2eee876a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added WorkspaceStatusBar: shows branch, ahead/behind indicators, CI status, session name/count, push/pull actions, GitHub link (only https allowed), disabled-state handling, and accessibility enhancements.

* **Tests**
  * Added comprehensive test suite validating rendering, push/pull command behavior, link safety, disabled interactions, and accessibility attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->