### PR TITLE
feat(ui): implement personal statistics (T-085)

### DIFF
--- a/src-tauri/src/cache/mod.rs
+++ b/src-tauri/src/cache/mod.rs
@@ -7,5 +7,6 @@ pub mod notifications;
 pub mod pull_requests;
 pub mod repos;
 pub mod reviews;
+pub mod stats;
 pub mod sync;
 pub mod workspaces;

--- a/src-tauri/src/cache/stats.rs
+++ b/src-tauri/src/cache/stats.rs
@@ -1,0 +1,204 @@
+use sqlx::SqlitePool;
+
+use crate::error::AppError;
+use crate::types::PersonalStats;
+
+/// Compute personal statistics for the authenticated user.
+///
+/// Queries:
+/// - `prs_merged_this_week`: PRs authored by the user merged in the current ISO week.
+/// - `avg_review_response_hours`: average hours between review request and review submission
+///   for this user as reviewer (all time). `0.0` when no data.
+/// - `reviews_given_this_week`: reviews submitted by the user in the current ISO week.
+/// - `active_workspace_count`: workspaces in `active` state (global, not user-scoped).
+pub async fn compute_personal_stats(
+    pool: &SqlitePool,
+    username: &str,
+) -> Result<PersonalStats, AppError> {
+    // Week boundary: Monday 00:00:00 UTC of the current ISO week.
+    // SQLite strftime('%W', ...) returns week number (Monday-based, 00-53).
+    // We compute the start-of-week as: date('now', 'weekday 0', '-6 days') which gives Monday.
+
+    let row: (i64, f64, i64, i64) = sqlx::query_as(
+        "SELECT \
+         (SELECT COUNT(*) FROM pull_requests \
+          WHERE author = $1 AND state = 'merged' \
+          AND updated_at >= date('now', 'weekday 0', '-6 days')), \
+         (SELECT COALESCE(AVG( \
+            (julianday(rv.submitted_at) - julianday(rr.requested_at)) * 24.0 \
+          ), 0.0) \
+          FROM reviews rv \
+          JOIN review_requests rr \
+            ON rv.pull_request_id = rr.pull_request_id \
+           AND rv.reviewer = rr.reviewer \
+          WHERE rv.reviewer = $1), \
+         (SELECT COUNT(*) FROM reviews \
+          WHERE reviewer = $1 \
+          AND submitted_at >= date('now', 'weekday 0', '-6 days')), \
+         (SELECT COUNT(*) FROM workspaces WHERE state = 'active')",
+    )
+    .bind(username)
+    .fetch_one(pool)
+    .await?;
+
+    Ok(PersonalStats {
+        prs_merged_this_week: u32::try_from(row.0).unwrap_or(u32::MAX),
+        avg_review_response_hours: if row.1 < 0.0 { 0.0 } else { row.1 },
+        reviews_given_this_week: u32::try_from(row.2).unwrap_or(u32::MAX),
+        active_workspace_count: u32::try_from(row.3).unwrap_or(u32::MAX),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cache::db::init_db;
+    use crate::cache::pull_requests::upsert_pull_request;
+    use crate::cache::repos::upsert_repo;
+    use crate::cache::reviews::{upsert_review, upsert_review_request};
+    use crate::cache::workspaces::create_workspace;
+    use crate::types::{
+        CiStatus, PrState, Priority, PullRequest, Repo, Review, ReviewRequest, ReviewStatus,
+        Workspace, WorkspaceState,
+    };
+
+    async fn test_pool() -> (SqlitePool, tempfile::TempDir) {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let pool = init_db(&tmp.path().join("test.db")).await.unwrap();
+        (pool, tmp)
+    }
+
+    fn sample_repo() -> Repo {
+        Repo {
+            id: "repo-1".to_string(),
+            org: "mpiton".to_string(),
+            name: "prism".to_string(),
+            full_name: "mpiton/prism".to_string(),
+            url: "https://github.com/mpiton/prism".to_string(),
+            default_branch: "main".to_string(),
+            is_archived: false,
+            enabled: true,
+            local_path: None,
+            last_sync_at: None,
+        }
+    }
+
+    fn sample_pr(id: &str, number: u32, author: &str, state: PrState) -> PullRequest {
+        PullRequest {
+            id: id.to_string(),
+            number,
+            title: format!("PR #{number}"),
+            author: author.to_string(),
+            state,
+            ci_status: CiStatus::Success,
+            priority: Priority::High,
+            repo_id: "repo-1".to_string(),
+            url: format!("https://github.com/mpiton/prism/pull/{number}"),
+            labels: vec![],
+            additions: 10,
+            deletions: 5,
+            created_at: "2026-03-01T10:00:00Z".to_string(),
+            updated_at: "2026-03-30T10:00:00Z".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_compute_stats_empty() {
+        let (pool, _tmp) = test_pool().await;
+
+        let stats = compute_personal_stats(&pool, "alice").await.unwrap();
+
+        assert_eq!(stats.prs_merged_this_week, 0);
+        assert_eq!(stats.avg_review_response_hours, 0.0);
+        assert_eq!(stats.reviews_given_this_week, 0);
+        assert_eq!(stats.active_workspace_count, 0);
+
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_compute_stats_with_data() {
+        let (pool, _tmp) = test_pool().await;
+        upsert_repo(&pool, &sample_repo()).await.unwrap();
+
+        // 2 merged PRs this week by alice
+        let pr1 = sample_pr("pr-1", 1, "alice", PrState::Merged);
+        upsert_pull_request(&pool, &pr1).await.unwrap();
+        let pr2 = sample_pr("pr-2", 2, "alice", PrState::Merged);
+        upsert_pull_request(&pool, &pr2).await.unwrap();
+
+        // 1 open PR (should not count as merged)
+        let pr3 = sample_pr("pr-3", 3, "alice", PrState::Open);
+        upsert_pull_request(&pool, &pr3).await.unwrap();
+
+        // 1 merged PR by someone else (should not count)
+        let pr4 = sample_pr("pr-4", 4, "bob", PrState::Merged);
+        upsert_pull_request(&pool, &pr4).await.unwrap();
+
+        // Review request + review by alice (for avg response hours)
+        let pr5 = sample_pr("pr-5", 5, "charlie", PrState::Open);
+        upsert_pull_request(&pool, &pr5).await.unwrap();
+        let rr = ReviewRequest {
+            id: "rr-1".to_string(),
+            pull_request_id: "pr-5".to_string(),
+            reviewer: "alice".to_string(),
+            status: ReviewStatus::Approved,
+            requested_at: "2026-03-30T10:00:00Z".to_string(),
+        };
+        upsert_review_request(&pool, &rr).await.unwrap();
+        let review = Review {
+            id: "rev-1".to_string(),
+            pull_request_id: "pr-5".to_string(),
+            reviewer: "alice".to_string(),
+            status: ReviewStatus::Approved,
+            body: Some("LGTM".to_string()),
+            submitted_at: "2026-03-30T14:00:00Z".to_string(), // 4 hours later
+        };
+        upsert_review(&pool, &review).await.unwrap();
+
+        // 1 active workspace
+        let ws = Workspace {
+            id: "ws-1".to_string(),
+            repo_id: "repo-1".to_string(),
+            pull_request_number: 1,
+            state: WorkspaceState::Active,
+            worktree_path: Some("/tmp/ws".to_string()),
+            session_id: None,
+            created_at: "2026-03-20T10:00:00Z".to_string(),
+            updated_at: "2026-03-20T10:00:00Z".to_string(),
+        };
+        create_workspace(&pool, &ws).await.unwrap();
+
+        // 1 suspended workspace (should not count)
+        let ws2 = Workspace {
+            id: "ws-2".to_string(),
+            repo_id: "repo-1".to_string(),
+            pull_request_number: 2,
+            state: WorkspaceState::Suspended,
+            worktree_path: None,
+            session_id: None,
+            created_at: "2026-03-20T10:00:00Z".to_string(),
+            updated_at: "2026-03-20T10:00:00Z".to_string(),
+        };
+        create_workspace(&pool, &ws2).await.unwrap();
+
+        let stats = compute_personal_stats(&pool, "alice").await.unwrap();
+
+        assert_eq!(
+            stats.prs_merged_this_week, 2,
+            "2 merged PRs by alice this week"
+        );
+        assert!(
+            (stats.avg_review_response_hours - 4.0).abs() < 0.01,
+            "avg review response ~4 hours, got {}",
+            stats.avg_review_response_hours
+        );
+        assert_eq!(
+            stats.reviews_given_this_week, 1,
+            "1 review by alice this week"
+        );
+        assert_eq!(stats.active_workspace_count, 1, "1 active workspace");
+
+        pool.close().await;
+    }
+}

--- a/src-tauri/src/cache/stats.rs
+++ b/src-tauri/src/cache/stats.rs
@@ -23,19 +23,25 @@ pub async fn compute_personal_stats(
     // This is correct for all days of the week including Sunday (unlike `weekday 0, -6 days`).
     let monday = "date('now', 'weekday 1', '-7 days')";
 
+    // The avg review response sub-query uses an inner aggregation to avoid
+    // M×N cross-products when a reviewer has multiple review_requests or reviews
+    // on the same PR (dismiss/re-request, changes_requested/approve).
+    // We take MIN(submitted_at) paired with MIN(requested_at) per (PR, reviewer).
     let sql = format!(
         "SELECT \
          (SELECT COUNT(*) FROM pull_requests \
           WHERE author = $1 AND state = 'merged' \
           AND updated_at >= {monday}), \
-         (SELECT COALESCE(AVG( \
-            (julianday(rv.submitted_at) - julianday(rr.requested_at)) * 24.0 \
-          ), 0.0) \
-          FROM reviews rv \
-          JOIN review_requests rr \
-            ON rv.pull_request_id = rr.pull_request_id \
-           AND rv.reviewer = rr.reviewer \
-          WHERE rv.reviewer = $1), \
+         (SELECT COALESCE(AVG(response_hours), 0.0) FROM ( \
+            SELECT (julianday(MIN(rv.submitted_at)) - julianday(MIN(rr.requested_at))) * 24.0 \
+              AS response_hours \
+            FROM reviews rv \
+            JOIN review_requests rr \
+              ON rv.pull_request_id = rr.pull_request_id \
+             AND rv.reviewer = rr.reviewer \
+            WHERE rv.reviewer = $1 \
+            GROUP BY rv.pull_request_id, rv.reviewer \
+          )), \
          (SELECT COUNT(*) FROM reviews \
           WHERE reviewer = $1 \
           AND submitted_at >= {monday}), \
@@ -65,11 +71,24 @@ mod tests {
         CiStatus, PrState, Priority, PullRequest, Repo, Review, ReviewRequest, ReviewStatus,
         Workspace, WorkspaceState,
     };
+    use chrono::Utc;
 
     async fn test_pool() -> (SqlitePool, tempfile::TempDir) {
         let tmp = tempfile::TempDir::new().unwrap();
         let pool = init_db(&tmp.path().join("test.db")).await.unwrap();
         (pool, tmp)
+    }
+
+    /// Returns an ISO 8601 timestamp for "now", always within the current week.
+    fn now_ts() -> String {
+        Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string()
+    }
+
+    /// Returns an ISO 8601 timestamp for `hours` hours ago (still within current day).
+    fn hours_ago(hours: i64) -> String {
+        (Utc::now() - chrono::Duration::hours(hours))
+            .format("%Y-%m-%dT%H:%M:%SZ")
+            .to_string()
     }
 
     fn sample_repo() -> Repo {
@@ -101,8 +120,8 @@ mod tests {
             labels: vec![],
             additions: 10,
             deletions: 5,
-            created_at: "2026-03-01T10:00:00Z".to_string(),
-            updated_at: "2026-03-30T10:00:00Z".to_string(),
+            created_at: hours_ago(48),
+            updated_at: now_ts(),
         }
     }
 
@@ -140,6 +159,7 @@ mod tests {
         upsert_pull_request(&pool, &pr4).await.unwrap();
 
         // Review request + review by alice (for avg response hours)
+        // requested_at = 4 hours ago, submitted_at = now → ~4h response
         let pr5 = sample_pr("pr-5", 5, "charlie", PrState::Open);
         upsert_pull_request(&pool, &pr5).await.unwrap();
         let rr = ReviewRequest {
@@ -147,7 +167,7 @@ mod tests {
             pull_request_id: "pr-5".to_string(),
             reviewer: "alice".to_string(),
             status: ReviewStatus::Approved,
-            requested_at: "2026-03-30T10:00:00Z".to_string(),
+            requested_at: hours_ago(4),
         };
         upsert_review_request(&pool, &rr).await.unwrap();
         let review = Review {
@@ -156,7 +176,7 @@ mod tests {
             reviewer: "alice".to_string(),
             status: ReviewStatus::Approved,
             body: Some("LGTM".to_string()),
-            submitted_at: "2026-03-30T14:00:00Z".to_string(), // 4 hours later
+            submitted_at: now_ts(),
         };
         upsert_review(&pool, &review).await.unwrap();
 
@@ -168,8 +188,8 @@ mod tests {
             state: WorkspaceState::Active,
             worktree_path: Some("/tmp/ws".to_string()),
             session_id: None,
-            created_at: "2026-03-20T10:00:00Z".to_string(),
-            updated_at: "2026-03-20T10:00:00Z".to_string(),
+            created_at: hours_ago(24),
+            updated_at: hours_ago(1),
         };
         create_workspace(&pool, &ws).await.unwrap();
 
@@ -181,8 +201,8 @@ mod tests {
             state: WorkspaceState::Suspended,
             worktree_path: None,
             session_id: None,
-            created_at: "2026-03-20T10:00:00Z".to_string(),
-            updated_at: "2026-03-20T10:00:00Z".to_string(),
+            created_at: hours_ago(24),
+            updated_at: hours_ago(1),
         };
         create_workspace(&pool, &ws2).await.unwrap();
 
@@ -193,7 +213,7 @@ mod tests {
             "2 merged PRs by alice this week"
         );
         assert!(
-            (stats.avg_review_response_hours - 4.0).abs() < 0.01,
+            (stats.avg_review_response_hours - 4.0).abs() < 0.1,
             "avg review response ~4 hours, got {}",
             stats.avg_review_response_hours
         );

--- a/src-tauri/src/cache/stats.rs
+++ b/src-tauri/src/cache/stats.rs
@@ -6,24 +6,28 @@ use crate::types::PersonalStats;
 /// Compute personal statistics for the authenticated user.
 ///
 /// Queries:
-/// - `prs_merged_this_week`: PRs authored by the user merged in the current ISO week.
+/// - `prs_merged_this_week`: PRs authored by the user whose state changed to `merged`
+///   this week. Uses `updated_at` as proxy because the schema has no `merged_at` column;
+///   this is approximate — a PR re-synced this week will be counted even if merged earlier.
 /// - `avg_review_response_hours`: average hours between review request and review submission
 ///   for this user as reviewer (all time). `0.0` when no data.
 /// - `reviews_given_this_week`: reviews submitted by the user in the current ISO week.
-/// - `active_workspace_count`: workspaces in `active` state (global, not user-scoped).
+/// - `active_workspace_count`: workspaces in `active` state (global, not user-scoped —
+///   the workspaces table has no owner column).
 pub async fn compute_personal_stats(
     pool: &SqlitePool,
     username: &str,
 ) -> Result<PersonalStats, AppError> {
     // Week boundary: Monday 00:00:00 UTC of the current ISO week.
-    // SQLite strftime('%W', ...) returns week number (Monday-based, 00-53).
-    // We compute the start-of-week as: date('now', 'weekday 0', '-6 days') which gives Monday.
+    // `weekday 1` advances to next Monday, `-7 days` rolls back to the most recent Monday.
+    // This is correct for all days of the week including Sunday (unlike `weekday 0, -6 days`).
+    let monday = "date('now', 'weekday 1', '-7 days')";
 
-    let row: (i64, f64, i64, i64) = sqlx::query_as(
+    let sql = format!(
         "SELECT \
          (SELECT COUNT(*) FROM pull_requests \
           WHERE author = $1 AND state = 'merged' \
-          AND updated_at >= date('now', 'weekday 0', '-6 days')), \
+          AND updated_at >= {monday}), \
          (SELECT COALESCE(AVG( \
             (julianday(rv.submitted_at) - julianday(rr.requested_at)) * 24.0 \
           ), 0.0) \
@@ -34,13 +38,13 @@ pub async fn compute_personal_stats(
           WHERE rv.reviewer = $1), \
          (SELECT COUNT(*) FROM reviews \
           WHERE reviewer = $1 \
-          AND submitted_at >= date('now', 'weekday 0', '-6 days')), \
-         (SELECT COUNT(*) FROM workspaces WHERE state = 'active')",
-    )
-    .bind(username)
-    .fetch_one(pool)
-    .await?;
+          AND submitted_at >= {monday}), \
+         (SELECT COUNT(*) FROM workspaces WHERE state = 'active')"
+    );
 
+    let row: (i64, f64, i64, i64) = sqlx::query_as(&sql).bind(username).fetch_one(pool).await?;
+
+    // Saturating — COUNT(*) on a local SQLite DB will never exceed u32::MAX.
     Ok(PersonalStats {
         prs_merged_this_week: u32::try_from(row.0).unwrap_or(u32::MAX),
         avg_review_response_hours: if row.1 < 0.0 { 0.0 } else { row.1 },

--- a/src-tauri/src/cache/stats.rs
+++ b/src-tauri/src/cache/stats.rs
@@ -19,9 +19,10 @@ pub async fn compute_personal_stats(
     username: &str,
 ) -> Result<PersonalStats, AppError> {
     // Week boundary: Monday 00:00:00 UTC of the current ISO week.
-    // `weekday 1` advances to next Monday, `-7 days` rolls back to the most recent Monday.
-    // This is correct for all days of the week including Sunday (unlike `weekday 0, -6 days`).
-    let monday = "date('now', 'weekday 1', '-7 days')";
+    // `-6 days` first, then `weekday 1` advances to the next Monday.
+    // This correctly returns today on Mondays (unlike `weekday 1, -7 days`
+    // which overshoots to the previous Monday).
+    let monday = "date('now', '-6 days', 'weekday 1')";
 
     // The avg review response sub-query uses an inner aggregation to avoid
     // M×N cross-products when a reviewer has multiple review_requests or reviews

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -11,6 +11,7 @@ use crate::cache::activity::{mark_all_read, mark_read};
 use crate::cache::config::{get_config, set_config};
 use crate::cache::dashboard::{assemble_dashboard_data, compute_dashboard_stats};
 use crate::cache::repos::{get_repo, list_repos, set_local_path, set_repo_enabled};
+use crate::cache::stats::compute_personal_stats;
 use crate::cache::sync::sync_dashboard;
 use crate::cache::workspaces::{
     create_workspace, get_notes, list_workspaces, update_workspace_state,
@@ -20,7 +21,8 @@ use crate::github::auth;
 use crate::github::client::GitHubClient;
 use crate::types::{
     AppConfig, DashboardData, DashboardStats, OpenWorkspaceRequest, OpenWorkspaceResponse,
-    PartialAppConfig, Repo, Workspace, WorkspaceNote, WorkspaceState, merge_partial_config,
+    PartialAppConfig, PersonalStats, Repo, Workspace, WorkspaceNote, WorkspaceState,
+    merge_partial_config,
 };
 use crate::workspace::pty::PtyManager;
 use crate::workspace::worktree;
@@ -213,6 +215,18 @@ pub async fn github_get_stats(
 ) -> Result<DashboardStats, String> {
     let username = resolve_username(&cached).await?;
     compute_dashboard_stats(&pool, &username)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// Returns personal statistics for the authenticated user.
+#[tauri::command]
+pub async fn stats_personal(
+    pool: tauri::State<'_, SqlitePool>,
+    cached: tauri::State<'_, GithubUsername>,
+) -> Result<PersonalStats, String> {
+    let username = resolve_username(&cached).await?;
+    compute_personal_stats(&pool, &username)
         .await
         .map_err(|e| e.to_string())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -172,6 +172,7 @@ pub fn run() {
             commands::auth_logout,
             commands::github_get_dashboard,
             commands::github_get_stats,
+            commands::stats_personal,
             commands::github_force_sync,
             commands::repos_list,
             commands::repos_set_enabled,

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -248,6 +248,16 @@ pub struct DashboardStats {
     pub unread_activity: u32,
 }
 
+/// Personal statistics for the authenticated user (T-085).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PersonalStats {
+    pub prs_merged_this_week: u32,
+    pub avg_review_response_hours: f64,
+    pub reviews_given_this_week: u32,
+    pub active_workspace_count: u32,
+}
+
 // ── IPC payloads (T-011) ──────────────────────────────────────
 
 /// Request payload for the `workspace_open` IPC command.

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -947,6 +947,23 @@ mod tests {
         assert_eq!(stats, deserialized);
     }
 
+    #[test]
+    fn test_personal_stats_json_roundtrip() {
+        let stats = PersonalStats {
+            prs_merged_this_week: 3,
+            avg_review_response_hours: 2.5,
+            reviews_given_this_week: 7,
+            active_workspace_count: 1,
+        };
+        let json = serde_json::to_string(&stats).unwrap();
+        assert!(json.contains("\"prsMergedThisWeek\""));
+        assert!(json.contains("\"avgReviewResponseHours\""));
+        assert!(json.contains("\"reviewsGivenThisWeek\""));
+        assert!(json.contains("\"activeWorkspaceCount\""));
+        let deserialized: PersonalStats = serde_json::from_str(&json).unwrap();
+        assert_eq!(stats, deserialized);
+    }
+
     // ── T-011: IPC payload roundtrip tests ─────────────────────────
 
     #[test]

--- a/src/components/Settings/Settings.test.tsx
+++ b/src/components/Settings/Settings.test.tsx
@@ -340,9 +340,9 @@ describe("Settings", () => {
     // Wait for stats data to load (the section renders immediately in loading state)
     expect(await screen.findByText("3.2h")).toBeInTheDocument();
     const statsSection = screen.getByTestId("settings-stats");
-    expect(within(statsSection).getByText("5")).toBeInTheDocument();
-    expect(within(statsSection).getByText("12")).toBeInTheDocument();
-    expect(within(statsSection).getByText("2")).toBeInTheDocument();
+    expect(within(statsSection).getByText(/^5$/)).toBeInTheDocument();
+    expect(within(statsSection).getByText(/^12$/)).toBeInTheDocument();
+    expect(within(statsSection).getByText(/^2$/)).toBeInTheDocument();
   });
 
   it("should show stats unavailable when stats fetch fails", async () => {

--- a/src/components/Settings/Settings.test.tsx
+++ b/src/components/Settings/Settings.test.tsx
@@ -344,4 +344,26 @@ describe("Settings", () => {
     expect(within(statsSection).getByText("12")).toBeInTheDocument();
     expect(within(statsSection).getByText("2")).toBeInTheDocument();
   });
+
+  it("should show stats unavailable when stats fetch fails", async () => {
+    setupMocks();
+    mockedGetPersonalStats.mockRejectedValue(new Error("DB error"));
+
+    renderWithProviders(<Settings />);
+
+    expect(await screen.findByText(/stats unavailable/i)).toBeInTheDocument();
+  });
+
+  it("should show N/A for non-finite avg review response hours", async () => {
+    setupMocks(
+      makeConfig(),
+      [],
+      makeAuthStatus(),
+      makePersonalStats({ avgReviewResponseHours: Infinity }),
+    );
+
+    renderWithProviders(<Settings />);
+
+    expect(await screen.findByText("N/A")).toBeInTheDocument();
+  });
 });

--- a/src/components/Settings/Settings.test.tsx
+++ b/src/components/Settings/Settings.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, within, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import type { AppConfig, AuthStatus, Repo } from "../../lib/types";
+import type { AppConfig, AuthStatus, PersonalStats, Repo } from "../../lib/types";
 
 vi.mock("../../lib/tauri", () => ({
   getConfig: vi.fn(),
@@ -11,6 +11,7 @@ vi.mock("../../lib/tauri", () => ({
   listRepos: vi.fn(),
   setRepoEnabled: vi.fn(),
   authGetStatus: vi.fn(),
+  getPersonalStats: vi.fn(),
 }));
 
 import {
@@ -19,6 +20,7 @@ import {
   listRepos,
   setRepoEnabled,
   authGetStatus,
+  getPersonalStats,
 } from "../../lib/tauri";
 
 const mockedGetConfig = vi.mocked(getConfig);
@@ -26,6 +28,7 @@ const mockedSetConfig = vi.mocked(setConfig);
 const mockedListRepos = vi.mocked(listRepos);
 const mockedSetRepoEnabled = vi.mocked(setRepoEnabled);
 const mockedAuthGetStatus = vi.mocked(authGetStatus);
+const mockedGetPersonalStats = vi.mocked(getPersonalStats);
 
 function renderWithProviders(ui: ReactElement) {
   const queryClient = new QueryClient({
@@ -73,15 +76,27 @@ function makeRepo(n: number, overrides: Partial<Repo> = {}): Repo {
   };
 }
 
+function makePersonalStats(overrides: Partial<PersonalStats> = {}): PersonalStats {
+  return {
+    prsMergedThisWeek: 3,
+    avgReviewResponseHours: 2.5,
+    reviewsGivenThisWeek: 7,
+    activeWorkspaceCount: 1,
+    ...overrides,
+  };
+}
+
 function setupMocks(
   config: AppConfig = makeConfig(),
   repos: Repo[] = [makeRepo(1), makeRepo(2)],
   auth: AuthStatus = makeAuthStatus(),
+  stats: PersonalStats = makePersonalStats(),
 ) {
   mockedGetConfig.mockResolvedValue(config);
   mockedListRepos.mockResolvedValue(repos);
   mockedAuthGetStatus.mockResolvedValue(auth);
   mockedSetConfig.mockResolvedValue(config);
+  mockedGetPersonalStats.mockResolvedValue(stats);
 }
 
 // Lazy import so mocks are set up before module loads
@@ -305,5 +320,28 @@ describe("Settings", () => {
 
     await screen.findByRole("alert");
     await waitFor(() => expect(input).toHaveValue(300));
+  });
+
+  it("should render stats section", async () => {
+    setupMocks(
+      makeConfig(),
+      [],
+      makeAuthStatus(),
+      makePersonalStats({
+        prsMergedThisWeek: 5,
+        avgReviewResponseHours: 3.2,
+        reviewsGivenThisWeek: 12,
+        activeWorkspaceCount: 2,
+      }),
+    );
+
+    renderWithProviders(<Settings />);
+
+    // Wait for stats data to load (the section renders immediately in loading state)
+    expect(await screen.findByText("3.2h")).toBeInTheDocument();
+    const statsSection = screen.getByTestId("settings-stats");
+    expect(within(statsSection).getByText("5")).toBeInTheDocument();
+    expect(within(statsSection).getByText("12")).toBeInTheDocument();
+    expect(within(statsSection).getByText("2")).toBeInTheDocument();
   });
 });

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -8,6 +8,7 @@ import {
   authGetStatus,
 } from "../../lib/tauri";
 import type { PartialAppConfig, Repo } from "../../lib/types";
+import { Stats } from "./Stats";
 
 function useConfigQuery() {
   return useQuery({ queryKey: ["config"], queryFn: getConfig });
@@ -197,6 +198,8 @@ export function Settings(): ReactElement {
           </div>
         )}
       </div>
+
+      <Stats />
     </section>
   );
 }

--- a/src/components/Settings/Stats.tsx
+++ b/src/components/Settings/Stats.tsx
@@ -1,0 +1,57 @@
+import type { ReactElement } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { getPersonalStats } from "../../lib/tauri";
+
+interface StatItemProps {
+  readonly label: string;
+  readonly value: string;
+}
+
+function StatItem({ label, value }: StatItemProps): ReactElement {
+  return (
+    <div className="flex items-center justify-between text-sm">
+      <span className="text-dim">{label}</span>
+      <span className="font-mono text-white">{value}</span>
+    </div>
+  );
+}
+
+export function Stats(): ReactElement {
+  const statsQuery = useQuery({
+    queryKey: ["stats", "personal"],
+    queryFn: getPersonalStats,
+  });
+
+  if (statsQuery.isLoading) {
+    return (
+      <div data-testid="settings-stats" className="flex flex-col gap-3">
+        <h2 className="text-accent text-sm font-semibold uppercase tracking-wider">Statistics</h2>
+        <span className="text-dim text-sm">Loading stats...</span>
+      </div>
+    );
+  }
+
+  if (statsQuery.error || !statsQuery.data) {
+    return (
+      <div data-testid="settings-stats" className="flex flex-col gap-3">
+        <h2 className="text-accent text-sm font-semibold uppercase tracking-wider">Statistics</h2>
+        <span className="text-dim text-sm">Stats unavailable</span>
+      </div>
+    );
+  }
+
+  const stats = statsQuery.data;
+  const avgHours = Number.isFinite(stats.avgReviewResponseHours)
+    ? `${Math.round(stats.avgReviewResponseHours * 10) / 10}h`
+    : "N/A";
+
+  return (
+    <div data-testid="settings-stats" className="flex flex-col gap-3">
+      <h2 className="text-accent text-sm font-semibold uppercase tracking-wider">Statistics</h2>
+      <StatItem label="PRs merged this week" value={String(stats.prsMergedThisWeek)} />
+      <StatItem label="Avg review response" value={avgHours} />
+      <StatItem label="Reviews given this week" value={String(stats.reviewsGivenThisWeek)} />
+      <StatItem label="Active workspaces" value={String(stats.activeWorkspaceCount)} />
+    </div>
+  );
+}

--- a/src/components/Settings/Stats.tsx
+++ b/src/components/Settings/Stats.tsx
@@ -20,6 +20,7 @@ export function Stats(): ReactElement {
   const statsQuery = useQuery({
     queryKey: ["stats", "personal"],
     queryFn: getPersonalStats,
+    staleTime: 60_000,
   });
 
   if (statsQuery.isLoading) {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -9,6 +9,7 @@ import type {
   OpenWorkspaceRequest,
   OpenWorkspaceResponse,
   PartialAppConfig,
+  PersonalStats,
   PtyInput,
   PtyResize,
   Repo,
@@ -39,6 +40,10 @@ export async function getGithubDashboard(): Promise<DashboardData> {
 
 export async function getGithubStats(): Promise<DashboardStats> {
   return invoke<DashboardStats>(TAURI_COMMANDS.github_get_stats);
+}
+
+export async function getPersonalStats(): Promise<PersonalStats> {
+  return invoke<PersonalStats>(TAURI_COMMANDS.stats_personal);
 }
 
 export async function forceGithubSync(): Promise<void> {

--- a/src/lib/types.test.ts
+++ b/src/lib/types.test.ts
@@ -412,8 +412,8 @@ describe("IPC payload shapes", () => {
 // ── TauriCommands & TauriEvents maps ─────────────────────────────
 
 describe("TAURI_COMMANDS constant", () => {
-  it("should contain all 23 IPC command names", () => {
-    expect(Object.keys(TAURI_COMMANDS)).toHaveLength(23);
+  it("should contain all 24 IPC command names", () => {
+    expect(Object.keys(TAURI_COMMANDS)).toHaveLength(24);
   });
 
   it("should have matching key-value pairs", () => {

--- a/src/lib/types.test.ts
+++ b/src/lib/types.test.ts
@@ -20,6 +20,7 @@ import type {
   PullRequestWithReview,
   DashboardData,
   DashboardStats,
+  PersonalStats,
   OpenWorkspaceRequest,
   OpenWorkspaceResponse,
   PtyInput,
@@ -313,6 +314,18 @@ describe("Composite struct shapes", () => {
     const stats = coerceFixture<DashboardStats>(json);
     expect(stats.pendingReviews).toBe(5);
     expect(stats.openPrs).toBe(12);
+  });
+
+  it("should match PersonalStats shape", () => {
+    const json = {
+      prsMergedThisWeek: 3,
+      avgReviewResponseHours: 2.5,
+      reviewsGivenThisWeek: 7,
+      activeWorkspaceCount: 1,
+    };
+    const stats = coerceFixture<PersonalStats>(json);
+    expect(stats.prsMergedThisWeek).toBe(3);
+    expect(stats.avgReviewResponseHours).toBe(2.5);
   });
 });
 

--- a/src/lib/types.test.ts
+++ b/src/lib/types.test.ts
@@ -425,8 +425,8 @@ describe("IPC payload shapes", () => {
 // ── TauriCommands & TauriEvents maps ─────────────────────────────
 
 describe("TAURI_COMMANDS constant", () => {
-  it("should contain all 24 IPC command names", () => {
-    expect(Object.keys(TAURI_COMMANDS)).toHaveLength(24);
+  it("should include stats_personal in IPC command names", () => {
+    expect(TAURI_COMMANDS).toHaveProperty("stats_personal", "stats_personal");
   });
 
   it("should have matching key-value pairs", () => {

--- a/src/lib/types.test.ts
+++ b/src/lib/types.test.ts
@@ -425,6 +425,10 @@ describe("IPC payload shapes", () => {
 // ── TauriCommands & TauriEvents maps ─────────────────────────────
 
 describe("TAURI_COMMANDS constant", () => {
+  it("should contain all 24 IPC command names", () => {
+    expect(Object.keys(TAURI_COMMANDS)).toHaveLength(24);
+  });
+
   it("should include stats_personal in IPC command names", () => {
     expect(TAURI_COMMANDS).toHaveProperty("stats_personal", "stats_personal");
   });

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -177,6 +177,15 @@ export interface AuthStatus {
   readonly error: string | null;
 }
 
+// ── Personal stats (T-085) ───────────────────────────────────────
+
+export interface PersonalStats {
+  readonly prsMergedThisWeek: number;
+  readonly avgReviewResponseHours: number;
+  readonly reviewsGivenThisWeek: number;
+  readonly activeWorkspaceCount: number;
+}
+
 // ── IPC payloads (T-011) ─────────────────────────────────────────
 
 export interface OpenWorkspaceRequest {
@@ -257,6 +266,7 @@ export type TauriCommandName =
   | "config_set"
   | "activity_mark_read"
   | "activity_mark_all_read"
+  | "stats_personal"
   | "auth_set_token"
   | "auth_get_status"
   | "auth_logout";
@@ -282,6 +292,7 @@ export const TAURI_COMMANDS = {
   config_set: "config_set",
   activity_mark_read: "activity_mark_read",
   activity_mark_all_read: "activity_mark_all_read",
+  stats_personal: "stats_personal",
   auth_set_token: "auth_set_token",
   auth_get_status: "auth_get_status",
   auth_logout: "auth_logout",


### PR DESCRIPTION
## Summary

Implement personal statistics panel in Settings showing:
- PRs merged this week
- Average review response time (hours)
- Reviews given this week
- Active workspaces

## Changes

• **Backend**: New `cache/stats.rs` module computing stats from SQLite cache via SQL query
• **Frontend**: New `Stats.tsx` component rendering metrics with TanStack Query + caching
• **Integration**: Settings panel displays stats section below repo list
• **Tests**: 310 Rust unit tests + 423 TypeScript tests (all passing)
• **Review**: Applied Rust + TypeScript review fixes (date arithmetic, query optimization, test coverage)

## Type

feat

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Statistics panel in Settings (T-085) to show PRs merged this week, average review response time, reviews given this week, and active workspaces. Improves week-start handling and the average response calculation.

- **New Features**
  - Backend: `cache/stats.rs` computes user stats from SQLite using an ISO-week boundary; uses `updated_at` as a merged proxy; counts active workspaces globally.
  - IPC: new `stats_personal` command returning `PersonalStats`.
  - Frontend: `Settings/Stats.tsx` renders the panel with `@tanstack/react-query` (staleTime 60s), shows loading, error (“Stats unavailable”), and “N/A” for non-finite averages; integrated below the repo list.
  - Tests: unit tests for stat computation; UI/shape tests for loading/error/N/A branches.

- **Bug Fixes**
  - Stats accuracy: de-duplicate reviews in average response via GROUP BY with MIN timestamps; fix ISO Monday calculation to return today on Mondays.
  - Tests hardening: use dynamic timestamps; add `PersonalStats` serde/JSON roundtrip; tighten UI matchers; restore count-based command count guard and add an explicit `TAURI_COMMANDS.stats_personal` key assertion.

<sup>Written for commit a3465510159406039811138879e6bcbd02b29190. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Statistics section to Settings showing personal metrics: PRs merged this week, average review response (hours), reviews given this week, and active workspace count.
  * Metrics auto-refresh (60s); average response formatted with an "h" suffix and displays "N/A" when not finite; shows "Stats unavailable" on error or no data.

* **Tests**
  * Added tests for stats computation, serialization, and Settings UI (rendering, error/empty states).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->