### PR TITLE
feat(workspace): generate auto-notes on suspension

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -565,10 +565,13 @@ pub(crate) async fn workspace_open_inner(
                 if let Some(old_pty) = pty_state.unregister(&oldest.id) {
                     let _ = pty_state.manager.kill(&old_pty);
                 }
-                if let Err(e) =
-                    update_workspace_state(pool, &oldest.id, &WorkspaceState::Suspended, None).await
+                match update_workspace_state(pool, &oldest.id, &WorkspaceState::Suspended, None)
+                    .await
                 {
-                    log::warn!("failed to suspend evicted workspace {}: {e}", oldest.id);
+                    Ok(evicted) => spawn_suspension_note(pool, &evicted),
+                    Err(e) => {
+                        log::warn!("failed to suspend evicted workspace {}: {e}", oldest.id);
+                    }
                 }
             }
         }
@@ -589,17 +592,34 @@ pub(crate) async fn workspace_open_inner(
 /// Suspends an active workspace: kills its PTY and sets state to Suspended.
 ///
 /// Emits no event — the Tauri command wrapper handles event emission.
+/// Spawns a background task to generate and store a suspension note.
+///
+/// No-op if the workspace has no `session_id` or `worktree_path`.
+/// Fire-and-forget: failures are logged, never propagated.
+fn spawn_suspension_note(pool: &SqlitePool, ws: &Workspace) {
+    if let (Some(wt_path), Some(session_id)) = (ws.worktree_path.clone(), ws.session_id.clone()) {
+        let pool = pool.clone();
+        let ws_id = ws.id.clone();
+        tokio::spawn(async move {
+            if let Err(e) = crate::workspace::claude::create_suspension_note(
+                &pool,
+                &ws_id,
+                Path::new(&wt_path),
+                Some(&session_id),
+            )
+            .await
+            {
+                log::warn!("failed to generate suspension note for '{ws_id}': {e}");
+            }
+        });
+    }
+}
+
 pub(crate) async fn workspace_suspend_inner(
     pool: &SqlitePool,
     pty_state: &PtyManagerState,
     workspace_id: &str,
 ) -> Result<Workspace, AppError> {
-    // Fetch workspace before suspension to capture session_id + worktree_path
-    // for background note generation.
-    let ws = crate::cache::workspaces::get_workspace(pool, workspace_id)
-        .await?
-        .ok_or_else(|| AppError::NotFound(format!("workspace '{workspace_id}'")))?;
-
     // Kill the PTY if one is tracked (before DB update — safe direction of failure)
     if let Some(pty_id) = pty_state.unregister(workspace_id)
         && let Err(e) = pty_state.manager.kill(&pty_id)
@@ -616,24 +636,8 @@ pub(crate) async fn workspace_suspend_inner(
     )
     .await?;
 
-    // Best-effort: generate a suspension note in the background (up to 30 s).
-    // Fire-and-forget so the suspend command returns immediately.
-    if let (Some(wt_path), Some(session_id)) = (ws.worktree_path.clone(), ws.session_id.clone()) {
-        let pool = pool.clone();
-        let ws_id = workspace_id.to_string();
-        tokio::spawn(async move {
-            if let Err(e) = crate::workspace::claude::create_suspension_note(
-                &pool,
-                &ws_id,
-                Path::new(&wt_path),
-                Some(&session_id),
-            )
-            .await
-            {
-                log::warn!("failed to generate suspension note for '{ws_id}': {e}");
-            }
-        });
-    }
+    // Best-effort background note generation using the post-update workspace.
+    spawn_suspension_note(pool, &suspended);
 
     Ok(suspended)
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -589,9 +589,6 @@ pub(crate) async fn workspace_open_inner(
 
 // ── Workspace state transitions (T-070) ─────���──────────────────
 
-/// Suspends an active workspace: kills its PTY and sets state to Suspended.
-///
-/// Emits no event — the Tauri command wrapper handles event emission.
 /// Spawns a background task to generate and store a suspension note.
 ///
 /// No-op if the workspace has no `session_id` or `worktree_path`.
@@ -615,6 +612,10 @@ fn spawn_suspension_note(pool: &SqlitePool, ws: &Workspace) {
     }
 }
 
+/// Suspends an active workspace: kills its PTY and sets state to Suspended.
+///
+/// Emits no event — the Tauri command wrapper handles event emission.
+/// Spawns a background note-generation task via [`spawn_suspension_note`].
 pub(crate) async fn workspace_suspend_inner(
     pool: &SqlitePool,
     pty_state: &PtyManagerState,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -594,6 +594,12 @@ pub(crate) async fn workspace_suspend_inner(
     pty_state: &PtyManagerState,
     workspace_id: &str,
 ) -> Result<Workspace, AppError> {
+    // Fetch workspace before suspension to capture session_id + worktree_path
+    // for background note generation.
+    let ws = crate::cache::workspaces::get_workspace(pool, workspace_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("workspace '{workspace_id}'")))?;
+
     // Kill the PTY if one is tracked (before DB update — safe direction of failure)
     if let Some(pty_id) = pty_state.unregister(workspace_id)
         && let Err(e) = pty_state.manager.kill(&pty_id)
@@ -602,13 +608,34 @@ pub(crate) async fn workspace_suspend_inner(
     }
 
     // Atomic transition: WHERE state = 'active' prevents TOCTOU races
-    update_workspace_state(
+    let suspended = update_workspace_state(
         pool,
         workspace_id,
         &WorkspaceState::Suspended,
         Some(&WorkspaceState::Active),
     )
-    .await
+    .await?;
+
+    // Best-effort: generate a suspension note in the background (up to 30 s).
+    // Fire-and-forget so the suspend command returns immediately.
+    if let (Some(wt_path), Some(session_id)) = (ws.worktree_path.clone(), ws.session_id.clone()) {
+        let pool = pool.clone();
+        let ws_id = workspace_id.to_string();
+        tokio::spawn(async move {
+            if let Err(e) = crate::workspace::claude::create_suspension_note(
+                &pool,
+                &ws_id,
+                Path::new(&wt_path),
+                Some(&session_id),
+            )
+            .await
+            {
+                log::warn!("failed to generate suspension note for '{ws_id}': {e}");
+            }
+        });
+    }
+
+    Ok(suspended)
 }
 
 /// Resumes a suspended workspace: spawns a new PTY in the existing worktree.

--- a/src-tauri/src/workspace/claude.rs
+++ b/src-tauri/src/workspace/claude.rs
@@ -345,17 +345,18 @@ fn extract_pr_context(
 // ── Suspension notes ────────────────────────────────────────────
 
 const SUSPENSION_NOTE_TIMEOUT: Duration = Duration::from_secs(30);
-const SUSPENSION_NOTE_PROMPT: &str = "Resume the current work state in 2-3 sentences";
+const SUSPENSION_NOTE_PROMPT: &str = "Summarize the current work state in 2-3 sentences";
 
-/// Maximum stdout size (16 KiB). Output beyond this is treated as a failure
-/// to guard against runaway child processes filling memory.
+/// Maximum stdout size (16 KiB). Output beyond this is discarded to avoid
+/// persisting runaway output. The limit is enforced while streaming — the
+/// child is killed as soon as the cap is exceeded.
 const MAX_STDOUT_BYTES: usize = 16_384;
 
-/// Runs a command with a timeout, capturing stdout.
+/// Runs a command with a timeout, capturing stdout with a size cap.
 ///
 /// Returns trimmed stdout on success, empty string on timeout or error.
-/// Kills the child process on timeout to avoid orphans.
-/// Rejects stdout larger than [`MAX_STDOUT_BYTES`].
+/// Streams stdout incrementally and kills the child if output exceeds
+/// [`MAX_STDOUT_BYTES`]. On timeout, `kill_on_drop(true)` sends SIGKILL.
 ///
 /// This is the testable building block: tests can pass any command
 /// (e.g. `echo`) instead of the real `claude` binary.
@@ -366,9 +367,10 @@ pub(crate) async fn run_headless_with_timeout(
     timeout: Duration,
 ) -> String {
     use std::process::Stdio;
+    use tokio::io::AsyncReadExt;
     use tokio::process::Command;
 
-    let Ok(child) = Command::new(program)
+    let Ok(mut child) = Command::new(program)
         .args(args)
         .current_dir(cwd)
         .stdout(Stdio::piped())
@@ -379,11 +381,27 @@ pub(crate) async fn run_headless_with_timeout(
         return String::new();
     };
 
-    // On timeout the future is dropped, which drops `child`, which sends
-    // SIGKILL thanks to `kill_on_drop(true)` — no orphan process.
-    match tokio::time::timeout(timeout, child.wait_with_output()).await {
-        Ok(Ok(output)) if output.status.success() && output.stdout.len() <= MAX_STDOUT_BYTES => {
-            String::from_utf8_lossy(&output.stdout).trim().to_string()
+    let Some(stdout) = child.stdout.take() else {
+        return String::new();
+    };
+
+    // Stream stdout with a size cap: read at most MAX_STDOUT_BYTES + 1 to
+    // detect overflow, then kill the child immediately if exceeded.
+    let read_and_wait = async {
+        let mut buf = Vec::with_capacity(MAX_STDOUT_BYTES);
+        let mut limited = stdout.take((MAX_STDOUT_BYTES as u64) + 1);
+        let n = limited.read_to_end(&mut buf).await?;
+        if n > MAX_STDOUT_BYTES {
+            return Err(std::io::Error::other("output exceeded size limit"));
+        }
+        let status = child.wait().await?;
+        Ok((buf, status))
+    };
+
+    // On timeout the future is dropped → child is dropped → SIGKILL.
+    match tokio::time::timeout(timeout, read_and_wait).await {
+        Ok(Ok((buf, status))) if status.success() => {
+            String::from_utf8_lossy(&buf).trim().to_string()
         }
         _ => String::new(),
     }
@@ -391,13 +409,20 @@ pub(crate) async fn run_headless_with_timeout(
 
 /// Runs Claude Code headless to generate a workspace suspension note.
 ///
-/// Executes `claude -p "<prompt>" --output-format text` in the worktree.
+/// Resumes the given session with `claude --resume <session_id> -p "<prompt>"`
+/// so the note reflects the actual suspended conversation, not a fresh context.
 /// Returns the note text, or empty string on timeout (30 s) or error.
-#[allow(dead_code)]
-pub async fn generate_suspension_note(worktree_path: &Path) -> String {
+pub(crate) async fn generate_suspension_note(session_id: &str, worktree_path: &Path) -> String {
     run_headless_with_timeout(
         "claude",
-        &["-p", SUSPENSION_NOTE_PROMPT, "--output-format", "text"],
+        &[
+            "--resume",
+            session_id,
+            "-p",
+            SUSPENSION_NOTE_PROMPT,
+            "--output-format",
+            "text",
+        ],
         worktree_path,
         SUSPENSION_NOTE_TIMEOUT,
     )
@@ -406,19 +431,26 @@ pub async fn generate_suspension_note(worktree_path: &Path) -> String {
 
 /// Stores a suspension note in the database.
 ///
+/// Trims the content and rejects empty/whitespace-only notes with an error.
 /// Creates a [`WorkspaceNote`] and persists it via `cache::workspaces::add_note`.
-#[allow(dead_code)]
-pub async fn store_suspension_note(
+pub(crate) async fn store_suspension_note(
     pool: &SqlitePool,
     workspace_id: &str,
     content: String,
 ) -> Result<WorkspaceNote, AppError> {
     use chrono::{SecondsFormat, Utc};
 
+    let trimmed = content.trim().to_string();
+    if trimmed.is_empty() {
+        return Err(AppError::Workspace(
+            "suspension note content must not be empty".into(),
+        ));
+    }
+
     let note = WorkspaceNote {
         id: uuid::Uuid::new_v4().to_string(),
         workspace_id: workspace_id.to_string(),
-        content,
+        content: trimmed,
         created_at: Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true),
     };
 
@@ -427,21 +459,20 @@ pub async fn store_suspension_note(
 
 /// Generates a suspension note and stores it in the database.
 ///
-/// Only runs if `has_claude_session` is true (Claude Code was active in this
+/// Only runs if `session_id` is `Some` (Claude Code was active in this
 /// workspace). Returns `None` if Claude wasn't active or if the headless
 /// command failed / timed out (empty output).
-#[allow(dead_code)]
 pub async fn create_suspension_note(
     pool: &SqlitePool,
     workspace_id: &str,
     worktree_path: &Path,
-    has_claude_session: bool,
+    session_id: Option<&str>,
 ) -> Result<Option<WorkspaceNote>, AppError> {
-    if !has_claude_session {
+    let Some(sid) = session_id else {
         return Ok(None);
-    }
+    };
 
-    let content = generate_suspension_note(worktree_path).await;
+    let content = generate_suspension_note(sid, worktree_path).await;
     if content.is_empty() {
         return Ok(None);
     }
@@ -1061,7 +1092,7 @@ mod tests {
         create_workspace(&pool, &ws).await.unwrap();
 
         // No Claude session → should return None, no note stored
-        let result = create_suspension_note(&pool, "ws-1", tmp.path(), false)
+        let result = create_suspension_note(&pool, "ws-1", tmp.path(), None)
             .await
             .unwrap();
         assert!(
@@ -1071,6 +1102,53 @@ mod tests {
 
         let notes = get_notes(&pool, "ws-1").await.unwrap();
         assert!(notes.is_empty(), "no note should be stored");
+
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_store_suspension_note_rejects_empty() {
+        use crate::cache::db::init_db;
+        use crate::cache::repos::upsert_repo;
+        use crate::cache::workspaces::create_workspace;
+        use crate::types::{Repo, Workspace, WorkspaceState};
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let pool = init_db(&tmp.path().join("test.db")).await.unwrap();
+
+        let repo = Repo {
+            id: "repo-1".to_string(),
+            org: "mpiton".to_string(),
+            name: "prism".to_string(),
+            full_name: "mpiton/prism".to_string(),
+            url: "https://github.com/mpiton/prism".to_string(),
+            default_branch: "main".to_string(),
+            is_archived: false,
+            enabled: true,
+            local_path: None,
+            last_sync_at: None,
+        };
+        upsert_repo(&pool, &repo).await.unwrap();
+
+        let ws = Workspace {
+            id: "ws-1".to_string(),
+            repo_id: "repo-1".to_string(),
+            pull_request_number: 42,
+            state: WorkspaceState::Active,
+            worktree_path: Some("/tmp/worktree".to_string()),
+            session_id: None,
+            created_at: "2026-03-20T10:00:00Z".to_string(),
+            updated_at: "2026-03-20T10:00:00Z".to_string(),
+        };
+        create_workspace(&pool, &ws).await.unwrap();
+
+        // Empty content should be rejected
+        let err = store_suspension_note(&pool, "ws-1", String::new()).await;
+        assert!(err.is_err(), "should reject empty content");
+
+        // Whitespace-only content should be rejected
+        let err = store_suspension_note(&pool, "ws-1", "   \n  ".to_string()).await;
+        assert!(err.is_err(), "should reject whitespace-only content");
 
         pool.close().await;
     }

--- a/src-tauri/src/workspace/claude.rs
+++ b/src-tauri/src/workspace/claude.rs
@@ -1,12 +1,15 @@
 use std::path::Path;
 use std::sync::LazyLock;
+use std::time::Duration;
 
 use regex::Regex;
+use sqlx::SqlitePool;
 
 use super::pty::PtyManager;
 use crate::error::AppError;
 use crate::github::client::GitHubClient;
 use crate::github::queries::{PullRequestDetail, pull_request_detail};
+use crate::types::WorkspaceNote;
 
 /// Matches a Claude Code session ID from stdout.
 ///
@@ -337,6 +340,115 @@ fn extract_pr_context(
         unresolved_threads,
         changed_files,
     })
+}
+
+// ── Suspension notes ────────────────────────────────────────────
+
+const SUSPENSION_NOTE_TIMEOUT: Duration = Duration::from_secs(30);
+const SUSPENSION_NOTE_PROMPT: &str = "Resume the current work state in 2-3 sentences";
+
+/// Maximum stdout size (16 KiB). Output beyond this is treated as a failure
+/// to guard against runaway child processes filling memory.
+const MAX_STDOUT_BYTES: usize = 16_384;
+
+/// Runs a command with a timeout, capturing stdout.
+///
+/// Returns trimmed stdout on success, empty string on timeout or error.
+/// Kills the child process on timeout to avoid orphans.
+/// Rejects stdout larger than [`MAX_STDOUT_BYTES`].
+///
+/// This is the testable building block: tests can pass any command
+/// (e.g. `echo`) instead of the real `claude` binary.
+pub(crate) async fn run_headless_with_timeout(
+    program: &str,
+    args: &[&str],
+    cwd: &Path,
+    timeout: Duration,
+) -> String {
+    use std::process::Stdio;
+    use tokio::process::Command;
+
+    let Ok(child) = Command::new(program)
+        .args(args)
+        .current_dir(cwd)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .kill_on_drop(true)
+        .spawn()
+    else {
+        return String::new();
+    };
+
+    // On timeout the future is dropped, which drops `child`, which sends
+    // SIGKILL thanks to `kill_on_drop(true)` — no orphan process.
+    match tokio::time::timeout(timeout, child.wait_with_output()).await {
+        Ok(Ok(output)) if output.status.success() && output.stdout.len() <= MAX_STDOUT_BYTES => {
+            String::from_utf8_lossy(&output.stdout).trim().to_string()
+        }
+        _ => String::new(),
+    }
+}
+
+/// Runs Claude Code headless to generate a workspace suspension note.
+///
+/// Executes `claude -p "<prompt>" --output-format text` in the worktree.
+/// Returns the note text, or empty string on timeout (30 s) or error.
+#[allow(dead_code)]
+pub async fn generate_suspension_note(worktree_path: &Path) -> String {
+    run_headless_with_timeout(
+        "claude",
+        &["-p", SUSPENSION_NOTE_PROMPT, "--output-format", "text"],
+        worktree_path,
+        SUSPENSION_NOTE_TIMEOUT,
+    )
+    .await
+}
+
+/// Stores a suspension note in the database.
+///
+/// Creates a [`WorkspaceNote`] and persists it via `cache::workspaces::add_note`.
+#[allow(dead_code)]
+pub async fn store_suspension_note(
+    pool: &SqlitePool,
+    workspace_id: &str,
+    content: String,
+) -> Result<WorkspaceNote, AppError> {
+    use chrono::{SecondsFormat, Utc};
+
+    let note = WorkspaceNote {
+        id: uuid::Uuid::new_v4().to_string(),
+        workspace_id: workspace_id.to_string(),
+        content,
+        created_at: Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true),
+    };
+
+    crate::cache::workspaces::add_note(pool, &note).await
+}
+
+/// Generates a suspension note and stores it in the database.
+///
+/// Only runs if `has_claude_session` is true (Claude Code was active in this
+/// workspace). Returns `None` if Claude wasn't active or if the headless
+/// command failed / timed out (empty output).
+#[allow(dead_code)]
+pub async fn create_suspension_note(
+    pool: &SqlitePool,
+    workspace_id: &str,
+    worktree_path: &Path,
+    has_claude_session: bool,
+) -> Result<Option<WorkspaceNote>, AppError> {
+    if !has_claude_session {
+        return Ok(None);
+    }
+
+    let content = generate_suspension_note(worktree_path).await;
+    if content.is_empty() {
+        return Ok(None);
+    }
+
+    store_suspension_note(pool, workspace_id, content)
+        .await
+        .map(Some)
 }
 
 /// Fetches PR details from GitHub and generates a CLAUDE.md in the worktree.
@@ -810,5 +922,156 @@ mod tests {
             4,
             "table row should have 4 pipe delimiters"
         );
+    }
+
+    // ── Suspension note tests ────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_generate_note_success() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let content = run_headless_with_timeout(
+            "echo",
+            &["Working on auth refactor. Tests passing."],
+            tmp.path(),
+            Duration::from_secs(5),
+        )
+        .await;
+
+        assert_eq!(content, "Working on auth refactor. Tests passing.");
+    }
+
+    #[tokio::test]
+    async fn test_generate_note_timeout() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let content =
+            run_headless_with_timeout("sleep", &["60"], tmp.path(), Duration::from_secs(1)).await;
+
+        assert!(
+            content.is_empty(),
+            "should return empty on timeout, got: {content:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_generate_note_command_failure() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let content = run_headless_with_timeout(
+            "false", // exits with status 1
+            &[],
+            tmp.path(),
+            Duration::from_secs(5),
+        )
+        .await;
+
+        assert!(content.is_empty(), "should return empty on non-zero exit");
+    }
+
+    #[tokio::test]
+    async fn test_generate_note_stored_in_db() {
+        use crate::cache::db::init_db;
+        use crate::cache::repos::upsert_repo;
+        use crate::cache::workspaces::{create_workspace, get_notes};
+        use crate::types::{Repo, Workspace, WorkspaceState};
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let pool = init_db(&tmp.path().join("test.db")).await.unwrap();
+
+        let repo = Repo {
+            id: "repo-1".to_string(),
+            org: "mpiton".to_string(),
+            name: "prism".to_string(),
+            full_name: "mpiton/prism".to_string(),
+            url: "https://github.com/mpiton/prism".to_string(),
+            default_branch: "main".to_string(),
+            is_archived: false,
+            enabled: true,
+            local_path: None,
+            last_sync_at: None,
+        };
+        upsert_repo(&pool, &repo).await.unwrap();
+
+        let ws = Workspace {
+            id: "ws-1".to_string(),
+            repo_id: "repo-1".to_string(),
+            pull_request_number: 42,
+            state: WorkspaceState::Active,
+            worktree_path: Some("/tmp/worktree".to_string()),
+            session_id: Some("session-123".to_string()),
+            created_at: "2026-03-20T10:00:00Z".to_string(),
+            updated_at: "2026-03-20T10:00:00Z".to_string(),
+        };
+        create_workspace(&pool, &ws).await.unwrap();
+
+        // Store a note
+        let note = store_suspension_note(
+            &pool,
+            "ws-1",
+            "Working on auth refactor. Tests passing.".to_string(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(note.workspace_id, "ws-1");
+        assert_eq!(note.content, "Working on auth refactor. Tests passing.");
+        assert!(!note.id.is_empty());
+        assert!(!note.created_at.is_empty());
+
+        // Verify it's retrievable
+        let notes = get_notes(&pool, "ws-1").await.unwrap();
+        assert_eq!(notes.len(), 1);
+        assert_eq!(notes[0].content, "Working on auth refactor. Tests passing.");
+
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_create_suspension_note_skips_without_session() {
+        use crate::cache::db::init_db;
+        use crate::cache::repos::upsert_repo;
+        use crate::cache::workspaces::{create_workspace, get_notes};
+        use crate::types::{Repo, Workspace, WorkspaceState};
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let pool = init_db(&tmp.path().join("test.db")).await.unwrap();
+
+        let repo = Repo {
+            id: "repo-1".to_string(),
+            org: "mpiton".to_string(),
+            name: "prism".to_string(),
+            full_name: "mpiton/prism".to_string(),
+            url: "https://github.com/mpiton/prism".to_string(),
+            default_branch: "main".to_string(),
+            is_archived: false,
+            enabled: true,
+            local_path: None,
+            last_sync_at: None,
+        };
+        upsert_repo(&pool, &repo).await.unwrap();
+
+        let ws = Workspace {
+            id: "ws-1".to_string(),
+            repo_id: "repo-1".to_string(),
+            pull_request_number: 42,
+            state: WorkspaceState::Active,
+            worktree_path: Some("/tmp/worktree".to_string()),
+            session_id: None,
+            created_at: "2026-03-20T10:00:00Z".to_string(),
+            updated_at: "2026-03-20T10:00:00Z".to_string(),
+        };
+        create_workspace(&pool, &ws).await.unwrap();
+
+        // No Claude session → should return None, no note stored
+        let result = create_suspension_note(&pool, "ws-1", tmp.path(), false)
+            .await
+            .unwrap();
+        assert!(
+            result.is_none(),
+            "should return None without active session"
+        );
+
+        let notes = get_notes(&pool, "ws-1").await.unwrap();
+        assert!(notes.is_empty(), "no note should be stored");
+
+        pool.close().await;
     }
 }


### PR DESCRIPTION
## Summary

- Add headless Claude Code execution (`claude -p`) to generate 2-3 sentence work state summaries when a workspace is suspended
- Store generated notes in `workspace_notes` table via existing CRUD
- Use `kill_on_drop(true)` to prevent orphan processes on 30s timeout, cap stdout at 16 KiB
- Return `None` (no note stored) on timeout/error instead of persisting empty notes

## Test plan

- [x] `test_generate_note_success` — verify stdout capture via `echo`
- [x] `test_generate_note_timeout` — verify empty return after 1s timeout on `sleep 60`
- [x] `test_generate_note_command_failure` — verify empty return on non-zero exit
- [x] `test_generate_note_stored_in_db` — verify note persisted and retrievable via SQLite
- [x] `test_create_suspension_note_skips_without_session` — verify no note when Claude inactive
- [x] Full test suite: 297/297 passing, clippy clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically generate 2–3 sentence notes when suspending a workspace (including LRU evictions) by running `claude` headless with `--resume`, saving to `workspace_notes`. Runs in the background with a 30s timeout and 16 KiB cap; stores nothing on error. Implements Linear T-079.

- **New Features**
  - Run `claude --resume <session_id> -p "Summarize the current work state in 2-3 sentences"` in the worktree on suspend; only if a Claude session was active.
  - Fire-and-forget via `tokio::spawn` so suspend returns immediately.
  - Stream stdout with a 16 KiB cap and a 30s timeout; `kill_on_drop(true)` ensures cleanup. On failure/timeout, store nothing.
  - Validate/persist via existing CRUD; reject empty/whitespace output. `run_headless_with_timeout` is unit-tested.

- **Bug Fixes**
  - Use the post-update workspace when generating notes to avoid stale data.
  - Generate notes for LRU-evicted workspaces via a shared `spawn_suspension_note` helper.

<sup>Written for commit aaddb9524a4c9ae621d01ba7b0322194f7849bb9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added suspension notes: automatically generate, validate, timestamp, and store notes for sessions; created as background tasks on suspend or eviction so suspension proceeds without waiting.

* **Reliability**
  * Enforced timeouts, output size limits, non-empty content checks; failures are logged and do not block suspension.

* **Tests**
  * Added async tests for generation, timeout, non-zero exit, persistence, skipping, and empty-content rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->