### PR TITLE
feat(ui): add focus mode for critical+high reviews (T-083)

### DIFF
--- a/src/components/ReviewQueue/ReviewQueue.test.tsx
+++ b/src/components/ReviewQueue/ReviewQueue.test.tsx
@@ -86,7 +86,7 @@ const multiRepoReviews = [...allReviews, repo2HighPr, repo2LowPr];
 
 describe("ReviewQueue", () => {
   beforeEach(() => {
-    useDashboardStore.setState({ activeFilters: {} });
+    useDashboardStore.setState({ activeFilters: {}, focusMode: false });
   });
   it("should render PRs sorted by priority", () => {
     render(<ReviewQueue reviews={allReviews} onOpen={vi.fn()} />);

--- a/src/components/ReviewQueue/ReviewQueue.test.tsx
+++ b/src/components/ReviewQueue/ReviewQueue.test.tsx
@@ -232,6 +232,37 @@ describe("ReviewQueue", () => {
     expect(screen.getAllByRole("link")).toHaveLength(4);
   });
 
+  it("should filter critical+high in focus mode", () => {
+    useDashboardStore.setState({ focusMode: true });
+    render(<ReviewQueue reviews={allReviews} onOpen={vi.fn()} />);
+
+    const cards = screen.getAllByRole("link");
+    expect(cards).toHaveLength(2);
+    expect(screen.getByText("Critical fix")).toBeInTheDocument();
+    expect(screen.getByText("High feature")).toBeInTheDocument();
+    expect(screen.queryByText("Medium task")).not.toBeInTheDocument();
+    expect(screen.queryByText("Low chore")).not.toBeInTheDocument();
+  });
+
+  it("should show all PRs when focus mode is off", () => {
+    useDashboardStore.setState({ focusMode: false });
+    render(<ReviewQueue reviews={allReviews} onOpen={vi.fn()} />);
+
+    expect(screen.getAllByRole("link")).toHaveLength(4);
+  });
+
+  it("should combine focus mode with priority filter", async () => {
+    const user = userEvent.setup();
+    useDashboardStore.setState({ focusMode: true });
+    render(<ReviewQueue reviews={allReviews} onOpen={vi.fn()} />);
+
+    await user.click(screen.getByRole("button", { name: /^critical$/i }));
+
+    const cards = screen.getAllByRole("link");
+    expect(cards).toHaveLength(1);
+    expect(screen.getByText("Critical fix")).toBeInTheDocument();
+  });
+
   it("should forward onWorkspaceAction to ReviewCard", async () => {
     const prWithWorkspace = makePr({
       number: 99,

--- a/src/components/ReviewQueue/ReviewQueue.tsx
+++ b/src/components/ReviewQueue/ReviewQueue.tsx
@@ -54,6 +54,7 @@ export function ReviewQueue({
   const storePriority = useDashboardStore((s) => s.activeFilters.priority);
   const storeRepo = useDashboardStore((s) => s.activeFilters.repo);
   const setFilter = useDashboardStore((s) => s.setFilter);
+  const focusMode = useDashboardStore((s) => s.focusMode);
 
   useEffect(() => {
     return () => setFilter({ priority: undefined, repo: undefined });
@@ -74,13 +75,15 @@ export function ReviewQueue({
 
   const sorted = useMemo(() => {
     const filtered = reviews.filter((r) => {
+      if (focusMode && r.pullRequest.priority !== "critical" && r.pullRequest.priority !== "high")
+        return false;
       if (priorityFilter !== "all" && r.pullRequest.priority !== priorityFilter)
         return false;
       if (repoFilter && r.pullRequest.repoId !== repoFilter) return false;
       return true;
     });
     return sortByPriority(filtered);
-  }, [reviews, priorityFilter, repoFilter]);
+  }, [reviews, focusMode, priorityFilter, repoFilter]);
 
   const navItems = useMemo(
     () => sorted.map((r) => ({ url: r.pullRequest.url })),

--- a/src/components/ReviewQueue/ReviewQueue.tsx
+++ b/src/components/ReviewQueue/ReviewQueue.tsx
@@ -21,6 +21,8 @@ const PRIORITY_ORDER: Record<Priority, number> = {
 
 type PriorityFilter = "all" | Priority;
 
+const FOCUS_PRIORITIES: readonly Priority[] = ["critical", "high"];
+
 const PRIORITY_FILTERS: readonly PriorityFilter[] = [
   "all",
   "critical",
@@ -75,7 +77,7 @@ export function ReviewQueue({
 
   const sorted = useMemo(() => {
     const filtered = reviews.filter((r) => {
-      if (focusMode && r.pullRequest.priority !== "critical" && r.pullRequest.priority !== "high")
+      if (focusMode && !FOCUS_PRIORITIES.includes(r.pullRequest.priority))
         return false;
       if (priorityFilter !== "all" && r.pullRequest.priority !== priorityFilter)
         return false;

--- a/src/components/Sidebar/Sidebar.test.tsx
+++ b/src/components/Sidebar/Sidebar.test.tsx
@@ -88,7 +88,7 @@ function renderSidebar() {
 describe("Sidebar", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    useDashboardStore.setState({ currentView: "overview", activeFilters: {} });
+    useDashboardStore.setState({ currentView: "overview", activeFilters: {}, focusMode: false });
     useWorkspacesStore.setState({ activeWorkspaceId: null });
   });
 

--- a/src/components/Sidebar/Sidebar.test.tsx
+++ b/src/components/Sidebar/Sidebar.test.tsx
@@ -154,6 +154,27 @@ describe("Sidebar", () => {
     expect(useDashboardStore.getState().currentView).toBe("issues");
   });
 
+  it("should toggle focus mode via button", async () => {
+    renderSidebar();
+
+    const focusBtn = screen.getByRole("button", { name: /focus/i });
+    expect(focusBtn).toBeInTheDocument();
+
+    expect(useDashboardStore.getState().focusMode).toBe(false);
+    await userEvent.click(focusBtn);
+    expect(useDashboardStore.getState().focusMode).toBe(true);
+    await userEvent.click(focusBtn);
+    expect(useDashboardStore.getState().focusMode).toBe(false);
+  });
+
+  it("should show focus mode button as active when focus mode is on", () => {
+    useDashboardStore.setState({ focusMode: true });
+    renderSidebar();
+
+    const focusBtn = screen.getByRole("button", { name: /focus/i });
+    expect(focusBtn).toHaveAttribute("aria-pressed", "true");
+  });
+
   it("should show footer with keyboard shortcut", () => {
     renderSidebar();
     expect(screen.getByText(/⌘K/)).toBeInTheDocument();

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -29,6 +29,8 @@ export function Sidebar(): ReactElement {
   const queryClient = useQueryClient();
   const currentView = useDashboardStore((s) => s.currentView);
   const setView = useDashboardStore((s) => s.setView);
+  const focusMode = useDashboardStore((s) => s.focusMode);
+  const toggleFocusMode = useDashboardStore((s) => s.toggleFocusMode);
   const setActiveWorkspace = useWorkspacesStore((s) => s.setActiveWorkspace);
   const { stats, dashboard } = useGitHubData();
 
@@ -116,6 +118,22 @@ export function Sidebar(): ReactElement {
           <RepoList repos={repos} onToggleRepo={handleToggleRepo} />
         </div>
       )}
+
+      {/* Focus Mode Toggle */}
+      <div className="px-2">
+        <button
+          type="button"
+          aria-pressed={focusMode}
+          onClick={toggleFocusMode}
+          className={`w-full rounded px-2 py-1 text-xs font-medium ${
+            focusMode
+              ? "bg-accent text-white"
+              : "text-dim hover:text-foreground"
+          }`}
+        >
+          Focus
+        </button>
+      </div>
 
       {/* Footer */}
       <div className="mt-auto border-t border-border px-2 pt-2">

--- a/src/components/StatsBar/StatsBar.test.tsx
+++ b/src/components/StatsBar/StatsBar.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { createElement, type ReactNode } from "react";
 import { StatsBar } from "./StatsBar";
+import { useDashboardStore } from "../../stores/dashboard";
 import type { DashboardStats } from "../../lib/types";
 
 vi.mock("../../hooks/useGitHubData", () => ({
@@ -133,6 +134,34 @@ describe("StatsBar", () => {
     render(<StatsBar />, { wrapper: createWrapper() });
 
     expect(screen.getByText(/never synced/i)).toBeInTheDocument();
+  });
+
+  it("should show FOCUS MODE indicator when focus mode is on", () => {
+    useDashboardStore.setState({ focusMode: true });
+    (useGitHubData as Mock).mockReturnValue({
+      stats: MOCK_STATS,
+      dashboard: { syncedAt: "2026-03-28T10:00:00Z" },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<StatsBar />, { wrapper: createWrapper() });
+
+    expect(screen.getByText("FOCUS MODE")).toBeInTheDocument();
+  });
+
+  it("should not show FOCUS MODE indicator when focus mode is off", () => {
+    useDashboardStore.setState({ focusMode: false });
+    (useGitHubData as Mock).mockReturnValue({
+      stats: MOCK_STATS,
+      dashboard: { syncedAt: "2026-03-28T10:00:00Z" },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<StatsBar />, { wrapper: createWrapper() });
+
+    expect(screen.queryByText("FOCUS MODE")).not.toBeInTheDocument();
   });
 
   it("should show 'never synced' when syncedAt is an invalid date", () => {

--- a/src/components/StatsBar/StatsBar.test.tsx
+++ b/src/components/StatsBar/StatsBar.test.tsx
@@ -33,6 +33,7 @@ function createWrapper() {
 describe("StatsBar", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    useDashboardStore.setState({ focusMode: false });
   });
 
   it("should render all 4 stats", () => {

--- a/src/components/StatsBar/StatsBar.tsx
+++ b/src/components/StatsBar/StatsBar.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, type ReactElement } from "react";
 import { useGitHubData } from "../../hooks/useGitHubData";
+import { useDashboardStore } from "../../stores/dashboard";
 
 const TICK_INTERVAL = 10_000;
 
@@ -42,6 +43,7 @@ function StatItem({ label, value, testId, highlight }: StatItemProps): ReactElem
 
 export function StatsBar(): ReactElement {
   const { stats, dashboard } = useGitHubData();
+  const focusMode = useDashboardStore((s) => s.focusMode);
   const [now, setNow] = useState(() => Date.now());
 
   useEffect(() => {
@@ -79,7 +81,14 @@ export function StatsBar(): ReactElement {
           testId="stat-workspaces"
         />
       </div>
-      <span className="text-xs text-dim">{formatSyncedTime(syncedAt, now)}</span>
+      <div className="flex items-center gap-3">
+        {focusMode && (
+          <span className="rounded bg-accent px-2 py-0.5 text-xs font-bold text-white">
+            FOCUS MODE
+          </span>
+        )}
+        <span className="text-xs text-dim">{formatSyncedTime(syncedAt, now)}</span>
+      </div>
     </div>
   );
 }

--- a/src/stores/dashboard.ts
+++ b/src/stores/dashboard.ts
@@ -26,6 +26,7 @@ interface DashboardUiState {
   readonly activeFilters: DashboardFilters;
   readonly selectedIndex: number;
   readonly navigableItems: readonly NavigableItem[];
+  readonly focusMode: boolean;
 }
 
 interface DashboardActions {
@@ -34,6 +35,7 @@ interface DashboardActions {
   clearFilters: () => void;
   navigateList: (direction: "up" | "down") => void;
   setNavigableItems: (items: readonly NavigableItem[]) => void;
+  toggleFocusMode: () => void;
 }
 
 type DashboardState = DashboardUiState & DashboardActions;
@@ -43,6 +45,7 @@ export const useDashboardStore = create<DashboardState>((set) => ({
   activeFilters: {},
   selectedIndex: -1,
   navigableItems: [],
+  focusMode: false,
   setView: (view) =>
     set({ currentView: view, selectedIndex: -1, navigableItems: [] }),
   setFilter: (filter) =>
@@ -79,4 +82,6 @@ export const useDashboardStore = create<DashboardState>((set) => ({
           : state.selectedIndex;
       return { navigableItems: items, selectedIndex: clamped };
     }),
+  toggleFocusMode: () =>
+    set((state) => ({ focusMode: !state.focusMode })),
 }));


### PR DESCRIPTION
## Summary
- Add `focusMode` boolean to dashboard store with `toggleFocusMode` action
- Add Focus toggle button in Sidebar (with `aria-pressed` state)
- ReviewQueue filters to only critical + high priority PRs when focus mode is active
- StatsBar shows "FOCUS MODE" accent badge when active

## Test plan
- [x] `it("should filter critical+high in focus mode")` — ReviewQueue only shows critical+high
- [x] `it("should show all PRs when focus mode is off")` — no filtering when off
- [x] `it("should combine focus mode with priority filter")` — both filters compose
- [x] `it("should show FOCUS MODE indicator when focus mode is on")` — StatsBar badge
- [x] `it("should not show FOCUS MODE indicator when focus mode is off")` — no badge
- [x] `it("should toggle focus mode via button")` — store toggles on click
- [x] `it("should show focus mode button as active when focus mode is on")` — aria-pressed
- [x] All 419 existing tests still pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Focus Mode to help reviewers concentrate on urgent work. When enabled, the queue shows only critical and high-priority PRs with a clear StatsBar indicator. Implements T-083.

- **New Features**
  - Dashboard store: `focusMode` state and `toggleFocusMode` action.
  - Sidebar: Focus toggle button with `aria-pressed`.
  - ReviewQueue: filters to critical/high in focus mode; composes with existing priority filter.
  - StatsBar: shows “FOCUS MODE” badge when active.

- **Bug Fixes**
  - Reset `focusMode` in test setup to prevent state leakage; extracted `FOCUS_PRIORITIES` for cleaner filtering.

<sup>Written for commit 05c7de85987baec5937d356b534e83c38fdccf46. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Focus toggle button in the sidebar (accessible state/pressed feedback).
  * When enabled, the review queue shows only critical and high-priority PRs.
  * Focus mode composes with existing priority filters (e.g., selecting “critical” further narrows results).
  * A “FOCUS MODE” badge appears in the stats bar.
  * Focus mode state is preserved during your session.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->