### PR TITLE
feat(workspace): create WorkspaceListPage component (T-076)

### DIFF
--- a/src/components/Workspace/WorkspaceListPage.test.tsx
+++ b/src/components/Workspace/WorkspaceListPage.test.tsx
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { WorkspaceListPage } from "./WorkspaceListPage";
+import type { WorkspaceListEntry } from "../../lib/types";
+
+// ── Mock atoms ──────────────────────────────────────────────────
+
+vi.mock("../atoms/CI", () => ({
+  CI: ({ status }: { status: string }) => (
+    <span data-testid="ci-badge">{status}</span>
+  ),
+}));
+
+vi.mock("../atoms/EmptyState", () => ({
+  EmptyState: ({ message }: { message: string }) => (
+    <div data-testid="empty-state">{message}</div>
+  ),
+}));
+
+// ── Fixtures ────────────────────────────────────────────────────
+
+const ACTIVE_ENTRY: WorkspaceListEntry = {
+  workspace: {
+    id: "ws-1",
+    repoId: "repo-1",
+    pullRequestNumber: 42,
+    state: "active",
+    worktreePath: null,
+    sessionId: null,
+    createdAt: "2026-03-01T10:00:00Z",
+    updatedAt: "2026-03-28T14:30:00Z",
+  },
+  branch: "feat/login",
+  ahead: 3,
+  behind: 1,
+  ciStatus: "success",
+  sessionCount: 5,
+  diskUsageMb: 120,
+  lastNote: "Fixed auth flow, needs final review",
+};
+
+const SUSPENDED_ENTRY: WorkspaceListEntry = {
+  workspace: {
+    id: "ws-2",
+    repoId: "repo-1",
+    pullRequestNumber: 99,
+    state: "suspended",
+    worktreePath: null,
+    sessionId: null,
+    createdAt: "2026-02-15T08:00:00Z",
+    updatedAt: "2026-03-20T09:00:00Z",
+  },
+  branch: "fix/bug-99",
+  ahead: 0,
+  behind: 4,
+  ciStatus: "failure",
+  sessionCount: 2,
+  diskUsageMb: 85,
+  lastNote: null,
+};
+
+const ARCHIVED_ENTRY: WorkspaceListEntry = {
+  workspace: {
+    id: "ws-3",
+    repoId: "repo-2",
+    pullRequestNumber: 7,
+    state: "archived",
+    worktreePath: null,
+    sessionId: null,
+    createdAt: "2026-01-10T08:00:00Z",
+    updatedAt: "2026-02-01T12:00:00Z",
+  },
+  branch: null,
+  ahead: 0,
+  behind: 0,
+  ciStatus: null,
+  sessionCount: 0,
+  diskUsageMb: null,
+  lastNote: null,
+};
+
+const ENTRIES: readonly WorkspaceListEntry[] = [ACTIVE_ENTRY, SUSPENDED_ENTRY];
+
+// ── Tests ───────────────────────────────────────────────────────
+
+describe("WorkspaceListPage", () => {
+  it("should display PR numbers for all entries", () => {
+    render(
+      <WorkspaceListPage entries={ENTRIES} onWorkspaceClick={vi.fn()} />,
+    );
+
+    expect(screen.getByText(/PR #42/)).toBeInTheDocument();
+    expect(screen.getByText(/PR #99/)).toBeInTheDocument();
+  });
+
+  it("should show state dot with correct data attribute", () => {
+    const { container } = render(
+      <WorkspaceListPage entries={ENTRIES} onWorkspaceClick={vi.fn()} />,
+    );
+
+    const dots = container.querySelectorAll("[data-state]");
+    expect(dots).toHaveLength(2);
+    expect(dots[0]).toHaveAttribute("data-state", "active");
+    expect(dots[1]).toHaveAttribute("data-state", "suspended");
+  });
+
+  it("should show archived state dot", () => {
+    const { container } = render(
+      <WorkspaceListPage entries={[ARCHIVED_ENTRY]} onWorkspaceClick={vi.fn()} />,
+    );
+
+    const dot = container.querySelector("[data-state='archived']");
+    expect(dot).toBeInTheDocument();
+  });
+
+  it("should show disk usage total", () => {
+    render(
+      <WorkspaceListPage entries={ENTRIES} onWorkspaceClick={vi.fn()} />,
+    );
+
+    // 120 + 85 = 205 MB total
+    expect(screen.getByText(/205\s*MB/i)).toBeInTheDocument();
+  });
+
+  it("should show 0 MB total when all entries have diskUsageMb 0", () => {
+    const zeroEntries: readonly WorkspaceListEntry[] = [
+      { ...ACTIVE_ENTRY, diskUsageMb: 0 },
+    ];
+
+    render(
+      <WorkspaceListPage entries={zeroEntries} onWorkspaceClick={vi.fn()} />,
+    );
+
+    expect(screen.getByText(/Total: 0 MB/)).toBeInTheDocument();
+  });
+
+  it("should call onWorkspaceClick with workspace id on click", async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+
+    render(
+      <WorkspaceListPage entries={ENTRIES} onWorkspaceClick={handleClick} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /PR #42/ }));
+    expect(handleClick).toHaveBeenCalledWith("ws-1");
+  });
+
+  it("should show empty state when no workspaces", () => {
+    render(
+      <WorkspaceListPage entries={[]} onWorkspaceClick={vi.fn()} />,
+    );
+
+    expect(screen.getByTestId("empty-state")).toBeInTheDocument();
+  });
+
+  it("should show branch and ahead/behind info", () => {
+    render(
+      <WorkspaceListPage entries={[ACTIVE_ENTRY]} onWorkspaceClick={vi.fn()} />,
+    );
+
+    expect(screen.getByText(/feat\/login/)).toBeInTheDocument();
+    expect(screen.getByText("+3")).toBeInTheDocument();
+    expect(screen.getByText("-1")).toBeInTheDocument();
+  });
+
+  it("should show CI status badge", () => {
+    render(
+      <WorkspaceListPage entries={ENTRIES} onWorkspaceClick={vi.fn()} />,
+    );
+
+    const badges = screen.getAllByTestId("ci-badge");
+    expect(badges).toHaveLength(2);
+    expect(badges[0]).toHaveTextContent("success");
+    expect(badges[1]).toHaveTextContent("failure");
+  });
+
+  it("should show session count", () => {
+    render(
+      <WorkspaceListPage entries={ENTRIES} onWorkspaceClick={vi.fn()} />,
+    );
+
+    expect(screen.getByText(/5 sessions/i)).toBeInTheDocument();
+    expect(screen.getByText(/2 sessions/i)).toBeInTheDocument();
+  });
+
+  it("should show last note excerpt when available", () => {
+    render(
+      <WorkspaceListPage entries={ENTRIES} onWorkspaceClick={vi.fn()} />,
+    );
+
+    expect(screen.getByText(/Fixed auth flow/)).toBeInTheDocument();
+  });
+
+  it("should not show disk usage footer when no entries have disk data", () => {
+    const entriesNoDisk: readonly WorkspaceListEntry[] = [
+      { ...ACTIVE_ENTRY, diskUsageMb: null },
+    ];
+
+    render(
+      <WorkspaceListPage entries={entriesNoDisk} onWorkspaceClick={vi.fn()} />,
+    );
+
+    expect(screen.queryByText(/Total:/)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/Workspace/WorkspaceListPage.test.tsx
+++ b/src/components/Workspace/WorkspaceListPage.test.tsx
@@ -181,8 +181,8 @@ describe("WorkspaceListPage", () => {
       <WorkspaceListPage entries={ENTRIES} onWorkspaceClick={vi.fn()} />,
     );
 
-    expect(screen.getByText(/5 sessions/i)).toBeInTheDocument();
-    expect(screen.getByText(/2 sessions/i)).toBeInTheDocument();
+    expect(screen.getByText(/5 sessions/)).toBeInTheDocument();
+    expect(screen.getByText(/2 sessions/)).toBeInTheDocument();
   });
 
   it("should show last note excerpt when available", () => {
@@ -191,6 +191,18 @@ describe("WorkspaceListPage", () => {
     );
 
     expect(screen.getByText(/Fixed auth flow/)).toBeInTheDocument();
+  });
+
+  it("should use singular form for 1 session", () => {
+    const singleSession: readonly WorkspaceListEntry[] = [
+      { ...ACTIVE_ENTRY, sessionCount: 1 },
+    ];
+
+    render(
+      <WorkspaceListPage entries={singleSession} onWorkspaceClick={vi.fn()} />,
+    );
+
+    expect(screen.getByText(/1 session$/)).toBeInTheDocument();
   });
 
   it("should not show disk usage footer when no entries have disk data", () => {

--- a/src/components/Workspace/WorkspaceListPage.tsx
+++ b/src/components/Workspace/WorkspaceListPage.tsx
@@ -18,7 +18,7 @@ function formatDiskUsage(entries: readonly WorkspaceListEntry[]): string | null 
   const hasAnyDiskData = entries.some((e) => e.diskUsageMb != null);
   if (!hasAnyDiskData) return null;
   const total = entries.reduce((sum, e) => sum + (e.diskUsageMb ?? 0), 0);
-  return `${total} MB`;
+  return `${Math.round(total)} MB`;
 }
 
 export function WorkspaceListPage({
@@ -69,7 +69,7 @@ export function WorkspaceListPage({
                 )}
 
                 <div className="mt-0.5 flex items-center gap-3 text-xs text-dim">
-                  <span>{sessionCount} sessions</span>
+                  <span>{sessionCount} {sessionCount === 1 ? "session" : "sessions"}</span>
                   {diskUsageMb != null && <span>{diskUsageMb} MB</span>}
                 </div>
 

--- a/src/components/Workspace/WorkspaceListPage.tsx
+++ b/src/components/Workspace/WorkspaceListPage.tsx
@@ -1,0 +1,92 @@
+import type { ReactElement } from "react";
+import type { WorkspaceListEntry, WorkspaceState } from "../../lib/types";
+import { CI } from "../atoms/CI";
+import { EmptyState } from "../atoms/EmptyState";
+
+interface WorkspaceListPageProps {
+  readonly entries: readonly WorkspaceListEntry[];
+  readonly onWorkspaceClick: (workspaceId: string) => void;
+}
+
+const DOT_COLOR: Record<WorkspaceState, string> = {
+  active: "bg-green",
+  suspended: "bg-orange",
+  archived: "bg-dim",
+};
+
+function formatDiskUsage(entries: readonly WorkspaceListEntry[]): string | null {
+  const hasAnyDiskData = entries.some((e) => e.diskUsageMb != null);
+  if (!hasAnyDiskData) return null;
+  const total = entries.reduce((sum, e) => sum + (e.diskUsageMb ?? 0), 0);
+  return `${total} MB`;
+}
+
+export function WorkspaceListPage({
+  entries,
+  onWorkspaceClick,
+}: WorkspaceListPageProps): ReactElement {
+  if (entries.length === 0) {
+    return <EmptyState message="No workspaces yet" />;
+  }
+
+  const totalDisk = formatDiskUsage(entries);
+
+  return (
+    <section data-testid="workspace-list" className="flex h-full flex-col">
+      <ul className="flex-1 divide-y divide-border overflow-y-auto" role="list">
+        {entries.map(({ workspace, branch, ahead, behind, ciStatus, sessionCount, diskUsageMb, lastNote }) => (
+          <li key={workspace.id}>
+            <button
+              type="button"
+              onClick={() => onWorkspaceClick(workspace.id)}
+              aria-label={`PR #${workspace.pullRequestNumber} (${workspace.state})`}
+              className="flex w-full items-start gap-3 px-4 py-3 text-left hover:bg-surface-hover"
+            >
+              <span
+                data-state={workspace.state}
+                className={`mt-1.5 inline-block h-2 w-2 shrink-0 rounded-full ${DOT_COLOR[workspace.state]}`}
+              />
+
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium text-foreground">
+                    PR #{workspace.pullRequestNumber}
+                  </span>
+                  {ciStatus && <CI status={ciStatus} />}
+                </div>
+
+                {branch && (
+                  <div className="mt-0.5 flex items-center gap-2 text-xs text-dim">
+                    <span className="truncate">{branch}</span>
+                    {(ahead > 0 || behind > 0) && (
+                      <span>
+                        {ahead > 0 && <span className="text-green">+{ahead}</span>}
+                        {ahead > 0 && behind > 0 && " "}
+                        {behind > 0 && <span className="text-orange">-{behind}</span>}
+                      </span>
+                    )}
+                  </div>
+                )}
+
+                <div className="mt-0.5 flex items-center gap-3 text-xs text-dim">
+                  <span>{sessionCount} sessions</span>
+                  {diskUsageMb != null && <span>{diskUsageMb} MB</span>}
+                </div>
+
+                {lastNote && (
+                  <p className="mt-1 truncate text-xs text-dim/70">{lastNote}</p>
+                )}
+              </div>
+            </button>
+          </li>
+        ))}
+      </ul>
+
+      {totalDisk && (
+        <footer className="border-t border-border px-4 py-2 text-xs text-dim">
+          Total: {totalDisk}
+        </footer>
+      )}
+    </section>
+  );
+}

--- a/src/components/Workspace/index.tsx
+++ b/src/components/Workspace/index.tsx
@@ -1,2 +1,2 @@
+export { WorkspaceListPage } from "./WorkspaceListPage";
 export { WorkspaceView } from "./WorkspaceView";
-export type { WorkspaceStatusInfo } from "../../lib/types";

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -125,6 +125,19 @@ export interface WorkspaceStatusInfo {
   readonly githubUrl: string;
 }
 
+// ── Workspace list entry (T-076) ─────────────────────────────────
+
+export interface WorkspaceListEntry {
+  readonly workspace: Workspace;
+  readonly branch: string | null;
+  readonly ahead: number;
+  readonly behind: number;
+  readonly ciStatus: CiStatus | null;
+  readonly sessionCount: number;
+  readonly diskUsageMb: number | null;
+  readonly lastNote: string | null;
+}
+
 // ── Composite structs (T-010) ────────────────────────────────────
 
 export interface WorkspaceSummary {


### PR DESCRIPTION
## Summary

- Add `WorkspaceListPage` component at `src/components/Workspace/WorkspaceListPage.tsx` displaying all workspaces with state dot, PR number, branch, ahead/behind, CI status, session count, disk usage, and last note excerpt
- Add `WorkspaceListEntry` composite type in `lib/types.ts` combining workspace data with display info
- Total disk usage footer with null-safe aggregation
- Empty state when no workspaces
- 12 tests covering rendering, state dots (active/suspended/archived), disk usage, click handler, CI badges, session count, and edge cases

## Test plan

- [x] `npx vitest run` — 401/401 tests pass
- [x] `npx oxlint .` — 0 warnings, 0 errors
- [x] Code review: HIGH issues resolved (name collision, barrel re-export)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `WorkspaceListPage` to list all workspaces with status and key metrics, addressing Linear T-076. Includes a total disk usage footer and an empty state.

- **New Features**
  - Shows state dot, PR number, branch, ahead/behind, CI status, session count, disk usage, and last note.
  - Emits workspace id on click via `onWorkspaceClick`.
  - Displays total disk usage when any entry has disk data; hides footer otherwise.
  - Introduces `WorkspaceListEntry` type and exports `WorkspaceListPage` from `Workspace/index.tsx`.

- **Bug Fixes**
  - Use singular "session" when count is 1.
  - Round total disk usage to the nearest MB.

<sup>Written for commit a4b18ed820da9a8c72762713717d3fc9f0800187. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace list page displaying workspace entries with PR numbers, color-coded state indicators, CI status badges, branch details with ahead/behind counts, session counts, disk usage totals, and last notes. Supports workspace selection via click interactions and empty-state messaging.

* **Tests**
  * Added comprehensive test coverage for the new workspace list functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->