### PR TITLE
feat(ui): add memory monitoring debug section (T-087)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3000,6 +3000,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "pango"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3422,6 +3432,7 @@ dependencies = [
  "log",
  "mockito",
  "notify-rust",
+ "page_size",
  "portable-pty",
  "regex",
  "reqwest",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -32,6 +32,7 @@ graphql_client = { version = "0.16.0", features = ["graphql_query_derive"] }
 notify-rust = "4.12.0"
 portable-pty = "0.9.0"
 regex = "1.12.3"
+page_size = "0.6.0"
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -32,6 +32,7 @@ graphql_client = { version = "0.16.0", features = ["graphql_query_derive"] }
 notify-rust = "4.12.0"
 portable-pty = "0.9.0"
 regex = "1.12.3"
+[target.'cfg(target_os = "linux")'.dependencies]
 page_size = "0.6.0"
 
 [lints.clippy]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -20,9 +20,9 @@ use crate::error::AppError;
 use crate::github::auth;
 use crate::github::client::GitHubClient;
 use crate::types::{
-    AppConfig, DashboardData, DashboardStats, OpenWorkspaceRequest, OpenWorkspaceResponse,
-    PartialAppConfig, PersonalStats, Repo, Workspace, WorkspaceNote, WorkspaceState,
-    merge_partial_config,
+    AppConfig, DashboardData, DashboardStats, MemoryStats, OpenWorkspaceRequest,
+    OpenWorkspaceResponse, PartialAppConfig, PersonalStats, Repo, Workspace, WorkspaceNote,
+    WorkspaceState, merge_partial_config,
 };
 use crate::workspace::pty::PtyManager;
 use crate::workspace::worktree;
@@ -1109,6 +1109,53 @@ pub async fn pty_kill(
 ) -> Result<(), String> {
     pty_state.unregister_by_pty_id(&pty_id);
     pty_state.manager.kill(&pty_id).map_err(|e| e.to_string())
+}
+
+// ── Debug / Memory monitoring (T-087) ───────────────────────────
+
+/// Reads the RSS (Resident Set Size) of the current process from `/proc/self/statm`.
+///
+/// Returns 0 on non-Linux platforms or if the read fails (best-effort).
+pub(crate) fn get_process_rss_bytes() -> u64 {
+    #[cfg(target_os = "linux")]
+    {
+        let Ok(statm) = std::fs::read_to_string("/proc/self/statm") else {
+            return 0;
+        };
+        let rss_pages: u64 = statm
+            .split_whitespace()
+            .nth(1)
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0);
+        rss_pages * (page_size::get() as u64)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        0
+    }
+}
+
+/// Returns the file size in bytes, or 0 if the file does not exist / is unreadable.
+pub(crate) fn get_file_size_bytes(path: &Path) -> u64 {
+    std::fs::metadata(path).map(|m| m.len()).unwrap_or(0)
+}
+
+/// Returns memory usage statistics for the debug section in Settings.
+#[tauri::command]
+pub async fn debug_memory_usage(app_handle: tauri::AppHandle) -> Result<MemoryStats, String> {
+    let rss_bytes = get_process_rss_bytes();
+
+    let db_path = app_handle
+        .path()
+        .app_data_dir()
+        .map(|d| d.join("prism.db"))
+        .map_err(|e| format!("failed to resolve data dir: {e}"))?;
+    let db_size_bytes = get_file_size_bytes(&db_path);
+
+    Ok(MemoryStats {
+        rss_bytes,
+        db_size_bytes,
+    })
 }
 
 #[cfg(test)]
@@ -2637,5 +2684,30 @@ mod tests {
 
         pool.close().await;
         pool2.close().await;
+    }
+
+    // -- Memory monitoring tests (T-087) --
+
+    #[test]
+    fn test_get_process_rss_bytes_returns_nonzero_on_linux() {
+        let rss = get_process_rss_bytes();
+        #[cfg(target_os = "linux")]
+        assert!(rss > 0, "RSS should be > 0 on Linux, got {rss}");
+        #[cfg(not(target_os = "linux"))]
+        assert_eq!(rss, 0, "RSS should be 0 on non-Linux");
+    }
+
+    #[test]
+    fn test_get_file_size_bytes_existing_file() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), "hello world").unwrap();
+        let size = get_file_size_bytes(tmp.path());
+        assert_eq!(size, 11, "expected 11 bytes for 'hello world'");
+    }
+
+    #[test]
+    fn test_get_file_size_bytes_missing_file() {
+        let size = get_file_size_bytes(Path::new("/tmp/nonexistent_prism_test_file.db"));
+        assert_eq!(size, 0, "missing file should return 0");
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1141,16 +1141,18 @@ pub(crate) fn get_file_size_bytes(path: &Path) -> u64 {
 }
 
 /// Returns memory usage statistics for the debug section in Settings.
+///
+/// Best-effort: returns 0 for any metric that cannot be read rather than
+/// failing the entire call.
 #[tauri::command]
 pub async fn debug_memory_usage(app_handle: tauri::AppHandle) -> Result<MemoryStats, String> {
     let rss_bytes = get_process_rss_bytes();
 
-    let db_path = app_handle
+    let db_size_bytes = app_handle
         .path()
         .app_data_dir()
-        .map(|d| d.join("prism.db"))
-        .map_err(|e| format!("failed to resolve data dir: {e}"))?;
-    let db_size_bytes = get_file_size_bytes(&db_path);
+        .map(|d| get_file_size_bytes(&d.join("prism.db")))
+        .unwrap_or(0);
 
     Ok(MemoryStats {
         rss_bytes,
@@ -2707,7 +2709,9 @@ mod tests {
 
     #[test]
     fn test_get_file_size_bytes_missing_file() {
-        let size = get_file_size_bytes(Path::new("/tmp/nonexistent_prism_test_file.db"));
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp.path().join("nonexistent.db");
+        let size = get_file_size_bytes(&missing);
         assert_eq!(size, 0, "missing file should return 0");
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -191,6 +191,7 @@ pub fn run() {
             commands::pty_write,
             commands::pty_resize,
             commands::pty_kill,
+            commands::debug_memory_usage,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -310,6 +310,16 @@ pub struct PtyResize {
     pub rows: u16,
 }
 
+/// Memory usage statistics returned by `debug_memory_usage` (T-087).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MemoryStats {
+    /// Resident Set Size of the main process in bytes.
+    pub rss_bytes: u64,
+    /// Size of the SQLite database file in bytes.
+    pub db_size_bytes: u64,
+}
+
 /// Event payload emitted when a workspace changes state (T-070).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -1090,6 +1100,19 @@ mod tests {
         let json = serde_json::to_string(&config).unwrap();
         let deserialized: AppConfig = serde_json::from_str(&json).unwrap();
         assert_eq!(config, deserialized);
+    }
+
+    #[test]
+    fn test_memory_stats_serializes_camel_case() {
+        let stats = MemoryStats {
+            rss_bytes: 50_000_000,
+            db_size_bytes: 1_234_567,
+        };
+        let json = serde_json::to_value(&stats).unwrap();
+        assert_eq!(json["rssBytes"], 50_000_000);
+        assert_eq!(json["dbSizeBytes"], 1_234_567);
+        let roundtrip: MemoryStats = serde_json::from_value(json).unwrap();
+        assert_eq!(stats, roundtrip);
     }
 
     #[test]

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -316,7 +316,7 @@ pub struct PtyResize {
 pub struct MemoryStats {
     /// Resident Set Size of the main process in bytes.
     pub rss_bytes: u64,
-    /// Size of the SQLite database file in bytes.
+    /// Size of the `SQLite` database file in bytes.
     pub db_size_bytes: u64,
 }
 

--- a/src/components/Settings/DebugInfo.test.tsx
+++ b/src/components/Settings/DebugInfo.test.tsx
@@ -100,4 +100,26 @@ describe("DebugInfo", () => {
 
     expect(await screen.findByText("512 B")).toBeInTheDocument();
   });
+
+  it("should format GB-level sizes", async () => {
+    mockedGetMemoryUsage.mockResolvedValue({
+      rssBytes: 1_610_612_736, // 1.5 GB
+      dbSizeBytes: 1_048_576,
+    });
+
+    renderWithProviders(<DebugInfo />);
+
+    expect(await screen.findByText("1.5 GB")).toBeInTheDocument();
+  });
+
+  it("should show N/A when RSS is 0 (non-Linux)", async () => {
+    mockedGetMemoryUsage.mockResolvedValue({
+      rssBytes: 0,
+      dbSizeBytes: 1_048_576,
+    });
+
+    renderWithProviders(<DebugInfo />);
+
+    expect(await screen.findByText("N/A")).toBeInTheDocument();
+  });
 });

--- a/src/components/Settings/DebugInfo.test.tsx
+++ b/src/components/Settings/DebugInfo.test.tsx
@@ -1,0 +1,103 @@
+import { type ReactElement } from "react";
+import { render, screen, within } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../../lib/tauri", () => ({
+  getMemoryUsage: vi.fn(),
+}));
+
+import { getMemoryUsage } from "../../lib/tauri";
+
+const mockedGetMemoryUsage = vi.mocked(getMemoryUsage);
+
+function renderWithProviders(ui: ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  );
+}
+
+let DebugInfo: () => ReactElement;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  const mod = await import("./DebugInfo");
+  DebugInfo = mod.DebugInfo;
+});
+
+describe("DebugInfo", () => {
+  it("should render debug section header", async () => {
+    mockedGetMemoryUsage.mockResolvedValue({
+      rssBytes: 50_000_000,
+      dbSizeBytes: 1_234_567,
+    });
+
+    renderWithProviders(<DebugInfo />);
+
+    const section = await screen.findByTestId("settings-debug");
+    expect(within(section).getByText(/debug/i)).toBeInTheDocument();
+  });
+
+  it("should display RSS in human-readable MB format", async () => {
+    mockedGetMemoryUsage.mockResolvedValue({
+      rssBytes: 52_428_800, // 50 MB
+      dbSizeBytes: 1_048_576,
+    });
+
+    renderWithProviders(<DebugInfo />);
+
+    expect(await screen.findByText("50 MB")).toBeInTheDocument();
+  });
+
+  it("should display database size in human-readable format", async () => {
+    mockedGetMemoryUsage.mockResolvedValue({
+      rssBytes: 50_000_000,
+      dbSizeBytes: 1_048_576, // 1 MB
+    });
+
+    renderWithProviders(<DebugInfo />);
+
+    expect(await screen.findByText("1 MB")).toBeInTheDocument();
+  });
+
+  it("should show loading state while fetching", () => {
+    mockedGetMemoryUsage.mockReturnValue(new Promise(() => {}));
+
+    renderWithProviders(<DebugInfo />);
+
+    expect(screen.getByText(/loading memory/i)).toBeInTheDocument();
+  });
+
+  it("should show unavailable when fetch fails", async () => {
+    mockedGetMemoryUsage.mockRejectedValue(new Error("failed"));
+
+    renderWithProviders(<DebugInfo />);
+
+    expect(await screen.findByText(/memory info unavailable/i)).toBeInTheDocument();
+  });
+
+  it("should format small sizes in KB", async () => {
+    mockedGetMemoryUsage.mockResolvedValue({
+      rssBytes: 50_000_000,
+      dbSizeBytes: 512_000, // ~500 KB
+    });
+
+    renderWithProviders(<DebugInfo />);
+
+    expect(await screen.findByText("500 KB")).toBeInTheDocument();
+  });
+
+  it("should format byte-level sizes", async () => {
+    mockedGetMemoryUsage.mockResolvedValue({
+      rssBytes: 50_000_000,
+      dbSizeBytes: 512,
+    });
+
+    renderWithProviders(<DebugInfo />);
+
+    expect(await screen.findByText("512 B")).toBeInTheDocument();
+  });
+});

--- a/src/components/Settings/DebugInfo.tsx
+++ b/src/components/Settings/DebugInfo.tsx
@@ -1,0 +1,42 @@
+import type { ReactElement } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { getMemoryUsage } from "../../lib/tauri";
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const kb = bytes / 1024;
+  if (kb < 1024) return `${Math.round(kb * 10) / 10} KB`;
+  const mb = kb / 1024;
+  return `${Math.round(mb * 10) / 10} MB`;
+}
+
+export function DebugInfo(): ReactElement {
+  const memoryQuery = useQuery({
+    queryKey: ["debug", "memory"],
+    queryFn: getMemoryUsage,
+    staleTime: 10_000,
+    refetchInterval: 30_000,
+  });
+
+  return (
+    <div data-testid="settings-debug" className="flex flex-col gap-3">
+      <h2 className="text-accent text-sm font-semibold uppercase tracking-wider">Debug</h2>
+      {memoryQuery.isLoading ? (
+        <span className="text-dim text-sm">Loading memory info...</span>
+      ) : memoryQuery.error ? (
+        <span className="text-dim text-sm">Memory info unavailable</span>
+      ) : memoryQuery.data ? (
+        <>
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-dim">Process RSS</span>
+            <span className="font-mono text-white">{formatBytes(memoryQuery.data.rssBytes)}</span>
+          </div>
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-dim">Database size</span>
+            <span className="font-mono text-white">{formatBytes(memoryQuery.data.dbSizeBytes)}</span>
+          </div>
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/Settings/DebugInfo.tsx
+++ b/src/components/Settings/DebugInfo.tsx
@@ -7,7 +7,9 @@ function formatBytes(bytes: number): string {
   const kb = bytes / 1024;
   if (kb < 1024) return `${Math.round(kb * 10) / 10} KB`;
   const mb = kb / 1024;
-  return `${Math.round(mb * 10) / 10} MB`;
+  if (mb < 1024) return `${Math.round(mb * 10) / 10} MB`;
+  const gb = mb / 1024;
+  return `${Math.round(gb * 10) / 10} GB`;
 }
 
 export function DebugInfo(): ReactElement {
@@ -23,19 +25,21 @@ export function DebugInfo(): ReactElement {
       <h2 className="text-accent text-sm font-semibold uppercase tracking-wider">Debug</h2>
       {memoryQuery.isLoading ? (
         <span className="text-dim text-sm">Loading memory info...</span>
-      ) : memoryQuery.error ? (
-        <span className="text-dim text-sm">Memory info unavailable</span>
       ) : memoryQuery.data ? (
         <>
           <div className="flex items-center justify-between text-sm">
             <span className="text-dim">Process RSS</span>
-            <span className="font-mono text-white">{formatBytes(memoryQuery.data.rssBytes)}</span>
+            <span className="font-mono text-white">
+              {memoryQuery.data.rssBytes > 0 ? formatBytes(memoryQuery.data.rssBytes) : "N/A"}
+            </span>
           </div>
           <div className="flex items-center justify-between text-sm">
             <span className="text-dim">Database size</span>
             <span className="font-mono text-white">{formatBytes(memoryQuery.data.dbSizeBytes)}</span>
           </div>
         </>
+      ) : memoryQuery.error ? (
+        <span className="text-dim text-sm">Memory info unavailable</span>
       ) : null}
     </div>
   );

--- a/src/components/Settings/Settings.test.tsx
+++ b/src/components/Settings/Settings.test.tsx
@@ -12,6 +12,7 @@ vi.mock("../../lib/tauri", () => ({
   setRepoEnabled: vi.fn(),
   authGetStatus: vi.fn(),
   getPersonalStats: vi.fn(),
+  getMemoryUsage: vi.fn(),
 }));
 
 import {
@@ -21,6 +22,7 @@ import {
   setRepoEnabled,
   authGetStatus,
   getPersonalStats,
+  getMemoryUsage,
 } from "../../lib/tauri";
 
 const mockedGetConfig = vi.mocked(getConfig);
@@ -29,6 +31,7 @@ const mockedListRepos = vi.mocked(listRepos);
 const mockedSetRepoEnabled = vi.mocked(setRepoEnabled);
 const mockedAuthGetStatus = vi.mocked(authGetStatus);
 const mockedGetPersonalStats = vi.mocked(getPersonalStats);
+const mockedGetMemoryUsage = vi.mocked(getMemoryUsage);
 
 function renderWithProviders(ui: ReactElement) {
   const queryClient = new QueryClient({
@@ -97,6 +100,10 @@ function setupMocks(
   mockedAuthGetStatus.mockResolvedValue(auth);
   mockedSetConfig.mockResolvedValue(config);
   mockedGetPersonalStats.mockResolvedValue(stats);
+  mockedGetMemoryUsage.mockResolvedValue({
+    rssBytes: 50_000_000,
+    dbSizeBytes: 1_048_576,
+  });
 }
 
 // Lazy import so mocks are set up before module loads
@@ -352,6 +359,16 @@ describe("Settings", () => {
     renderWithProviders(<Settings />);
 
     expect(await screen.findByText(/stats unavailable/i)).toBeInTheDocument();
+  });
+
+  it("should render debug section with memory info", async () => {
+    setupMocks();
+
+    renderWithProviders(<Settings />);
+
+    const debugSection = await screen.findByTestId("settings-debug");
+    expect(debugSection).toBeInTheDocument();
+    expect(within(debugSection).getByText(/debug/i)).toBeInTheDocument();
   });
 
   it("should show N/A for non-finite avg review response hours", async () => {

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -9,6 +9,7 @@ import {
 } from "../../lib/tauri";
 import type { PartialAppConfig, Repo } from "../../lib/types";
 import { Stats } from "./Stats";
+import { DebugInfo } from "./DebugInfo";
 
 function useConfigQuery() {
   return useQuery({ queryKey: ["config"], queryFn: getConfig });
@@ -200,6 +201,8 @@ export function Settings(): ReactElement {
       </div>
 
       <Stats />
+
+      <DebugInfo />
     </section>
   );
 }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -6,6 +6,7 @@ import type {
   AuthStatus,
   DashboardData,
   DashboardStats,
+  MemoryStats,
   OpenWorkspaceRequest,
   OpenWorkspaceResponse,
   PartialAppConfig,
@@ -126,6 +127,12 @@ export async function markActivityRead(activityId: string): Promise<boolean> {
 
 export async function markAllActivityRead(): Promise<number> {
   return invoke<number>(TAURI_COMMANDS.activity_mark_all_read);
+}
+
+// ── Debug ────────────────────────────────────────────────────────
+
+export async function getMemoryUsage(): Promise<MemoryStats> {
+  return invoke<MemoryStats>(TAURI_COMMANDS.debug_memory_usage);
 }
 
 // ── Events ───────────────────────────────────────────────────────

--- a/src/lib/types.test.ts
+++ b/src/lib/types.test.ts
@@ -425,8 +425,8 @@ describe("IPC payload shapes", () => {
 // ── TauriCommands & TauriEvents maps ─────────────────────────────
 
 describe("TAURI_COMMANDS constant", () => {
-  it("should contain all 24 IPC command names", () => {
-    expect(Object.keys(TAURI_COMMANDS)).toHaveLength(24);
+  it("should contain all 25 IPC command names", () => {
+    expect(Object.keys(TAURI_COMMANDS)).toHaveLength(25);
   });
 
   it("should include stats_personal in IPC command names", () => {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -243,6 +243,13 @@ export interface PartialAppConfig {
   readonly workspacesDir?: string | null;
 }
 
+// ── Debug (T-087) ───────────────────────────────────────────────
+
+export interface MemoryStats {
+  readonly rssBytes: number;
+  readonly dbSizeBytes: number;
+}
+
 // ── Tauri IPC command & event registries ─────────────────────────
 
 export type TauriCommandName =
@@ -269,7 +276,8 @@ export type TauriCommandName =
   | "stats_personal"
   | "auth_set_token"
   | "auth_get_status"
-  | "auth_logout";
+  | "auth_logout"
+  | "debug_memory_usage";
 
 export const TAURI_COMMANDS = {
   github_get_dashboard: "github_get_dashboard",
@@ -296,6 +304,7 @@ export const TAURI_COMMANDS = {
   auth_set_token: "auth_set_token",
   auth_get_status: "auth_get_status",
   auth_logout: "auth_logout",
+  debug_memory_usage: "debug_memory_usage",
 } as const satisfies Record<TauriCommandName, TauriCommandName>;
 
 export type TauriEventName =


### PR DESCRIPTION
## Summary
- Add `debug_memory_usage` Tauri command that returns process RSS (via `/proc/self/statm`) and SQLite DB file size
- Add `MemoryStats` struct (Rust) and interface (TypeScript) with camelCase serialization
- New `DebugInfo` component in Settings page with auto-refresh every 30s
- Human-readable byte formatting (B/KB/MB)

## Test plan
- [x] Rust: `test_memory_stats_serializes_camel_case` — roundtrip JSON
- [x] Rust: `test_get_process_rss_bytes_returns_nonzero_on_linux` — RSS > 0
- [x] Rust: `test_get_file_size_bytes_existing_file` — correct size
- [x] Rust: `test_get_file_size_bytes_missing_file` — returns 0
- [x] TS: 7 DebugInfo unit tests (loading, error, MB/KB/B formatting)
- [x] TS: Settings integration test for debug section presence
- [x] 315 Rust tests passing, 432 TS tests passing

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a memory monitoring Debug section in Settings (T-087) with auto-refresh. It uses a new `debug_memory_usage` Tauri command to show process RSS and the `SQLite` DB size.

- **New Features**
  - `debug_memory_usage` returns `MemoryStats` (`rssBytes`, `dbSizeBytes`); RSS read from `/proc/self/statm` on Linux, 0 elsewhere.
  - New `DebugInfo` shows both values with B/KB/MB/GB formatting and refreshes every 30s; shared `MemoryStats` (camelCase) and `getMemoryUsage` helper.

- **Bug Fixes**
  - Made `debug_memory_usage` best-effort and the UI resilient: returns 0 on failures, keeps stale data on refetch errors, and shows "N/A" for RSS on non-Linux.
  - Scoped `page_size` to Linux and stabilized tests by using a tempdir for missing-file cases.

<sup>Written for commit 500bffe89c5e1e8cef4f0a34376e8f473e983e06. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Debug section in Settings showing Process RSS and Database size with human-readable units and periodic refresh.

* **Tests**
  * Added unit and UI tests covering memory stats retrieval, formatting (B/KB/MB/GB), loading, error, and N/A states.

* **Chores**
  * Enabled platform-specific support for reading process memory and database file size on Linux.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->