### PR TITLE
feat(workspace): LRU eviction for max active workspaces (T-081)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -609,28 +609,14 @@ pub(crate) async fn workspace_open_inner(
 
     // 7. LRU eviction — deferred until AFTER the new workspace is safely created.
     //    Best-effort: eviction failures must not fail the already-created workspace.
-    //    Note: SQLite serialises writes, so concurrent opens are not a realistic
-    //    race for this single-window desktop app.
-    if let Ok(active) = list_workspaces(pool, Some(&WorkspaceState::Active)).await {
-        if active.len() > config.max_active_workspaces as usize {
-            // Suspend the oldest active workspace (last in updated_at DESC list),
-            // skipping the one we just created.
-            if let Some(oldest) = active.iter().rev().find(|w| w.id != workspace_id) {
-                if let Some(old_pty) = pty_state.unregister(&oldest.id) {
-                    let _ = pty_state.manager.kill(&old_pty);
-                }
-                match update_workspace_state(pool, &oldest.id, &WorkspaceState::Suspended, None)
-                    .await
-                {
-                    Ok(evicted) => spawn_suspension_note(pool, &evicted),
-                    Err(e) => {
-                        log::warn!("failed to suspend evicted workspace {}: {e}", oldest.id);
-                    }
-                }
-            }
-        }
-    } else {
-        log::warn!("failed to list active workspaces for LRU eviction");
+    if let Err(e) = crate::workspace::lifecycle::enforce_max_active(
+        pool,
+        pty_state,
+        config.max_active_workspaces,
+    )
+    .await
+    {
+        log::warn!("LRU eviction failed: {e}");
     }
 
     Ok(OpenWorkspaceResponse {

--- a/src-tauri/src/workspace/lifecycle.rs
+++ b/src-tauri/src/workspace/lifecycle.rs
@@ -61,6 +61,51 @@ pub(crate) async fn auto_suspend_expired(
     Ok(suspended_ids)
 }
 
+/// Enforce the maximum number of active workspaces (LRU eviction).
+///
+/// Counts active workspaces and, if the count exceeds `max`, suspends
+/// the oldest ones (by `last_active_at` ASC, falling back to `updated_at`)
+/// until the active count is within the limit.
+///
+/// Returns the IDs of workspaces that were successfully suspended.
+pub(crate) async fn enforce_max_active(
+    pool: &SqlitePool,
+    pty_state: &PtyManagerState,
+    max: u32,
+) -> Result<Vec<String>, AppError> {
+    let max = max as usize;
+
+    // Oldest first — candidates for eviction are at the front.
+    let candidates: Vec<(String,)> = sqlx::query_as(
+        "SELECT id FROM workspaces \
+         WHERE state = 'active' \
+         ORDER BY COALESCE(last_active_at, updated_at) ASC",
+    )
+    .fetch_all(pool)
+    .await?;
+
+    if candidates.len() <= max {
+        return Ok(Vec::new());
+    }
+
+    let to_evict = candidates.len() - max;
+    let mut suspended_ids = Vec::new();
+
+    for (ws_id,) in candidates.into_iter().take(to_evict) {
+        match workspace_suspend_inner(pool, pty_state, &ws_id).await {
+            Ok(_) => {
+                info!("lifecycle: LRU-evicted workspace '{ws_id}'");
+                suspended_ids.push(ws_id);
+            }
+            Err(e) => {
+                warn!("lifecycle: failed to LRU-evict workspace '{ws_id}': {e}");
+            }
+        }
+    }
+
+    Ok(suspended_ids)
+}
+
 /// Run one lifecycle tick: auto-suspend idle workspaces and auto-archive
 /// workspaces whose PRs have been merged/closed past the configured delay.
 ///
@@ -293,6 +338,158 @@ mod tests {
 
         let ws = get_workspace(&pool, "ws-1").await.unwrap().unwrap();
         assert_eq!(ws.state, WorkspaceState::Active);
+
+        pool.close().await;
+    }
+
+    // ── LRU eviction tests ─────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_lru_no_eviction_under_limit() {
+        let (pool, _tmp) = test_pool().await;
+        upsert_repo(&pool, &sample_repo()).await.unwrap();
+
+        // 2 active workspaces, max = 3 → no eviction
+        create_workspace(&pool, &sample_workspace("ws-1", 42))
+            .await
+            .unwrap();
+        create_workspace(&pool, &sample_workspace("ws-2", 43))
+            .await
+            .unwrap();
+
+        let ts1 = (Utc::now() - Duration::minutes(10)).to_rfc3339_opts(SecondsFormat::Millis, true);
+        let ts2 = (Utc::now() - Duration::minutes(5)).to_rfc3339_opts(SecondsFormat::Millis, true);
+        sqlx::query("UPDATE workspaces SET last_active_at = $1 WHERE id = $2")
+            .bind(&ts1)
+            .bind("ws-1")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("UPDATE workspaces SET last_active_at = $1 WHERE id = $2")
+            .bind(&ts2)
+            .bind("ws-2")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let pty_state = PtyManagerState::new();
+        let evicted = enforce_max_active(&pool, &pty_state, 3).await.unwrap();
+
+        assert!(evicted.is_empty(), "should not evict when under limit");
+        assert_eq!(
+            get_workspace(&pool, "ws-1").await.unwrap().unwrap().state,
+            WorkspaceState::Active
+        );
+        assert_eq!(
+            get_workspace(&pool, "ws-2").await.unwrap().unwrap().state,
+            WorkspaceState::Active
+        );
+
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_lru_evicts_oldest() {
+        let (pool, _tmp) = test_pool().await;
+        upsert_repo(&pool, &sample_repo()).await.unwrap();
+
+        // 4 active workspaces, max = 3 → evict 1 (the oldest)
+        for (id, pr) in [("ws-1", 42), ("ws-2", 43), ("ws-3", 44), ("ws-4", 45)] {
+            create_workspace(&pool, &sample_workspace(id, pr))
+                .await
+                .unwrap();
+        }
+
+        // ws-1: 40 min ago (oldest), ws-2: 30, ws-3: 20, ws-4: 10
+        for (id, mins) in [("ws-1", 40), ("ws-2", 30), ("ws-3", 20), ("ws-4", 10)] {
+            let ts =
+                (Utc::now() - Duration::minutes(mins)).to_rfc3339_opts(SecondsFormat::Millis, true);
+            sqlx::query("UPDATE workspaces SET last_active_at = $1 WHERE id = $2")
+                .bind(&ts)
+                .bind(id)
+                .execute(&pool)
+                .await
+                .unwrap();
+        }
+
+        let pty_state = PtyManagerState::new();
+        let evicted = enforce_max_active(&pool, &pty_state, 3).await.unwrap();
+
+        assert_eq!(evicted.len(), 1);
+        assert_eq!(evicted[0], "ws-1");
+
+        assert_eq!(
+            get_workspace(&pool, "ws-1").await.unwrap().unwrap().state,
+            WorkspaceState::Suspended
+        );
+        // Others remain active
+        for id in ["ws-2", "ws-3", "ws-4"] {
+            assert_eq!(
+                get_workspace(&pool, id).await.unwrap().unwrap().state,
+                WorkspaceState::Active
+            );
+        }
+
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_lru_evicts_multiple() {
+        let (pool, _tmp) = test_pool().await;
+        upsert_repo(&pool, &sample_repo()).await.unwrap();
+
+        // 5 active workspaces, max = 3 → evict 2 (the 2 oldest)
+        for (id, pr) in [
+            ("ws-1", 42),
+            ("ws-2", 43),
+            ("ws-3", 44),
+            ("ws-4", 45),
+            ("ws-5", 46),
+        ] {
+            create_workspace(&pool, &sample_workspace(id, pr))
+                .await
+                .unwrap();
+        }
+
+        // ws-1: 50 min ago (oldest), ws-2: 40, ws-3: 30, ws-4: 20, ws-5: 10
+        for (id, mins) in [
+            ("ws-1", 50),
+            ("ws-2", 40),
+            ("ws-3", 30),
+            ("ws-4", 20),
+            ("ws-5", 10),
+        ] {
+            let ts =
+                (Utc::now() - Duration::minutes(mins)).to_rfc3339_opts(SecondsFormat::Millis, true);
+            sqlx::query("UPDATE workspaces SET last_active_at = $1 WHERE id = $2")
+                .bind(&ts)
+                .bind(id)
+                .execute(&pool)
+                .await
+                .unwrap();
+        }
+
+        let pty_state = PtyManagerState::new();
+        let evicted = enforce_max_active(&pool, &pty_state, 3).await.unwrap();
+
+        assert_eq!(evicted.len(), 2);
+        assert!(evicted.contains(&"ws-1".to_string()));
+        assert!(evicted.contains(&"ws-2".to_string()));
+
+        // ws-1 and ws-2 suspended
+        for id in ["ws-1", "ws-2"] {
+            assert_eq!(
+                get_workspace(&pool, id).await.unwrap().unwrap().state,
+                WorkspaceState::Suspended
+            );
+        }
+        // ws-3, ws-4, ws-5 remain active
+        for id in ["ws-3", "ws-4", "ws-5"] {
+            assert_eq!(
+                get_workspace(&pool, id).await.unwrap().unwrap().state,
+                WorkspaceState::Active
+            );
+        }
 
         pool.close().await;
     }

--- a/src-tauri/src/workspace/lifecycle.rs
+++ b/src-tauri/src/workspace/lifecycle.rs
@@ -494,6 +494,84 @@ mod tests {
         pool.close().await;
     }
 
+    #[tokio::test]
+    async fn test_lru_evicts_all_when_max_zero() {
+        let (pool, _tmp) = test_pool().await;
+        upsert_repo(&pool, &sample_repo()).await.unwrap();
+
+        for (id, pr) in [("ws-1", 42), ("ws-2", 43)] {
+            create_workspace(&pool, &sample_workspace(id, pr))
+                .await
+                .unwrap();
+        }
+        for (id, mins) in [("ws-1", 20), ("ws-2", 10)] {
+            let ts =
+                (Utc::now() - Duration::minutes(mins)).to_rfc3339_opts(SecondsFormat::Millis, true);
+            sqlx::query("UPDATE workspaces SET last_active_at = $1 WHERE id = $2")
+                .bind(&ts)
+                .bind(id)
+                .execute(&pool)
+                .await
+                .unwrap();
+        }
+
+        let pty_state = PtyManagerState::new();
+        let evicted = enforce_max_active(&pool, &pty_state, 0).await.unwrap();
+
+        assert_eq!(evicted.len(), 2);
+        for id in ["ws-1", "ws-2"] {
+            assert_eq!(
+                get_workspace(&pool, id).await.unwrap().unwrap().state,
+                WorkspaceState::Suspended
+            );
+        }
+
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_lru_falls_back_to_updated_at_when_last_active_null() {
+        let (pool, _tmp) = test_pool().await;
+        upsert_repo(&pool, &sample_repo()).await.unwrap();
+
+        // Create workspaces with different updated_at but NULL last_active_at
+        for (id, pr) in [("ws-1", 42), ("ws-2", 43), ("ws-3", 44)] {
+            create_workspace(&pool, &sample_workspace(id, pr))
+                .await
+                .unwrap();
+        }
+
+        // Set updated_at directly (last_active_at stays NULL)
+        // ws-1 oldest, ws-3 newest
+        for (id, mins) in [("ws-1", 30), ("ws-2", 20), ("ws-3", 10)] {
+            let ts =
+                (Utc::now() - Duration::minutes(mins)).to_rfc3339_opts(SecondsFormat::Millis, true);
+            sqlx::query(
+                "UPDATE workspaces SET updated_at = $1, last_active_at = NULL WHERE id = $2",
+            )
+            .bind(&ts)
+            .bind(id)
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+
+        let pty_state = PtyManagerState::new();
+        let evicted = enforce_max_active(&pool, &pty_state, 2).await.unwrap();
+
+        assert_eq!(evicted.len(), 1);
+        assert_eq!(
+            evicted[0], "ws-1",
+            "should evict oldest by updated_at fallback"
+        );
+        assert_eq!(
+            get_workspace(&pool, "ws-1").await.unwrap().unwrap().state,
+            WorkspaceState::Suspended
+        );
+
+        pool.close().await;
+    }
+
     // ── Auto-archive via lifecycle tick ───────────────────────────────
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Add `enforce_max_active(pool, pty_state, max)` in `lifecycle.rs` that counts active workspaces and suspends the oldest (by `last_active_at` ASC) until within the configured limit
- Replace inline LRU eviction logic in `workspace_open_inner` with a call to the new function
- Supports evicting multiple workspaces when count exceeds max by more than one (previous inline code only evicted one)

## Test plan

- [x] `test_lru_no_eviction_under_limit` — 2 active, max 3, no eviction
- [x] `test_lru_evicts_oldest` — 4 active, max 3, evicts oldest
- [x] `test_lru_evicts_multiple` — 5 active, max 3, evicts 2 oldest
- [x] All 306 existing tests pass (no regressions)
- [x] Clippy clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add centralized LRU eviction to enforce the max number of active workspaces (T-081). We suspend the oldest by last activity until within the limit, including multiple at once; edge cases like max=0 and NULL `last_active_at` are covered.

- **New Features**
  - Added lifecycle `enforce_max_active(...)` that orders by `last_active_at` (fallback `updated_at`) and suspends oldest until under the limit.
  - Added tests for max=0 and NULL `last_active_at` to validate eviction order.

- **Refactors**
  - Replaced inline eviction in `workspace_open_inner` with a call to `enforce_max_active` after creation; failures are logged and do not block opening.

<sup>Written for commit e993ab527c07c04e86e040134c9a49b94c1c7842. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Workspace lifecycle now enforces the configured maximum of active workspaces with LRU-style suspension of oldest sessions and clearer single-line warning if eviction fails.
* **Tests**
  * Added unit tests covering eviction behavior: no-evict, single/multiple evictions, evict-all (max=0), and ordering when last-active timestamps are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->