### PR TITLE
feat(workspace): implement lifecycle auto-suspend timer (T-080)

### DIFF
--- a/src-tauri/src/cache/config.rs
+++ b/src-tauri/src/cache/config.rs
@@ -335,4 +335,20 @@ mod tests {
 
         pool.close().await;
     }
+
+    #[tokio::test]
+    async fn test_set_config_clamps_auto_suspend() {
+        let (pool, _tmp) = test_pool().await;
+
+        let mut config = get_config(&pool).await.unwrap();
+        config.auto_suspend_minutes = 2; // below minimum of 5
+
+        let result = set_config(&pool, &config).await.unwrap();
+        assert_eq!(
+            result.auto_suspend_minutes, MIN_AUTO_SUSPEND_MINUTES,
+            "should clamp 2 to minimum of 5"
+        );
+
+        pool.close().await;
+    }
 }

--- a/src-tauri/src/cache/config.rs
+++ b/src-tauri/src/cache/config.rs
@@ -9,6 +9,7 @@ const KEY_POLL_INTERVAL: &str = "poll_interval_secs";
 const KEY_MAX_WORKSPACES: &str = "max_active_workspaces";
 const KEY_ARCHIVE_DELAY: &str = "archive_delay_hours";
 const KEY_ARCHIVE_DELAY_CLOSED: &str = "archive_delay_closed_hours";
+const KEY_AUTO_SUSPEND: &str = "auto_suspend_minutes";
 const KEY_GITHUB_TOKEN: &str = "github_token";
 const KEY_DATA_DIR: &str = "data_dir";
 const KEY_WORKSPACES_DIR: &str = "workspaces_dir";
@@ -17,6 +18,8 @@ const KEY_WORKSPACES_DIR: &str = "workspaces_dir";
 const MIN_POLL_INTERVAL_SECS: u64 = 30;
 /// Minimum allowed value for `max_active_workspaces`.
 const MIN_MAX_ACTIVE_WORKSPACES: u32 = 1;
+/// Minimum allowed value for `auto_suspend_minutes`.
+const MIN_AUTO_SUSPEND_MINUTES: u64 = 5;
 
 /// Row from the `config` key-value table.
 #[derive(sqlx::FromRow)]
@@ -44,6 +47,18 @@ fn clamp_max_workspaces(value: u32) -> u32 {
             "max_active_workspaces {value} would evict all workspaces; clamping to {MIN_MAX_ACTIVE_WORKSPACES}"
         );
         MIN_MAX_ACTIVE_WORKSPACES
+    } else {
+        value
+    }
+}
+
+/// Clamp `auto_suspend_minutes` to its minimum, warning on violation.
+fn clamp_auto_suspend(value: u64) -> u64 {
+    if value < MIN_AUTO_SUSPEND_MINUTES {
+        warn!(
+            "auto_suspend_minutes {value} is below the minimum of {MIN_AUTO_SUSPEND_MINUTES}; clamping"
+        );
+        MIN_AUTO_SUSPEND_MINUTES
     } else {
         value
     }
@@ -90,6 +105,13 @@ pub async fn get_config(pool: &SqlitePool) -> Result<AppConfig, AppError> {
                     KEY_ARCHIVE_DELAY_CLOSED, row.value
                 ),
             },
+            KEY_AUTO_SUSPEND => match row.value.parse::<u64>() {
+                Ok(v) => config.auto_suspend_minutes = clamp_auto_suspend(v),
+                Err(_) => warn!(
+                    "ignoring non-parseable config value for '{}': '{}', using default",
+                    KEY_AUTO_SUSPEND, row.value
+                ),
+            },
             KEY_GITHUB_TOKEN => {
                 config.github_token = Some(row.value);
             }
@@ -115,6 +137,7 @@ pub async fn get_config(pool: &SqlitePool) -> Result<AppConfig, AppError> {
 pub async fn set_config(pool: &SqlitePool, config: &AppConfig) -> Result<AppConfig, AppError> {
     let poll_interval = clamp_poll_interval(config.poll_interval_secs);
     let max_workspaces = clamp_max_workspaces(config.max_active_workspaces);
+    let auto_suspend = clamp_auto_suspend(config.auto_suspend_minutes);
 
     let mut tx = pool.begin().await?;
 
@@ -132,6 +155,7 @@ pub async fn set_config(pool: &SqlitePool, config: &AppConfig) -> Result<AppConf
         &config.archive_delay_closed_hours.to_string(),
     )
     .await?;
+    upsert_key(&mut *tx, KEY_AUTO_SUSPEND, &auto_suspend.to_string()).await?;
 
     set_optional_key(&mut *tx, KEY_GITHUB_TOKEN, config.github_token.as_deref()).await?;
     set_optional_key(&mut *tx, KEY_DATA_DIR, config.data_dir.as_deref()).await?;
@@ -150,6 +174,7 @@ pub async fn set_config(pool: &SqlitePool, config: &AppConfig) -> Result<AppConf
         max_active_workspaces: max_workspaces,
         archive_delay_hours: config.archive_delay_hours,
         archive_delay_closed_hours: config.archive_delay_closed_hours,
+        auto_suspend_minutes: auto_suspend,
         github_token: config.github_token.clone(),
         data_dir: config.data_dir.clone(),
         workspaces_dir: config.workspaces_dir.clone(),
@@ -250,6 +275,7 @@ mod tests {
             max_active_workspaces: 5,
             archive_delay_hours: 12,
             archive_delay_closed_hours: 72,
+            auto_suspend_minutes: 30,
             github_token: Some("ghp_test".to_string()),
             data_dir: Some("/custom/data".to_string()),
             workspaces_dir: Some("/custom/ws".to_string()),

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -482,7 +482,11 @@ impl PtyManagerState {
     }
 
     /// Removes the mapping by workspace ID and returns the `pty_id` if present.
+    /// Also clears the corresponding `last_touch` throttle entry.
     pub fn unregister(&self, workspace_id: &str) -> Option<String> {
+        if let Ok(mut touch) = self.last_touch.lock() {
+            touch.remove(workspace_id);
+        }
         self.workspace_ptys.lock().ok()?.remove(workspace_id)
     }
 
@@ -490,9 +494,20 @@ impl PtyManagerState {
     ///
     /// Used by `pty_kill` to clean up the workspace→pty mapping when a PTY
     /// is killed directly by its ID rather than through LRU eviction.
+    /// Also clears the corresponding `last_touch` throttle entry.
     pub fn unregister_by_pty_id(&self, pty_id: &str) {
         if let Ok(mut map) = self.workspace_ptys.lock() {
+            // Find the workspace_id before removing, so we can clean last_touch.
+            let ws_id = map
+                .iter()
+                .find(|(_, v)| v.as_str() == pty_id)
+                .map(|(k, _)| k.clone());
             map.retain(|_, v| v != pty_id);
+            if let Some(ws_id) = ws_id
+                && let Ok(mut touch) = self.last_touch.lock()
+            {
+                touch.remove(&ws_id);
+            }
         }
     }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -439,13 +439,38 @@ pub async fn workspace_get_notes(
 pub struct PtyManagerState {
     pub manager: PtyManager,
     workspace_ptys: Mutex<HashMap<String, String>>,
+    /// Throttle map: `workspace_id` → last time `update_last_active` was called.
+    /// Used to avoid a DB write on every keystroke.
+    last_touch: Mutex<HashMap<String, std::time::Instant>>,
 }
+
+/// Minimum interval between `last_active_at` DB writes per workspace.
+const LAST_ACTIVE_THROTTLE: std::time::Duration = std::time::Duration::from_secs(5);
 
 impl PtyManagerState {
     pub fn new() -> Self {
         Self {
             manager: PtyManager::new(),
             workspace_ptys: Mutex::new(HashMap::new()),
+            last_touch: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Returns `true` if enough time has elapsed since the last touch for
+    /// this workspace (or if it has never been touched). Updates the stored
+    /// timestamp on success.
+    pub fn should_touch_last_active(&self, workspace_id: &str) -> bool {
+        let now = std::time::Instant::now();
+        let mut map = match self.last_touch.lock() {
+            Ok(g) => g,
+            Err(e) => e.into_inner(),
+        };
+        match map.get(workspace_id) {
+            Some(last) if now.duration_since(*last) < LAST_ACTIVE_THROTTLE => false,
+            _ => {
+                map.insert(workspace_id.to_string(), now);
+                true
+            }
         }
     }
 
@@ -1031,8 +1056,9 @@ pub async fn pty_write(
         .write_pty(&pty_id, data.as_bytes())
         .map_err(|e| e.to_string())?;
 
-    // Best-effort: update last_active_at for the workspace linked to this PTY.
+    // Best-effort: update last_active_at, throttled to at most once per 5s per workspace.
     if let Some(ws_id) = pty_state.lookup_workspace_by_pty(&pty_id)
+        && pty_state.should_touch_last_active(&ws_id)
         && let Err(e) = crate::cache::workspaces::update_last_active(&pool, &ws_id).await
     {
         log::warn!("pty_write: failed to touch last_active_at for workspace '{ws_id}': {e}");

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -470,6 +470,20 @@ impl PtyManagerState {
             map.retain(|_, v| v != pty_id);
         }
     }
+
+    /// Reverse lookup: find the workspace ID associated with a PTY ID.
+    ///
+    /// Recovers from a poisoned mutex to avoid silently losing
+    /// `last_active_at` updates (which would cause premature auto-suspend).
+    pub fn lookup_workspace_by_pty(&self, pty_id: &str) -> Option<String> {
+        let map = match self.workspace_ptys.lock() {
+            Ok(g) => g,
+            Err(e) => e.into_inner(),
+        };
+        map.iter()
+            .find(|(_, v)| v.as_str() == pty_id)
+            .map(|(k, _)| k.clone())
+    }
 }
 
 impl Default for PtyManagerState {
@@ -1001,11 +1015,13 @@ pub async fn workspace_cleanup(
     Ok(u32::try_from(archived_ids.len()).unwrap_or(u32::MAX))
 }
 
-/// Writes data to a PTY's stdin.
+/// Writes data to a PTY's stdin and touches `last_active_at` for the
+/// associated workspace so the lifecycle auto-suspend timer is reset.
 ///
 /// Tauri 2 renames `pty_id` → `ptyId` for the JS caller.
 #[tauri::command]
 pub async fn pty_write(
+    pool: tauri::State<'_, SqlitePool>,
     pty_state: tauri::State<'_, PtyManagerState>,
     pty_id: String,
     data: String,
@@ -1013,7 +1029,16 @@ pub async fn pty_write(
     pty_state
         .manager
         .write_pty(&pty_id, data.as_bytes())
-        .map_err(|e| e.to_string())
+        .map_err(|e| e.to_string())?;
+
+    // Best-effort: update last_active_at for the workspace linked to this PTY.
+    if let Some(ws_id) = pty_state.lookup_workspace_by_pty(&pty_id)
+        && let Err(e) = crate::cache::workspaces::update_last_active(&pool, &ws_id).await
+    {
+        log::warn!("pty_write: failed to touch last_active_at for workspace '{ws_id}': {e}");
+    }
+
+    Ok(())
 }
 
 /// Resizes a PTY to new dimensions.
@@ -1286,6 +1311,7 @@ mod tests {
             max_active_workspaces: 5,
             archive_delay_hours: 12,
             archive_delay_closed_hours: 72,
+            auto_suspend_minutes: 30,
             github_token: Some("ghp_test".into()),
             data_dir: None,
             workspaces_dir: Some("/ws".into()),
@@ -1344,6 +1370,7 @@ mod tests {
             max_active_workspaces: 3,
             archive_delay_hours: 24,
             archive_delay_closed_hours: 48,
+            auto_suspend_minutes: 30,
             github_token: None,
             data_dir: None,
             workspaces_dir: None,
@@ -1353,6 +1380,7 @@ mod tests {
             max_active_workspaces: None,
             archive_delay_hours: None,
             archive_delay_closed_hours: None,
+            auto_suspend_minutes: None,
             github_token: None,
             data_dir: None,
             workspaces_dir: None,
@@ -1369,6 +1397,7 @@ mod tests {
             max_active_workspaces: 3,
             archive_delay_hours: 24,
             archive_delay_closed_hours: 48,
+            auto_suspend_minutes: 30,
             github_token: Some("ghp_old".into()),
             data_dir: Some("/data".into()),
             workspaces_dir: None,
@@ -1379,6 +1408,7 @@ mod tests {
             max_active_workspaces: None,
             archive_delay_hours: None,
             archive_delay_closed_hours: None,
+            auto_suspend_minutes: None,
             github_token: Some(None), // clear it
             data_dir: None,           // leave as-is
             workspaces_dir: None,
@@ -1870,6 +1900,7 @@ mod tests {
                 max_active_workspaces: 3,
                 archive_delay_hours: 24,
                 archive_delay_closed_hours: 48,
+                auto_suspend_minutes: 30,
                 github_token: None,
                 data_dir: None,
                 workspaces_dir: Some(ws_base.path().to_string_lossy().to_string()),
@@ -1924,6 +1955,7 @@ mod tests {
                 max_active_workspaces: 1,
                 archive_delay_hours: 24,
                 archive_delay_closed_hours: 48,
+                auto_suspend_minutes: 30,
                 github_token: None,
                 data_dir: None,
                 workspaces_dir: Some(ws_base.path().to_string_lossy().to_string()),
@@ -1999,6 +2031,7 @@ mod tests {
                 max_active_workspaces: 3,
                 archive_delay_hours: 24,
                 archive_delay_closed_hours: 48,
+                auto_suspend_minutes: 30,
                 github_token: None,
                 data_dir: None,
                 workspaces_dir: Some(ws_base.path().to_string_lossy().to_string()),
@@ -2052,6 +2085,7 @@ mod tests {
                 max_active_workspaces: 3,
                 archive_delay_hours: 24,
                 archive_delay_closed_hours: 48,
+                auto_suspend_minutes: 30,
                 github_token: None,
                 data_dir: None,
                 workspaces_dir: Some(ws_base.path().to_string_lossy().to_string()),
@@ -2121,6 +2155,7 @@ mod tests {
                 max_active_workspaces: 3,
                 archive_delay_hours: 24,
                 archive_delay_closed_hours: 48,
+                auto_suspend_minutes: 30,
                 github_token: None,
                 data_dir: None,
                 workspaces_dir: Some(ws_base.path().to_string_lossy().to_string()),
@@ -2191,6 +2226,7 @@ mod tests {
                 max_active_workspaces: 3,
                 archive_delay_hours: 24,
                 archive_delay_closed_hours: 48,
+                auto_suspend_minutes: 30,
                 github_token: None,
                 data_dir: None,
                 workspaces_dir: Some(ws_base.path().to_string_lossy().to_string()),
@@ -2259,6 +2295,7 @@ mod tests {
                 max_active_workspaces: 3,
                 archive_delay_hours: 24,
                 archive_delay_closed_hours: 48,
+                auto_suspend_minutes: 30,
                 github_token: None,
                 data_dir: None,
                 workspaces_dir: Some(ws_base.path().to_string_lossy().to_string()),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@ use std::sync::Mutex;
 use std::sync::atomic::AtomicBool;
 
 use log::info;
+use sqlx::SqlitePool;
 use tauri::Manager;
 
 /// Guards against concurrent force-sync invocations from the tray or IPC.
@@ -155,6 +156,13 @@ pub fn run() {
             tauri::async_runtime::spawn(async move {
                 try_start_polling(handle, poll_pool).await;
             });
+
+            // Start workspace lifecycle task (auto-suspend & auto-archive).
+            // Intentionally detached: the tokio runtime abort on shutdown is sufficient.
+            let lifecycle_pool = app.state::<SqlitePool>().inner().clone();
+            let lifecycle_handle = app.handle().clone();
+            let _lifecycle_task =
+                workspace::lifecycle::start_workspace_lifecycle(lifecycle_handle, lifecycle_pool);
 
             Ok(())
         })

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -321,6 +321,8 @@ pub struct AppConfig {
     pub archive_delay_hours: u64,
     /// Hours after a PR is closed before its workspace is auto-archived (default 48).
     pub archive_delay_closed_hours: u64,
+    /// Minutes of inactivity before an active workspace is auto-suspended (default 30).
+    pub auto_suspend_minutes: u64,
     /// GitHub personal access token or OAuth token. `None` means not yet configured.
     pub github_token: Option<String>,
     /// Override for the `SQLite` data directory (`~/.local/share/prism/` by default).
@@ -339,6 +341,7 @@ impl fmt::Debug for AppConfig {
                 "archive_delay_closed_hours",
                 &self.archive_delay_closed_hours,
             )
+            .field("auto_suspend_minutes", &self.auto_suspend_minutes)
             .field(
                 "github_token",
                 &self.github_token.as_ref().map(|_| "<redacted>"),
@@ -356,6 +359,7 @@ impl Default for AppConfig {
             max_active_workspaces: 3,
             archive_delay_hours: 24,
             archive_delay_closed_hours: 48,
+            auto_suspend_minutes: 30,
             github_token: None,
             data_dir: None,
             workspaces_dir: None,
@@ -401,6 +405,7 @@ pub struct PartialAppConfig {
     pub max_active_workspaces: Option<u32>,
     pub archive_delay_hours: Option<u64>,
     pub archive_delay_closed_hours: Option<u64>,
+    pub auto_suspend_minutes: Option<u64>,
     #[serde(deserialize_with = "deserialize_double_option", default)]
     pub github_token: Option<Option<String>>,
     #[serde(deserialize_with = "deserialize_double_option", default)]
@@ -426,6 +431,9 @@ pub fn merge_partial_config(base: &AppConfig, partial: &PartialAppConfig) -> App
         archive_delay_closed_hours: partial
             .archive_delay_closed_hours
             .unwrap_or(base.archive_delay_closed_hours),
+        auto_suspend_minutes: partial
+            .auto_suspend_minutes
+            .unwrap_or(base.auto_suspend_minutes),
         github_token: match &partial.github_token {
             Some(v) => v.clone(),
             None => base.github_token.clone(),
@@ -1023,6 +1031,7 @@ mod tests {
             max_active_workspaces: 5,
             archive_delay_hours: 12,
             archive_delay_closed_hours: 72,
+            auto_suspend_minutes: 30,
             github_token: Some("test-token".to_string()),
             data_dir: Some("/custom/data".to_string()),
             workspaces_dir: None,

--- a/src-tauri/src/workspace/lifecycle.rs
+++ b/src-tauri/src/workspace/lifecycle.rs
@@ -1,0 +1,347 @@
+use chrono::{Duration, SecondsFormat, Utc};
+use log::{info, warn};
+use sqlx::SqlitePool;
+use tauri::Manager;
+
+use crate::commands::{PtyManagerState, workspace_cleanup_inner, workspace_suspend_inner};
+use crate::error::AppError;
+
+/// Find active workspaces whose idle time exceeds `auto_suspend_minutes`.
+///
+/// Uses `last_active_at` (with `updated_at` as fallback for workspaces that
+/// never received PTY input) to determine idle time.
+pub(crate) async fn find_expired_active_workspaces(
+    pool: &SqlitePool,
+    auto_suspend_minutes: u64,
+) -> Result<Vec<String>, AppError> {
+    // Cap at ~100 years to avoid Duration overflow (i64 * 60_000_000_000 ns).
+    const MAX_SUSPEND_MINUTES: i64 = 365 * 24 * 60 * 100;
+
+    let minutes = i64::try_from(auto_suspend_minutes)
+        .unwrap_or(MAX_SUSPEND_MINUTES)
+        .min(MAX_SUSPEND_MINUTES);
+    let cutoff =
+        (Utc::now() - Duration::minutes(minutes)).to_rfc3339_opts(SecondsFormat::Millis, true);
+
+    let ids: Vec<(String,)> = sqlx::query_as(
+        "SELECT id FROM workspaces \
+         WHERE state = 'active' \
+         AND COALESCE(last_active_at, updated_at) < $1",
+    )
+    .bind(&cutoff)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(ids.into_iter().map(|(id,)| id).collect())
+}
+
+/// Suspend active workspaces that have exceeded the idle timeout.
+///
+/// Returns the IDs of workspaces that were successfully suspended.
+pub(crate) async fn auto_suspend_expired(
+    pool: &SqlitePool,
+    pty_state: &PtyManagerState,
+    auto_suspend_minutes: u64,
+) -> Result<Vec<String>, AppError> {
+    let expired_ids = find_expired_active_workspaces(pool, auto_suspend_minutes).await?;
+
+    let mut suspended_ids = Vec::new();
+    for ws_id in &expired_ids {
+        match workspace_suspend_inner(pool, pty_state, ws_id).await {
+            Ok(_) => {
+                info!("lifecycle: auto-suspended idle workspace '{ws_id}'");
+                suspended_ids.push(ws_id.clone());
+            }
+            Err(e) => {
+                warn!("lifecycle: failed to auto-suspend workspace '{ws_id}': {e}");
+            }
+        }
+    }
+
+    Ok(suspended_ids)
+}
+
+/// Run one lifecycle tick: auto-suspend idle workspaces and auto-archive
+/// workspaces whose PRs have been merged/closed past the configured delay.
+///
+/// Returns `(suspended_ids, archived_ids)`.
+pub(crate) async fn run_lifecycle_tick(
+    pool: &SqlitePool,
+    pty_state: &PtyManagerState,
+    auto_suspend_minutes: u64,
+    archive_delay_hours: u64,
+    archive_delay_closed_hours: u64,
+) -> (Vec<String>, Vec<String>) {
+    let suspended = auto_suspend_expired(pool, pty_state, auto_suspend_minutes)
+        .await
+        .unwrap_or_else(|e| {
+            warn!("lifecycle: auto-suspend check failed: {e}");
+            Vec::new()
+        });
+
+    let archived = workspace_cleanup_inner(
+        pool,
+        pty_state,
+        archive_delay_hours,
+        archive_delay_closed_hours,
+    )
+    .await
+    .unwrap_or_else(|e| {
+        warn!("lifecycle: auto-archive check failed: {e}");
+        Vec::new()
+    });
+
+    (suspended, archived)
+}
+
+/// Interval between lifecycle ticks in seconds.
+const LIFECYCLE_INTERVAL_SECS: u64 = 60;
+
+/// Start the background lifecycle task. Runs every 60 seconds.
+///
+/// Each tick reads the current config from the database, so changes to
+/// `auto_suspend_minutes` or `archive_delay_*` take effect without restart.
+///
+/// Emits `workspace:state_changed` for each suspended/archived workspace
+/// so the frontend stays in sync.
+pub fn start_workspace_lifecycle(
+    app_handle: tauri::AppHandle,
+    pool: SqlitePool,
+) -> tokio::task::JoinHandle<()> {
+    use tauri::Emitter;
+
+    tokio::spawn(async move {
+        let mut interval =
+            tokio::time::interval(std::time::Duration::from_secs(LIFECYCLE_INTERVAL_SECS));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        // Skip the immediate first tick — let the app finish startup.
+        interval.tick().await;
+
+        loop {
+            interval.tick().await;
+
+            let pty_state: tauri::State<'_, PtyManagerState> = app_handle.state();
+
+            let config = match crate::cache::config::get_config(&pool).await {
+                Ok(c) => c,
+                Err(e) => {
+                    warn!("lifecycle: failed to read config: {e}");
+                    continue;
+                }
+            };
+
+            let (suspended, archived) = run_lifecycle_tick(
+                &pool,
+                &pty_state,
+                config.auto_suspend_minutes,
+                config.archive_delay_hours,
+                config.archive_delay_closed_hours,
+            )
+            .await;
+
+            for ws_id in suspended.iter().chain(archived.iter()) {
+                if let Err(e) = app_handle.emit("workspace:state_changed", ws_id) {
+                    warn!("lifecycle: failed to emit state_changed for '{ws_id}': {e}");
+                }
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cache::db::init_db;
+    use crate::cache::repos::upsert_repo;
+    use crate::cache::workspaces::{create_workspace, get_workspace, update_last_active};
+    use crate::types::{Repo, Workspace, WorkspaceState};
+
+    async fn test_pool() -> (SqlitePool, tempfile::TempDir) {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let pool = init_db(&tmp.path().join("test.db")).await.unwrap();
+        (pool, tmp)
+    }
+
+    fn sample_repo() -> Repo {
+        Repo {
+            id: "repo-1".to_string(),
+            org: "mpiton".to_string(),
+            name: "prism".to_string(),
+            full_name: "mpiton/prism".to_string(),
+            url: "https://github.com/mpiton/prism".to_string(),
+            default_branch: "main".to_string(),
+            is_archived: false,
+            enabled: true,
+            local_path: None,
+            last_sync_at: None,
+        }
+    }
+
+    fn sample_workspace(id: &str, pr_number: u32) -> Workspace {
+        Workspace {
+            id: id.to_string(),
+            repo_id: "repo-1".to_string(),
+            pull_request_number: pr_number,
+            state: WorkspaceState::Active,
+            worktree_path: Some(format!(
+                "/home/user/.prism/workspaces/prism/worktrees/pr-{pr_number}"
+            )),
+            session_id: None,
+            created_at: "2026-03-20T10:00:00Z".to_string(),
+            updated_at: "2026-03-20T10:00:00Z".to_string(),
+        }
+    }
+
+    async fn insert_test_pr(
+        pool: &SqlitePool,
+        id: &str,
+        number: u32,
+        state: crate::types::PrState,
+        updated_at: &str,
+    ) {
+        use crate::types::{CiStatus, Priority, PullRequest};
+        let pr = PullRequest {
+            id: id.to_string(),
+            number,
+            title: format!("PR #{number}"),
+            author: "alice".to_string(),
+            state,
+            ci_status: CiStatus::Success,
+            priority: Priority::Medium,
+            repo_id: "repo-1".to_string(),
+            url: format!("https://github.com/mpiton/prism/pull/{number}"),
+            labels: vec![],
+            additions: 10,
+            deletions: 5,
+            created_at: "2026-03-01T00:00:00Z".to_string(),
+            updated_at: updated_at.to_string(),
+        };
+        crate::cache::pull_requests::upsert_pull_request(pool, &pr)
+            .await
+            .unwrap();
+    }
+
+    // ── Auto-suspend tests ───────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_auto_suspend_after_timeout() {
+        let (pool, _tmp) = test_pool().await;
+        upsert_repo(&pool, &sample_repo()).await.unwrap();
+
+        let ws = sample_workspace("ws-1", 42);
+        create_workspace(&pool, &ws).await.unwrap();
+
+        // Set last_active_at to 60 minutes ago (well past 30-minute timeout)
+        let old_ts =
+            (Utc::now() - Duration::minutes(60)).to_rfc3339_opts(SecondsFormat::Millis, true);
+        sqlx::query("UPDATE workspaces SET last_active_at = $1 WHERE id = $2")
+            .bind(&old_ts)
+            .bind("ws-1")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let pty_state = PtyManagerState::new();
+        let suspended = auto_suspend_expired(&pool, &pty_state, 30).await.unwrap();
+
+        assert_eq!(suspended.len(), 1);
+        assert_eq!(suspended[0], "ws-1");
+
+        let ws = get_workspace(&pool, "ws-1").await.unwrap().unwrap();
+        assert_eq!(ws.state, WorkspaceState::Suspended);
+
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_no_suspend_if_active() {
+        let (pool, _tmp) = test_pool().await;
+        upsert_repo(&pool, &sample_repo()).await.unwrap();
+
+        let ws = sample_workspace("ws-1", 42);
+        create_workspace(&pool, &ws).await.unwrap();
+
+        // Touch last_active_at to now — workspace is active
+        update_last_active(&pool, "ws-1").await.unwrap();
+
+        let pty_state = PtyManagerState::new();
+        let suspended = auto_suspend_expired(&pool, &pty_state, 30).await.unwrap();
+
+        assert!(
+            suspended.is_empty(),
+            "should not suspend recently active workspace"
+        );
+
+        let ws = get_workspace(&pool, "ws-1").await.unwrap().unwrap();
+        assert_eq!(ws.state, WorkspaceState::Active);
+
+        pool.close().await;
+    }
+
+    // ── Auto-archive via lifecycle tick ───────────────────────────────
+
+    #[tokio::test]
+    async fn test_auto_archive_merged_pr() {
+        let (pool, _tmp) = test_pool().await;
+        upsert_repo(&pool, &sample_repo()).await.unwrap();
+
+        // Merged PR with old updated_at (well past 24h delay)
+        insert_test_pr(
+            &pool,
+            "pr-1",
+            42,
+            crate::types::PrState::Merged,
+            "2026-03-01T00:00:00Z",
+        )
+        .await;
+
+        // Suspended workspace linked to this PR
+        let mut ws = sample_workspace("ws-1", 42);
+        ws.state = WorkspaceState::Suspended;
+        ws.worktree_path = None;
+        create_workspace(&pool, &ws).await.unwrap();
+
+        let pty_state = PtyManagerState::new();
+        let (_, archived) = run_lifecycle_tick(&pool, &pty_state, 30, 24, 48).await;
+
+        assert_eq!(archived.len(), 1);
+        assert_eq!(archived[0], "ws-1");
+
+        let ws = get_workspace(&pool, "ws-1").await.unwrap().unwrap();
+        assert_eq!(ws.state, WorkspaceState::Archived);
+
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_auto_archive_respects_delay() {
+        let (pool, _tmp) = test_pool().await;
+        upsert_repo(&pool, &sample_repo()).await.unwrap();
+
+        // Merged PR with very recent updated_at (within the 24h delay)
+        let recent = Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true);
+        insert_test_pr(&pool, "pr-1", 42, crate::types::PrState::Merged, &recent).await;
+
+        let mut ws = sample_workspace("ws-1", 42);
+        ws.state = WorkspaceState::Suspended;
+        ws.worktree_path = None;
+        create_workspace(&pool, &ws).await.unwrap();
+
+        let pty_state = PtyManagerState::new();
+        let (_, archived) = run_lifecycle_tick(&pool, &pty_state, 30, 24, 48).await;
+
+        assert!(
+            archived.is_empty(),
+            "should not archive workspace within delay"
+        );
+
+        let ws = get_workspace(&pool, "ws-1").await.unwrap().unwrap();
+        assert_eq!(
+            ws.state,
+            WorkspaceState::Suspended,
+            "workspace should remain suspended"
+        );
+
+        pool.close().await;
+    }
+}

--- a/src-tauri/src/workspace/lifecycle.rs
+++ b/src-tauri/src/workspace/lifecycle.rs
@@ -139,8 +139,27 @@ pub fn start_workspace_lifecycle(
             )
             .await;
 
-            for ws_id in suspended.iter().chain(archived.iter()) {
-                if let Err(e) = app_handle.emit("workspace:state_changed", ws_id) {
+            // Emit structured payloads matching the WorkspaceStateChanged contract.
+            // If a workspace was suspended and then archived in the same tick,
+            // skip the Suspended event — only emit the final Archived state.
+            for ws_id in &suspended {
+                if archived.contains(ws_id) {
+                    continue;
+                }
+                let payload = crate::types::WorkspaceStateChanged {
+                    workspace_id: ws_id.clone(),
+                    new_state: crate::types::WorkspaceState::Suspended,
+                };
+                if let Err(e) = app_handle.emit("workspace:state_changed", &payload) {
+                    warn!("lifecycle: failed to emit state_changed for '{ws_id}': {e}");
+                }
+            }
+            for ws_id in &archived {
+                let payload = crate::types::WorkspaceStateChanged {
+                    workspace_id: ws_id.clone(),
+                    new_state: crate::types::WorkspaceState::Archived,
+                };
+                if let Err(e) = app_handle.emit("workspace:state_changed", &payload) {
                     warn!("lifecycle: failed to emit state_changed for '{ws_id}': {e}");
                 }
             }

--- a/src-tauri/src/workspace/mod.rs
+++ b/src-tauri/src/workspace/mod.rs
@@ -1,3 +1,4 @@
 pub mod claude;
+pub mod lifecycle;
 pub mod pty;
 pub mod worktree;

--- a/src/components/Settings/Settings.test.tsx
+++ b/src/components/Settings/Settings.test.tsx
@@ -40,6 +40,7 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
   return {
     pollIntervalSecs: 300,
     maxActiveWorkspaces: 3,
+    autoSuspendMinutes: 30,
     githubToken: "test-token",
     dataDir: null,
     workspacesDir: null,

--- a/src/lib/types.test.ts
+++ b/src/lib/types.test.ts
@@ -383,6 +383,7 @@ describe("IPC payload shapes", () => {
     const json = {
       pollIntervalSecs: 300,
       maxActiveWorkspaces: 3,
+      autoSuspendMinutes: 30,
       githubToken: null,
       dataDir: null,
       workspacesDir: null,
@@ -397,6 +398,7 @@ describe("IPC payload shapes", () => {
     const json = {
       pollIntervalSecs: 120,
       maxActiveWorkspaces: 5,
+      autoSuspendMinutes: 30,
       githubToken: "ghp_xxx",
       dataDir: "/custom/data",
       workspacesDir: "/custom/workspaces",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -210,6 +210,8 @@ export interface AppConfig {
   /** Rust type is u64 — safe as `number` since practical values never exceed 2^53. */
   readonly pollIntervalSecs: number;
   readonly maxActiveWorkspaces: number;
+  /** Minutes of inactivity before an active workspace is auto-suspended (min 5, default 30). */
+  readonly autoSuspendMinutes: number;
   readonly githubToken: string | null;
   readonly dataDir: string | null;
   readonly workspacesDir: string | null;
@@ -224,6 +226,7 @@ export interface AppConfig {
 export interface PartialAppConfig {
   readonly pollIntervalSecs?: number;
   readonly maxActiveWorkspaces?: number;
+  readonly autoSuspendMinutes?: number;
   /** undefined = leave unchanged, null = clear token, string = set token.
    * Prefer `authSetToken` for validated token updates. */
   readonly githubToken?: string | null;

--- a/src/stores/settings.test.ts
+++ b/src/stores/settings.test.ts
@@ -5,6 +5,7 @@ import type { AppConfig } from "../lib/types";
 const fakeConfig: AppConfig = {
   pollIntervalSecs: 60,
   maxActiveWorkspaces: 3,
+  autoSuspendMinutes: 30,
   githubToken: "FAKE_TOKEN_FOR_TESTING",
   dataDir: "/home/user/.local/share/prism",
   workspacesDir: "/home/user/.prism/workspaces",
@@ -30,6 +31,7 @@ describe("useSettingsStore", () => {
     const minimal: AppConfig = {
       pollIntervalSecs: 30,
       maxActiveWorkspaces: 1,
+      autoSuspendMinutes: 30,
       githubToken: null,
       dataDir: null,
       workspacesDir: null,


### PR DESCRIPTION
## Summary

- Add background lifecycle task (60s interval) that auto-suspends idle workspaces and auto-archives workspaces whose PRs are merged/closed past the configured delay
- Add `auto_suspend_minutes` config key (default 30min, minimum 5min) to `AppConfig`/`PartialAppConfig` with DB persistence and value clamping
- Update `pty_write` to touch `last_active_at` on every keystroke via reverse PTY→workspace lookup (poison-safe mutex recovery)
- Wire lifecycle task into Tauri setup with `MissedTickBehavior::Skip` and safe `i64` overflow capping

## Files changed

| File | Change |
|------|--------|
| `src-tauri/src/workspace/lifecycle.rs` | **NEW** — `find_expired_active_workspaces`, `auto_suspend_expired`, `run_lifecycle_tick`, `start_workspace_lifecycle` |
| `src-tauri/src/workspace/mod.rs` | Add `lifecycle` module export |
| `src-tauri/src/types.rs` | Add `auto_suspend_minutes` to `AppConfig`, `PartialAppConfig`, `merge_partial_config` |
| `src-tauri/src/cache/config.rs` | Add `KEY_AUTO_SUSPEND`, clamping, parsing, persistence |
| `src-tauri/src/commands.rs` | Add `lookup_workspace_by_pty` to `PtyManagerState`, update `pty_write` |
| `src-tauri/src/lib.rs` | Wire lifecycle task into Tauri setup |

## Test plan

- [x] `test_auto_suspend_after_timeout` — workspace with expired `last_active_at` gets suspended
- [x] `test_no_suspend_if_active` — recently active workspace stays active
- [x] `test_auto_archive_merged_pr` — suspended workspace with old merged PR gets archived
- [x] `test_auto_archive_respects_delay` — recently merged PR workspace NOT archived
- [x] 302 Rust tests pass, clippy clean
- [x] 402 frontend tests pass (no regression)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements T-080: adds a 60s background lifecycle task that auto-suspends idle workspaces and auto-archives workspaces once their PRs are merged/closed. Emits structured events and throttles activity updates to cut DB writes.

- **New Features**
  - Background lifecycle runner (60s, `MissedTickBehavior::Skip`) reads config each tick; auto-suspends after `auto_suspend_minutes` and auto-archives per `archive_delay_hours`/`archive_delay_closed_hours`.
  - `pty_write` updates `last_active_at` via reverse PTY→workspace lookup, throttled to once every 5s per workspace.
  - Emits `workspace:state_changed` with `WorkspaceStateChanged` payload; deduplicates when a workspace is suspended and archived in the same tick.
  - Adds `auto_suspend_minutes` to `AppConfig`/`PartialAppConfig` with DB persistence and min-value clamping; adds `autoSuspendMinutes` to TS `AppConfig`/`PartialAppConfig` and backfills TS test fixtures.

- **Bug Fixes**
  - Clean up `last_touch` throttle entries on PTY unregister/kill to prevent unbounded growth.

<sup>Written for commit e1a9467ca0db1fd61ce38264b1488f57b2d21b75. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable auto-suspend (minutes) with a background lifecycle that auto-suspends and archives idle workspaces on a schedule
  * Terminal activity now updates workspace last-active time so idle detection is more accurate

* **Bug Fixes / Stability**
  * Auto-suspend values are validated and clamped with warnings to prevent invalid settings; lifecycle processing is resilient and does not disrupt regular commands

* **Tests**
  * Added and updated tests for auto-suspend validation, clamping, lifecycle ticks, and activity suppression
<!-- end of auto-generated comment: release notes by coderabbit.ai -->