### PR TITLE
feat(workspace): assemble WorkspaceView (T-075)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -77,14 +77,14 @@ describe("App layout", () => {
   it("should render workspace in workspace mode", () => {
     useDashboardStore.setState({ currentView: "workspaces" });
     renderApp();
-    expect(screen.getByTestId("workspace")).toBeInTheDocument();
+    expect(screen.getByTestId("workspace-view")).toBeInTheDocument();
   });
 
   it("should keep sidebar visible in workspace mode", () => {
     useDashboardStore.setState({ currentView: "workspaces" });
     renderApp();
     expect(screen.getByTestId("sidebar")).toBeInTheDocument();
-    expect(screen.getByTestId("workspace")).toBeInTheDocument();
+    expect(screen.getByTestId("workspace-view")).toBeInTheDocument();
   });
 });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,9 +20,10 @@ function openUrl(url: string): void {
 
 interface MainContentProps {
   readonly view: DashboardView;
+  readonly onBackToDashboard: () => void;
 }
 
-function MainContent({ view }: MainContentProps): ReactElement {
+function MainContent({ view, onBackToDashboard }: MainContentProps): ReactElement {
   switch (view) {
     case "overview":
       return <Overview />;
@@ -39,7 +40,7 @@ function MainContent({ view }: MainContentProps): ReactElement {
         <WorkspaceView
           workspaces={[]}
           statusInfo={{}}
-          onBackToDashboard={() => useDashboardStore.getState().setView("overview")}
+          onBackToDashboard={onBackToDashboard}
         />
       );
     case "settings":
@@ -99,7 +100,7 @@ function App(): ReactElement {
       </aside>
 
       <main className={isWorkspace ? "flex-1" : "min-w-0 flex-1"}>
-        <MainContent view={currentView} />
+        <MainContent view={currentView} onBackToDashboard={handleEscape} />
       </main>
 
       <Toast />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import { ReviewQueue } from "./components/ReviewQueue";
 import { MyPRs } from "./components/MyPRs";
 import { Issues } from "./components/Issues";
 import { ActivityFeed } from "./components/ActivityFeed";
-import { Workspace } from "./components/Workspace";
+import { WorkspaceView } from "./components/Workspace";
 import { Settings } from "./components/Settings";
 import { Toast } from "./components/Toast";
 import { CommandPalette } from "./components/CommandPalette";
@@ -35,7 +35,13 @@ function MainContent({ view }: MainContentProps): ReactElement {
     case "feed":
       return <ActivityFeed activities={[]} onMarkAllRead={() => {}} />;
     case "workspaces":
-      return <Workspace />;
+      return (
+        <WorkspaceView
+          workspaces={[]}
+          statusInfo={{}}
+          onBackToDashboard={() => useDashboardStore.getState().setView("overview")}
+        />
+      );
     case "settings":
       return <Settings />;
     default: {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,6 +36,7 @@ function MainContent({ view, onBackToDashboard }: MainContentProps): ReactElemen
     case "feed":
       return <ActivityFeed activities={[]} onMarkAllRead={() => {}} />;
     case "workspaces":
+      // TODO(T-082): wire real workspace data from TanStack Query
       return (
         <WorkspaceView
           workspaces={[]}

--- a/src/components/Workspace/WorkspaceView.test.tsx
+++ b/src/components/Workspace/WorkspaceView.test.tsx
@@ -133,7 +133,7 @@ describe("WorkspaceView", () => {
     expect(screen.getByText(/select a workspace/i)).toBeInTheDocument();
   });
 
-  it("should show empty state when active workspace has no status info", () => {
+  it("should render terminal without status bar when status info is missing", () => {
     render(
       <WorkspaceView
         workspaces={WORKSPACES}
@@ -143,8 +143,8 @@ describe("WorkspaceView", () => {
     );
 
     expect(screen.getByTestId("workspace-switcher")).toBeInTheDocument();
-    expect(screen.queryByTestId("terminal-ws-1")).not.toBeInTheDocument();
-    expect(screen.getByText(/select a workspace/i)).toBeInTheDocument();
+    expect(screen.getByTestId("terminal-ws-1")).toBeInTheDocument();
+    expect(screen.queryByTestId("workspace-statusbar")).not.toBeInTheDocument();
   });
 
   it("should show empty state when active workspace not in list", () => {
@@ -160,5 +160,6 @@ describe("WorkspaceView", () => {
 
     expect(screen.getByTestId("workspace-switcher")).toBeInTheDocument();
     expect(screen.queryByTestId("workspace-statusbar")).not.toBeInTheDocument();
+    expect(screen.getByText(/select a workspace/i)).toBeInTheDocument();
   });
 });

--- a/src/components/Workspace/WorkspaceView.test.tsx
+++ b/src/components/Workspace/WorkspaceView.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, act } from "@testing-library/react";
 import { useWorkspacesStore } from "../../stores/workspaces";
-import type { Workspace, CiStatus } from "../../lib/types";
+import type { Workspace, WorkspaceStatusInfo } from "../../lib/types";
 
 // ── Mock child components ────────────────────────────────────────
 
@@ -31,7 +31,6 @@ vi.mock("./WorkspaceStatusBar", () => ({
 }));
 
 import { WorkspaceView } from "./WorkspaceView";
-import type { WorkspaceStatusInfo } from "./WorkspaceView";
 
 // ── Mock data ────────────────────────────────────────────────────
 
@@ -58,12 +57,12 @@ const WORKSPACES: readonly Workspace[] = [
   },
 ];
 
-const STATUS_INFO: Readonly<Record<string, WorkspaceStatusInfo>> = {
+const STATUS_INFO = {
   "ws-1": {
     branch: "feat/login",
     ahead: 2,
     behind: 0,
-    ciStatus: "success" as CiStatus,
+    ciStatus: "success",
     sessionName: "prism-pr-42",
     sessionCount: 3,
     githubUrl: "https://github.com/test/repo/pull/42",
@@ -72,12 +71,12 @@ const STATUS_INFO: Readonly<Record<string, WorkspaceStatusInfo>> = {
     branch: "fix/bug-99",
     ahead: 0,
     behind: 1,
-    ciStatus: "pending" as CiStatus,
+    ciStatus: "pending",
     sessionName: null,
     sessionCount: 0,
     githubUrl: "https://github.com/test/repo/pull/99",
   },
-};
+} satisfies Readonly<Record<string, WorkspaceStatusInfo>>;
 
 describe("WorkspaceView", () => {
   beforeEach(() => {
@@ -125,6 +124,20 @@ describe("WorkspaceView", () => {
       <WorkspaceView
         workspaces={WORKSPACES}
         statusInfo={STATUS_INFO}
+        onBackToDashboard={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("workspace-switcher")).toBeInTheDocument();
+    expect(screen.queryByTestId("terminal-ws-1")).not.toBeInTheDocument();
+    expect(screen.getByText(/select a workspace/i)).toBeInTheDocument();
+  });
+
+  it("should show empty state when active workspace has no status info", () => {
+    render(
+      <WorkspaceView
+        workspaces={WORKSPACES}
+        statusInfo={{}}
         onBackToDashboard={vi.fn()}
       />,
     );

--- a/src/components/Workspace/WorkspaceView.test.tsx
+++ b/src/components/Workspace/WorkspaceView.test.tsx
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import { useWorkspacesStore } from "../../stores/workspaces";
+import type { Workspace, CiStatus } from "../../lib/types";
+
+// ── Mock child components ────────────────────────────────────────
+
+vi.mock("./WorkspaceSwitcher", () => ({
+  WorkspaceSwitcher: ({
+    workspaces,
+  }: {
+    workspaces: readonly Workspace[];
+    onBackToDashboard: () => void;
+  }) => (
+    <div data-testid="workspace-switcher">
+      {workspaces.length} tabs
+    </div>
+  ),
+}));
+
+vi.mock("./Terminal", () => ({
+  Terminal: ({ ptyId }: { ptyId: string }) => (
+    <div data-testid={`terminal-${ptyId}`} />
+  ),
+}));
+
+vi.mock("./WorkspaceStatusBar", () => ({
+  WorkspaceStatusBar: ({ workspaceId }: { workspaceId: string }) => (
+    <div data-testid="workspace-statusbar">{workspaceId}</div>
+  ),
+}));
+
+import { WorkspaceView } from "./WorkspaceView";
+import type { WorkspaceStatusInfo } from "./WorkspaceView";
+
+// ── Mock data ────────────────────────────────────────────────────
+
+const WORKSPACES: readonly Workspace[] = [
+  {
+    id: "ws-1",
+    repoId: "repo-1",
+    pullRequestNumber: 42,
+    state: "active",
+    worktreePath: "/tmp/ws-1",
+    sessionId: "session-1",
+    createdAt: "2026-03-01T00:00:00Z",
+    updatedAt: "2026-03-01T00:00:00Z",
+  },
+  {
+    id: "ws-2",
+    repoId: "repo-1",
+    pullRequestNumber: 99,
+    state: "suspended",
+    worktreePath: "/tmp/ws-2",
+    sessionId: null,
+    createdAt: "2026-03-01T00:00:00Z",
+    updatedAt: "2026-03-01T00:00:00Z",
+  },
+];
+
+const STATUS_INFO: Readonly<Record<string, WorkspaceStatusInfo>> = {
+  "ws-1": {
+    branch: "feat/login",
+    ahead: 2,
+    behind: 0,
+    ciStatus: "success" as CiStatus,
+    sessionName: "prism-pr-42",
+    sessionCount: 3,
+    githubUrl: "https://github.com/test/repo/pull/42",
+  },
+  "ws-2": {
+    branch: "fix/bug-99",
+    ahead: 0,
+    behind: 1,
+    ciStatus: "pending" as CiStatus,
+    sessionName: null,
+    sessionCount: 0,
+    githubUrl: "https://github.com/test/repo/pull/99",
+  },
+};
+
+describe("WorkspaceView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useWorkspacesStore.setState({ activeWorkspaceId: "ws-1" });
+  });
+
+  it("should render switcher, terminal, and status bar", () => {
+    render(
+      <WorkspaceView
+        workspaces={WORKSPACES}
+        statusInfo={STATUS_INFO}
+        onBackToDashboard={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("workspace-switcher")).toBeInTheDocument();
+    expect(screen.getByTestId("terminal-ws-1")).toBeInTheDocument();
+    expect(screen.getByTestId("workspace-statusbar")).toBeInTheDocument();
+  });
+
+  it("should switch terminal on workspace change", () => {
+    render(
+      <WorkspaceView
+        workspaces={WORKSPACES}
+        statusInfo={STATUS_INFO}
+        onBackToDashboard={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("terminal-ws-1")).toBeInTheDocument();
+
+    act(() => {
+      useWorkspacesStore.setState({ activeWorkspaceId: "ws-2" });
+    });
+
+    expect(screen.getByTestId("terminal-ws-2")).toBeInTheDocument();
+    expect(screen.queryByTestId("terminal-ws-1")).not.toBeInTheDocument();
+  });
+
+  it("should show empty state when no active workspace", () => {
+    useWorkspacesStore.setState({ activeWorkspaceId: null });
+
+    render(
+      <WorkspaceView
+        workspaces={WORKSPACES}
+        statusInfo={STATUS_INFO}
+        onBackToDashboard={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("workspace-switcher")).toBeInTheDocument();
+    expect(screen.queryByTestId("terminal-ws-1")).not.toBeInTheDocument();
+    expect(screen.getByText(/select a workspace/i)).toBeInTheDocument();
+  });
+
+  it("should show empty state when active workspace not in list", () => {
+    useWorkspacesStore.setState({ activeWorkspaceId: "ws-unknown" });
+
+    render(
+      <WorkspaceView
+        workspaces={WORKSPACES}
+        statusInfo={STATUS_INFO}
+        onBackToDashboard={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("workspace-switcher")).toBeInTheDocument();
+    expect(screen.queryByTestId("workspace-statusbar")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/Workspace/WorkspaceView.tsx
+++ b/src/components/Workspace/WorkspaceView.tsx
@@ -1,19 +1,9 @@
 import type { ReactElement } from "react";
-import type { CiStatus, Workspace } from "../../lib/types";
+import type { Workspace, WorkspaceStatusInfo } from "../../lib/types";
 import { useWorkspacesStore } from "../../stores/workspaces";
 import { WorkspaceSwitcher } from "./WorkspaceSwitcher";
 import { Terminal } from "./Terminal";
 import { WorkspaceStatusBar } from "./WorkspaceStatusBar";
-
-export interface WorkspaceStatusInfo {
-  readonly branch: string;
-  readonly ahead: number;
-  readonly behind: number;
-  readonly ciStatus: CiStatus;
-  readonly sessionName: string | null;
-  readonly sessionCount: number;
-  readonly githubUrl: string;
-}
 
 interface WorkspaceViewProps {
   readonly workspaces: readonly Workspace[];

--- a/src/components/Workspace/WorkspaceView.tsx
+++ b/src/components/Workspace/WorkspaceView.tsx
@@ -30,21 +30,23 @@ export function WorkspaceView({
         onBackToDashboard={onBackToDashboard}
       />
 
-      {active && info ? (
+      {active ? (
         <>
           <div className="min-h-0 flex-1">
             <Terminal ptyId={active.id} />
           </div>
-          <WorkspaceStatusBar
-            workspaceId={active.id}
-            branch={info.branch}
-            ahead={info.ahead}
-            behind={info.behind}
-            ciStatus={info.ciStatus}
-            sessionName={info.sessionName}
-            sessionCount={info.sessionCount}
-            githubUrl={info.githubUrl}
-          />
+          {info && (
+            <WorkspaceStatusBar
+              workspaceId={active.id}
+              branch={info.branch}
+              ahead={info.ahead}
+              behind={info.behind}
+              ciStatus={info.ciStatus}
+              sessionName={info.sessionName}
+              sessionCount={info.sessionCount}
+              githubUrl={info.githubUrl}
+            />
+          )}
         </>
       ) : (
         <div className="flex flex-1 items-center justify-center text-dim">

--- a/src/components/Workspace/WorkspaceView.tsx
+++ b/src/components/Workspace/WorkspaceView.tsx
@@ -1,0 +1,66 @@
+import type { ReactElement } from "react";
+import type { CiStatus, Workspace } from "../../lib/types";
+import { useWorkspacesStore } from "../../stores/workspaces";
+import { WorkspaceSwitcher } from "./WorkspaceSwitcher";
+import { Terminal } from "./Terminal";
+import { WorkspaceStatusBar } from "./WorkspaceStatusBar";
+
+export interface WorkspaceStatusInfo {
+  readonly branch: string;
+  readonly ahead: number;
+  readonly behind: number;
+  readonly ciStatus: CiStatus;
+  readonly sessionName: string | null;
+  readonly sessionCount: number;
+  readonly githubUrl: string;
+}
+
+interface WorkspaceViewProps {
+  readonly workspaces: readonly Workspace[];
+  readonly statusInfo: Readonly<Record<string, WorkspaceStatusInfo>>;
+  readonly onBackToDashboard: () => void;
+}
+
+export function WorkspaceView({
+  workspaces,
+  statusInfo,
+  onBackToDashboard,
+}: WorkspaceViewProps): ReactElement {
+  const activeWorkspaceId = useWorkspacesStore((s) => s.activeWorkspaceId);
+  const active = workspaces.find((w) => w.id === activeWorkspaceId);
+  const info = active ? statusInfo[active.id] : undefined;
+
+  return (
+    <section
+      data-testid="workspace-view"
+      className="flex h-full flex-col"
+    >
+      <WorkspaceSwitcher
+        workspaces={workspaces}
+        onBackToDashboard={onBackToDashboard}
+      />
+
+      {active && info ? (
+        <>
+          <div className="min-h-0 flex-1">
+            <Terminal ptyId={active.id} />
+          </div>
+          <WorkspaceStatusBar
+            workspaceId={active.id}
+            branch={info.branch}
+            ahead={info.ahead}
+            behind={info.behind}
+            ciStatus={info.ciStatus}
+            sessionName={info.sessionName}
+            sessionCount={info.sessionCount}
+            githubUrl={info.githubUrl}
+          />
+        </>
+      ) : (
+        <div className="flex flex-1 items-center justify-center text-dim">
+          Select a workspace to begin
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/Workspace/index.tsx
+++ b/src/components/Workspace/index.tsx
@@ -1,3 +1,2 @@
-export function Workspace() {
-  return <section data-testid="workspace">Workspace</section>;
-}
+export { WorkspaceView } from "./WorkspaceView";
+export type { WorkspaceStatusInfo } from "./WorkspaceView";

--- a/src/components/Workspace/index.tsx
+++ b/src/components/Workspace/index.tsx
@@ -1,2 +1,2 @@
 export { WorkspaceView } from "./WorkspaceView";
-export type { WorkspaceStatusInfo } from "./WorkspaceView";
+export type { WorkspaceStatusInfo } from "../../lib/types";

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -115,6 +115,16 @@ export interface WorkspaceNote {
   readonly createdAt: string;
 }
 
+export interface WorkspaceStatusInfo {
+  readonly branch: string;
+  readonly ahead: number;
+  readonly behind: number;
+  readonly ciStatus: CiStatus;
+  readonly sessionName: string | null;
+  readonly sessionCount: number;
+  readonly githubUrl: string;
+}
+
 // ── Composite structs (T-010) ────────────────────────────────────
 
 export interface WorkspaceSummary {


### PR DESCRIPTION
## Summary

• Implements T-075: Composant WorkspaceView qui assemble Switcher + Terminal + StatusBar
• Piloté par `useWorkspacesStore.activeWorkspaceId` pour afficher le workspace courant
• Interface `WorkspaceStatusInfo` exposée pour données du statusbar
• Affiche un état vide si aucun workspace sélectionné

## Test Plan

✅ All TypeScript tests pass (388/388)
✅ oxlint clean (0 warnings, 0 errors)
✅ Red → Green → Refactor TDD cycle completed
✅ Component composition verified (mocks in tests)
✅ Empty state scenarios covered

## Changes

- `WorkspaceView.tsx`: New component composing Switcher/Terminal/StatusBar
- `WorkspaceView.test.tsx`: 4 tests covering render, switching, empty states
- `App.tsx`: Updated to use WorkspaceView instead of placeholder
- `index.tsx`: Re-exports WorkspaceView and WorkspaceStatusInfo type
- `App.test.tsx`: Updated test IDs to match new component

## Dependencies

Depends on T-072 (Terminal), T-073 (WorkspaceSwitcher), T-074 (WorkspaceStatusBar) — all merged ✅

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements T-075 by adding a `WorkspaceView` that assembles the Switcher, Terminal, and StatusBar. It follows `useWorkspacesStore.activeWorkspaceId`, shows an empty state when no workspace is active, and keeps the Terminal visible even if status info is missing (StatusBar hides).

- **New Features**
  - Added `WorkspaceView` composing `WorkspaceSwitcher` (top), `Terminal` (center), and `WorkspaceStatusBar` (bottom).
  - Terminal switches when the active workspace changes.
  - Added `onBackToDashboard` prop; `App` passes a stable handler and sets `data-testid="workspace-view"`.

- **Refactors**
  - Moved `WorkspaceStatusInfo` to `src/lib/types` and re-exported it in `components/Workspace/index.tsx`.
  - Added tests for missing status info and aligned test IDs.

<sup>Written for commit 13ed97e725f6d52cb60c36106f2a96a8ff6985d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace view enhanced to show detailed status (branch, ahead/behind, CI, session info, GitHub link).
  * Empty-state prompt when no workspace is selected.
  * Back-to-dashboard navigation available from the workspace view.

* **Tests**
  * Added comprehensive tests for the Workspace view and adjusted layout tests to expect the updated workspace view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->