### PR TITLE
feat: add useWorkspace hook for real-time workspace state sync (T-082)

### DIFF
--- a/src/hooks/useWorkspace.test.ts
+++ b/src/hooks/useWorkspace.test.ts
@@ -221,8 +221,10 @@ describe("useWorkspace", () => {
 
     unmount();
 
-    expect(unlistenStateChanged).toHaveBeenCalledOnce();
-    expect(unlistenClaudeSession).toHaveBeenCalledOnce();
+    await waitFor(() => {
+      expect(unlistenStateChanged).toHaveBeenCalledOnce();
+      expect(unlistenClaudeSession).toHaveBeenCalledOnce();
+    });
   });
 
   it("should not flag suspended workspace when it is not the active one", async () => {
@@ -280,6 +282,40 @@ describe("useWorkspace", () => {
 
     await act(() => {
       handler({ workspaceId: "ws-1", newState: "active" });
+    });
+
+    expect(result.current.suspendedActiveWorkspace).toBeNull();
+  });
+
+  it("should clear suspended notice when workspace is archived", async () => {
+    (useWorkspacesStore as unknown as Mock).mockImplementation((selector: (s: { activeWorkspaceId: string | null }) => unknown) =>
+      selector({ activeWorkspaceId: "ws-1" }),
+    );
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useWorkspace(), { wrapper });
+
+    await waitFor(() => {
+      expect(onEvent).toHaveBeenCalledWith(
+        "workspace:state_changed",
+        expect.any(Function),
+      );
+    });
+
+    const handler = getEventHandler<{ workspaceId: string; newState: WorkspaceState }>(
+      "workspace:state_changed",
+    );
+
+    await act(() => {
+      handler({ workspaceId: "ws-1", newState: "suspended" });
+    });
+
+    await waitFor(() => {
+      expect(result.current.suspendedActiveWorkspace).toBe("ws-1");
+    });
+
+    await act(() => {
+      handler({ workspaceId: "ws-1", newState: "archived" });
     });
 
     expect(result.current.suspendedActiveWorkspace).toBeNull();

--- a/src/hooks/useWorkspace.test.ts
+++ b/src/hooks/useWorkspace.test.ts
@@ -144,6 +144,9 @@ describe("useWorkspace", () => {
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ["workspaces"],
     });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ["github", "dashboard"],
+    });
   });
 
   it("should show message when active workspace suspended", async () => {
@@ -246,5 +249,76 @@ describe("useWorkspace", () => {
     });
 
     expect(result.current.suspendedActiveWorkspace).toBeNull();
+  });
+
+  it("should clear suspended notice when workspace resumes", async () => {
+    (useWorkspacesStore as unknown as Mock).mockImplementation((selector: (s: { activeWorkspaceId: string | null }) => unknown) =>
+      selector({ activeWorkspaceId: "ws-1" }),
+    );
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useWorkspace(), { wrapper });
+
+    await waitFor(() => {
+      expect(onEvent).toHaveBeenCalledWith(
+        "workspace:state_changed",
+        expect.any(Function),
+      );
+    });
+
+    const handler = getEventHandler<{ workspaceId: string; newState: WorkspaceState }>(
+      "workspace:state_changed",
+    );
+
+    await act(() => {
+      handler({ workspaceId: "ws-1", newState: "suspended" });
+    });
+
+    await waitFor(() => {
+      expect(result.current.suspendedActiveWorkspace).toBe("ws-1");
+    });
+
+    await act(() => {
+      handler({ workspaceId: "ws-1", newState: "active" });
+    });
+
+    expect(result.current.suspendedActiveWorkspace).toBeNull();
+  });
+
+  it("should clear stale notice when active workspace changes", async () => {
+    let currentActiveId: string | null = "ws-1";
+    (useWorkspacesStore as unknown as Mock).mockImplementation((selector: (s: { activeWorkspaceId: string | null }) => unknown) =>
+      selector({ activeWorkspaceId: currentActiveId }),
+    );
+
+    const { wrapper } = createWrapper();
+    const { result, rerender } = renderHook(() => useWorkspace(), { wrapper });
+
+    await waitFor(() => {
+      expect(onEvent).toHaveBeenCalledWith(
+        "workspace:state_changed",
+        expect.any(Function),
+      );
+    });
+
+    const handler = getEventHandler<{ workspaceId: string; newState: WorkspaceState }>(
+      "workspace:state_changed",
+    );
+
+    await act(() => {
+      handler({ workspaceId: "ws-1", newState: "suspended" });
+    });
+
+    await waitFor(() => {
+      expect(result.current.suspendedActiveWorkspace).toBe("ws-1");
+    });
+
+    // Switch active workspace
+    currentActiveId = "ws-2";
+    rerender();
+
+    await waitFor(() => {
+      expect(result.current.suspendedActiveWorkspace).toBeNull();
+    });
   });
 });

--- a/src/hooks/useWorkspace.test.ts
+++ b/src/hooks/useWorkspace.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createElement, type ReactNode } from "react";
+import { useWorkspace } from "./useWorkspace";
+import type { Workspace, WorkspaceState } from "../lib/types";
+
+vi.mock("../lib/tauri", () => ({
+  listWorkspaces: vi.fn(),
+  onEvent: vi.fn(),
+}));
+
+vi.mock("../stores/workspaces", () => ({
+  useWorkspacesStore: vi.fn(),
+}));
+
+import { listWorkspaces, onEvent } from "../lib/tauri";
+import { useWorkspacesStore } from "../stores/workspaces";
+
+const MOCK_WORKSPACES: readonly Workspace[] = [
+  {
+    id: "ws-1",
+    repoId: "repo-1",
+    pullRequestNumber: 42,
+    state: "active",
+    worktreePath: "/tmp/ws-1",
+    sessionId: null,
+    createdAt: "2026-03-30T10:00:00Z",
+    updatedAt: "2026-03-30T10:00:00Z",
+  },
+  {
+    id: "ws-2",
+    repoId: "repo-1",
+    pullRequestNumber: 43,
+    state: "suspended",
+    worktreePath: "/tmp/ws-2",
+    sessionId: "session-abc",
+    createdAt: "2026-03-30T09:00:00Z",
+    updatedAt: "2026-03-30T09:00:00Z",
+  },
+];
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return {
+    queryClient,
+    wrapper: ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children),
+  };
+}
+
+function getEventHandler<T>(eventName: string): (payload: T) => void {
+  const call = (onEvent as Mock).mock.calls.find(
+    (c: unknown[]) => c[0] === eventName,
+  );
+  if (!call) throw new Error(`No onEvent call registered for "${eventName}"`);
+  return call[1] as (payload: T) => void;
+}
+
+describe("useWorkspace", () => {
+  let unlistenStateChanged: Mock;
+  let unlistenClaudeSession: Mock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    unlistenStateChanged = vi.fn();
+    unlistenClaudeSession = vi.fn();
+    (onEvent as Mock)
+      .mockResolvedValueOnce(unlistenStateChanged)
+      .mockResolvedValueOnce(unlistenClaudeSession);
+    (listWorkspaces as Mock).mockResolvedValue(MOCK_WORKSPACES);
+    (useWorkspacesStore as unknown as Mock).mockImplementation((selector: (s: { activeWorkspaceId: string | null }) => unknown) =>
+      selector({ activeWorkspaceId: null }),
+    );
+  });
+
+  it("should fetch workspaces via TanStack Query", async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useWorkspace(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.workspaces).toEqual(MOCK_WORKSPACES);
+    expect(listWorkspaces).toHaveBeenCalledOnce();
+  });
+
+  it("should update on state_changed event", async () => {
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    renderHook(() => useWorkspace(), { wrapper });
+
+    await waitFor(() => {
+      expect(onEvent).toHaveBeenCalledWith(
+        "workspace:state_changed",
+        expect.any(Function),
+      );
+    });
+
+    const handler = getEventHandler<{ workspaceId: string; newState: WorkspaceState }>(
+      "workspace:state_changed",
+    );
+
+    await act(() => {
+      handler({ workspaceId: "ws-1", newState: "suspended" });
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ["workspaces"],
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ["github", "dashboard"],
+    });
+  });
+
+  it("should invalidate queries on claude_session event", async () => {
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    renderHook(() => useWorkspace(), { wrapper });
+
+    await waitFor(() => {
+      expect(onEvent).toHaveBeenCalledWith(
+        "workspace:claude_session",
+        expect.any(Function),
+      );
+    });
+
+    const handler = getEventHandler<{ workspaceId: string; sessionId: string }>(
+      "workspace:claude_session",
+    );
+
+    await act(() => {
+      handler({ workspaceId: "ws-1", sessionId: "session-xyz" });
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ["workspaces"],
+    });
+  });
+
+  it("should show message when active workspace suspended", async () => {
+    (useWorkspacesStore as unknown as Mock).mockImplementation((selector: (s: { activeWorkspaceId: string | null }) => unknown) =>
+      selector({ activeWorkspaceId: "ws-1" }),
+    );
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useWorkspace(), { wrapper });
+
+    await waitFor(() => {
+      expect(onEvent).toHaveBeenCalledWith(
+        "workspace:state_changed",
+        expect.any(Function),
+      );
+    });
+
+    const handler = getEventHandler<{ workspaceId: string; newState: WorkspaceState }>(
+      "workspace:state_changed",
+    );
+
+    await act(() => {
+      handler({ workspaceId: "ws-1", newState: "suspended" });
+    });
+
+    await waitFor(() => {
+      expect(result.current.suspendedActiveWorkspace).toBe("ws-1");
+    });
+  });
+
+  it("should clear suspended message after acknowledgement", async () => {
+    (useWorkspacesStore as unknown as Mock).mockImplementation((selector: (s: { activeWorkspaceId: string | null }) => unknown) =>
+      selector({ activeWorkspaceId: "ws-1" }),
+    );
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useWorkspace(), { wrapper });
+
+    await waitFor(() => {
+      expect(onEvent).toHaveBeenCalledWith(
+        "workspace:state_changed",
+        expect.any(Function),
+      );
+    });
+
+    const handler = getEventHandler<{ workspaceId: string; newState: WorkspaceState }>(
+      "workspace:state_changed",
+    );
+
+    await act(() => {
+      handler({ workspaceId: "ws-1", newState: "suspended" });
+    });
+
+    await waitFor(() => {
+      expect(result.current.suspendedActiveWorkspace).toBe("ws-1");
+    });
+
+    act(() => {
+      result.current.dismissSuspendedNotice();
+    });
+
+    expect(result.current.suspendedActiveWorkspace).toBeNull();
+  });
+
+  it("should call unlisten on unmount", async () => {
+    const { wrapper } = createWrapper();
+    const { unmount } = renderHook(() => useWorkspace(), { wrapper });
+
+    await waitFor(() => {
+      expect(onEvent).toHaveBeenCalledTimes(2);
+    });
+
+    unmount();
+
+    expect(unlistenStateChanged).toHaveBeenCalledOnce();
+    expect(unlistenClaudeSession).toHaveBeenCalledOnce();
+  });
+
+  it("should not flag suspended workspace when it is not the active one", async () => {
+    (useWorkspacesStore as unknown as Mock).mockImplementation((selector: (s: { activeWorkspaceId: string | null }) => unknown) =>
+      selector({ activeWorkspaceId: "ws-2" }),
+    );
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useWorkspace(), { wrapper });
+
+    await waitFor(() => {
+      expect(onEvent).toHaveBeenCalledWith(
+        "workspace:state_changed",
+        expect.any(Function),
+      );
+    });
+
+    const handler = getEventHandler<{ workspaceId: string; newState: WorkspaceState }>(
+      "workspace:state_changed",
+    );
+
+    await act(() => {
+      handler({ workspaceId: "ws-1", newState: "suspended" });
+    });
+
+    expect(result.current.suspendedActiveWorkspace).toBeNull();
+  });
+});

--- a/src/hooks/useWorkspace.ts
+++ b/src/hooks/useWorkspace.ts
@@ -75,7 +75,7 @@ export function useWorkspace(): UseWorkspaceResult {
         if (!cancelled && payload.workspaceId === activeIdRef.current) {
           if (payload.newState === "suspended") {
             setSuspendedActiveWorkspace(payload.workspaceId);
-          } else if (payload.newState === "active") {
+          } else if (payload.newState !== "suspended") {
             setSuspendedActiveWorkspace(null);
           }
         }

--- a/src/hooks/useWorkspace.ts
+++ b/src/hooks/useWorkspace.ts
@@ -1,0 +1,129 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { listWorkspaces, onEvent } from "../lib/tauri";
+import { TAURI_EVENTS } from "../lib/types";
+import type { Workspace, WorkspaceState } from "../lib/types";
+import { useWorkspacesStore } from "../stores/workspaces";
+
+const STALE_TIME = 30_000;
+
+interface StateChangedPayload {
+  readonly workspaceId: string;
+  readonly newState: WorkspaceState;
+}
+
+interface ClaudeSessionPayload {
+  readonly workspaceId: string;
+  readonly sessionId: string;
+}
+
+interface UseWorkspaceResult {
+  readonly workspaces: Workspace[] | null;
+  readonly isLoading: boolean;
+  readonly error: Error | null;
+  readonly suspendedActiveWorkspace: string | null;
+  readonly dismissSuspendedNotice: () => void;
+}
+
+function invalidateWorkspaceQueries(
+  queryClient: ReturnType<typeof useQueryClient>,
+) {
+  return Promise.all([
+    queryClient.invalidateQueries({ queryKey: ["workspaces"] }),
+    queryClient.invalidateQueries({ queryKey: ["github", "dashboard"] }),
+  ]);
+}
+
+export function useWorkspace(): UseWorkspaceResult {
+  const queryClient = useQueryClient();
+  const activeWorkspaceId = useWorkspacesStore((s) => s.activeWorkspaceId);
+  const [suspendedActiveWorkspace, setSuspendedActiveWorkspace] = useState<
+    string | null
+  >(null);
+
+  // Keep a ref so the event handler always sees the latest value
+  const activeIdRef = useRef(activeWorkspaceId);
+  activeIdRef.current = activeWorkspaceId;
+
+  const workspacesQuery = useQuery({
+    queryKey: ["workspaces"],
+    queryFn: listWorkspaces,
+    staleTime: STALE_TIME,
+  });
+
+  // Each effect invocation creates its own `cancelled` closure. On cleanup,
+  // `cancelled` is set to `true` so that:
+  // (a) any pending `onEvent` promise resolves and immediately unlistens, and
+  // (b) async handlers skip state updates if the component has unmounted.
+  useEffect(() => {
+    let cancelled = false;
+    let unlistenState: (() => void) | undefined;
+    let unlistenClaude: (() => void) | undefined;
+
+    onEvent<StateChangedPayload>(
+      TAURI_EVENTS["workspace:state_changed"],
+      async (payload) => {
+        await invalidateWorkspaceQueries(queryClient);
+
+        if (
+          !cancelled &&
+          payload.workspaceId === activeIdRef.current &&
+          payload.newState === "suspended"
+        ) {
+          setSuspendedActiveWorkspace(payload.workspaceId);
+        }
+      },
+    )
+      .then((fn) => {
+        if (cancelled) {
+          fn();
+        } else {
+          unlistenState = fn;
+        }
+      })
+      .catch((err: unknown) => {
+        console.error(
+          "[useWorkspace] failed to register workspace:state_changed listener:",
+          err,
+        );
+      });
+
+    onEvent<ClaudeSessionPayload>(
+      TAURI_EVENTS["workspace:claude_session"],
+      async () => {
+        await invalidateWorkspaceQueries(queryClient);
+      },
+    )
+      .then((fn) => {
+        if (cancelled) {
+          fn();
+        } else {
+          unlistenClaude = fn;
+        }
+      })
+      .catch((err: unknown) => {
+        console.error(
+          "[useWorkspace] failed to register workspace:claude_session listener:",
+          err,
+        );
+      });
+
+    return () => {
+      cancelled = true;
+      unlistenState?.();
+      unlistenClaude?.();
+    };
+  }, [queryClient]);
+
+  const dismissSuspendedNotice = useCallback(() => {
+    setSuspendedActiveWorkspace(null);
+  }, []);
+
+  return {
+    workspaces: workspacesQuery.data ?? null,
+    isLoading: workspacesQuery.isLoading,
+    error: workspacesQuery.error ?? null,
+    suspendedActiveWorkspace,
+    dismissSuspendedNotice,
+  };
+}

--- a/src/hooks/useWorkspace.ts
+++ b/src/hooks/useWorkspace.ts
@@ -51,6 +51,13 @@ export function useWorkspace(): UseWorkspaceResult {
     staleTime: STALE_TIME,
   });
 
+  // Clear stale suspended notice when the user switches active workspace
+  useEffect(() => {
+    setSuspendedActiveWorkspace((prev) =>
+      prev !== null && prev !== activeWorkspaceId ? null : prev,
+    );
+  }, [activeWorkspaceId]);
+
   // Each effect invocation creates its own `cancelled` closure. On cleanup,
   // `cancelled` is set to `true` so that:
   // (a) any pending `onEvent` promise resolves and immediately unlistens, and
@@ -65,12 +72,12 @@ export function useWorkspace(): UseWorkspaceResult {
       async (payload) => {
         await invalidateWorkspaceQueries(queryClient);
 
-        if (
-          !cancelled &&
-          payload.workspaceId === activeIdRef.current &&
-          payload.newState === "suspended"
-        ) {
-          setSuspendedActiveWorkspace(payload.workspaceId);
+        if (!cancelled && payload.workspaceId === activeIdRef.current) {
+          if (payload.newState === "suspended") {
+            setSuspendedActiveWorkspace(payload.workspaceId);
+          } else if (payload.newState === "active") {
+            setSuspendedActiveWorkspace(null);
+          }
         }
       },
     )


### PR DESCRIPTION
## Summary

• Add `useWorkspace` hook that listens to Tauri events `workspace:state_changed` and `workspace:claude_session`
• Auto-invalidates TanStack queries (`workspaces`, `github/dashboard`) on state changes
• Tracks when active workspace is suspended and exposes `suspendedActiveWorkspace` + `dismissSuspendedNotice` to UI
• 7 comprehensive tests; all 409 tests pass with zero lint warnings

## Type

feat

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `useWorkspace` hook for real-time workspace state sync from Tauri. Meets Linear T-082 by wiring events into the UI data layer to auto-refresh data and show/clear an active-workspace suspend notice.

- **New Features**
  - Listens to `workspace:state_changed` and `workspace:claude_session`.
  - Invalidates `@tanstack/react-query` caches for `workspaces` and `github/dashboard`.
  - Exposes `suspendedActiveWorkspace` and `dismissSuspendedNotice` for the UI.
  - Cleans up event listeners on unmount.

- **Bug Fixes**
  - Clears suspended notice on any non-suspended state (active, archived) and when the user switches the active workspace.
  - Tests: add missing `["github","dashboard"]` invalidation assertion; cover resume/archive/switch; wrap unlisten assertions with `waitFor` to avoid races.

<sup>Written for commit c34add9e449439bac2d29d89b59010eaaae52144. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a workspace hook that provides the workspace list, loading/error state, automatic tracking of a suspended active workspace, and a dismissible suspension notice that clears appropriately when active workspace changes.

* **Tests**
  * Adds comprehensive tests covering workspace fetching, event-driven refreshes, suspension lifecycle and dismissal behavior, and cleanup of event listeners on unmount.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->