### PR TITLE
feat(ui): add ARIA accessibility attributes (T-088)

### DIFF
--- a/src/components/Issues/IssueCard.test.tsx
+++ b/src/components/Issues/IssueCard.test.tsx
@@ -83,4 +83,16 @@ describe("IssueCard", () => {
       "https://github.com/org/repo/issues/42",
     );
   });
+
+  it("should have aria-label on link describing the issue", () => {
+    render(<IssueCard issue={makeIssue()} onOpen={vi.fn()} />);
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("aria-label", "Issue #42: Fix login bug");
+  });
+
+  it("should mark state dot as aria-hidden", () => {
+    render(<IssueCard issue={makeIssue()} onOpen={vi.fn()} />);
+    const dot = screen.getByTestId("issue-state-dot");
+    expect(dot).toHaveAttribute("aria-hidden", "true");
+  });
 });

--- a/src/components/Issues/IssueCard.test.tsx
+++ b/src/components/Issues/IssueCard.test.tsx
@@ -87,7 +87,7 @@ describe("IssueCard", () => {
   it("should have aria-label on link describing the issue", () => {
     render(<IssueCard issue={makeIssue()} onOpen={vi.fn()} />);
     const link = screen.getByRole("link");
-    expect(link).toHaveAttribute("aria-label", "Issue #42: Fix login bug");
+    expect(link).toHaveAttribute("aria-label", "Issue #42: Fix login bug (open)");
   });
 
   it("should mark state dot as aria-hidden", () => {

--- a/src/components/Issues/IssueCard.tsx
+++ b/src/components/Issues/IssueCard.tsx
@@ -27,10 +27,12 @@ export function IssueCard({ issue, onOpen }: IssueCardProps): ReactElement {
       <a
         href={issue.url}
         onClick={handleClick}
+        aria-label={`Issue #${issue.number}: ${issue.title}`}
         className="flex min-w-0 flex-1 cursor-pointer items-center gap-3 no-underline"
       >
         <span
           data-testid="issue-state-dot"
+          aria-hidden="true"
           className={`h-2.5 w-2.5 shrink-0 rounded-full ${STATE_DOT_COLOR[issue.state]}`}
         />
 

--- a/src/components/Issues/IssueCard.tsx
+++ b/src/components/Issues/IssueCard.tsx
@@ -27,7 +27,7 @@ export function IssueCard({ issue, onOpen }: IssueCardProps): ReactElement {
       <a
         href={issue.url}
         onClick={handleClick}
-        aria-label={`Issue #${issue.number}: ${issue.title}`}
+        aria-label={`Issue #${issue.number}: ${issue.title} (${issue.state})`}
         className="flex min-w-0 flex-1 cursor-pointer items-center gap-3 no-underline"
       >
         <span

--- a/src/components/MyPRs/MyPrCard.test.tsx
+++ b/src/components/MyPRs/MyPrCard.test.tsx
@@ -198,4 +198,24 @@ describe("MyPrCard", () => {
     expect(timeElement).toHaveTextContent("2h");
     vi.useRealTimers();
   });
+
+  it("should have aria-label on link describing the PR", () => {
+    render(<MyPrCard data={basePr} onOpen={vi.fn()} />);
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("aria-label", "PR #99: Add dashboard feature");
+  });
+
+  it("should mark CI dot as aria-hidden", () => {
+    render(<MyPrCard data={basePr} onOpen={vi.fn()} />);
+    const ciDot = screen.getByTestId("ci-dot");
+    expect(ciDot).toHaveAttribute("aria-hidden", "true");
+  });
+
+  it("should mark review dots as aria-hidden", () => {
+    render(<MyPrCard data={basePr} onOpen={vi.fn()} />);
+    const dots = screen.getAllByTestId("review-dot");
+    for (const dot of dots) {
+      expect(dot).toHaveAttribute("aria-hidden", "true");
+    }
+  });
 });

--- a/src/components/MyPRs/MyPrCard.tsx
+++ b/src/components/MyPRs/MyPrCard.tsx
@@ -64,10 +64,12 @@ export function MyPrCard({
       <a
         href={pr.url}
         onClick={handleClick}
+        aria-label={`PR #${pr.number}: ${pr.title}`}
         className="flex min-w-0 flex-1 cursor-pointer items-center gap-3 no-underline"
       >
         <span
           data-testid="ci-dot"
+          aria-hidden="true"
           className={`h-2.5 w-2.5 shrink-0 rounded-full ${CI_DOT_COLOR[pr.ciStatus]}`}
         />
 
@@ -90,6 +92,7 @@ export function MyPrCard({
             <span
               key={dot.key}
               data-testid="review-dot"
+              aria-hidden="true"
               className={`h-2 w-2 rounded-full ${dot.color}`}
             />
           ))}

--- a/src/components/ReviewQueue/ReviewCard.test.tsx
+++ b/src/components/ReviewQueue/ReviewCard.test.tsx
@@ -102,4 +102,10 @@ describe("ReviewCard", () => {
     await userEvent.click(screen.getByRole("button"));
     expect(handleWs).toHaveBeenCalledWith("ws-1");
   });
+
+  it("should have aria-label on link describing the PR", () => {
+    render(<ReviewCard data={mockData} onOpen={vi.fn()} />);
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("aria-label", "PR #42: Fix login bug by alice");
+  });
 });

--- a/src/components/ReviewQueue/ReviewCard.tsx
+++ b/src/components/ReviewQueue/ReviewCard.tsx
@@ -29,6 +29,7 @@ export function ReviewCard({
       <a
         href={pr.url}
         onClick={handleClick}
+        aria-label={`PR #${pr.number}: ${pr.title} by ${pr.author}`}
         className="flex min-w-0 flex-1 cursor-pointer items-center gap-3 no-underline"
       >
         <PriorityBar priority={pr.priority} />

--- a/src/components/Sidebar/NavItem.test.tsx
+++ b/src/components/Sidebar/NavItem.test.tsx
@@ -58,9 +58,17 @@ describe("NavItem", () => {
     expect(button).toHaveAttribute("aria-label", "To Review (5)");
   });
 
-  it("should have aria-label without count when count is zero or absent", () => {
+  it("should not have aria-label when count is absent", () => {
     render(
       <NavItem label="Overview" view="overview" isActive={false} onClick={vi.fn()} />,
+    );
+    const button = screen.getByRole("button");
+    expect(button).not.toHaveAttribute("aria-label");
+  });
+
+  it("should not have aria-label when count is zero", () => {
+    render(
+      <NavItem label="Issues" view="issues" count={0} isActive={false} onClick={vi.fn()} />,
     );
     const button = screen.getByRole("button");
     expect(button).not.toHaveAttribute("aria-label");

--- a/src/components/Sidebar/NavItem.test.tsx
+++ b/src/components/Sidebar/NavItem.test.tsx
@@ -49,4 +49,20 @@ describe("NavItem", () => {
     await userEvent.click(screen.getByRole("button", { name: /reviews/i }));
     expect(handleClick).toHaveBeenCalledWith("reviews");
   });
+
+  it("should have aria-label including count when present", () => {
+    render(
+      <NavItem label="To Review" view="reviews" count={5} isActive={false} onClick={vi.fn()} />,
+    );
+    const button = screen.getByRole("button");
+    expect(button).toHaveAttribute("aria-label", "To Review (5)");
+  });
+
+  it("should have aria-label without count when count is zero or absent", () => {
+    render(
+      <NavItem label="Overview" view="overview" isActive={false} onClick={vi.fn()} />,
+    );
+    const button = screen.getByRole("button");
+    expect(button).not.toHaveAttribute("aria-label");
+  });
 });

--- a/src/components/Sidebar/NavItem.tsx
+++ b/src/components/Sidebar/NavItem.tsx
@@ -21,6 +21,7 @@ export function NavItem({
       type="button"
       onClick={() => onClick(view)}
       aria-current={isActive ? "page" : undefined}
+      aria-label={count !== undefined && count > 0 ? `${label} (${count})` : undefined}
       className={`flex w-full items-center justify-between rounded px-2 py-1 text-left text-sm ${
         isActive
           ? "bg-surface text-white"

--- a/src/components/Sidebar/Sidebar.test.tsx
+++ b/src/components/Sidebar/Sidebar.test.tsx
@@ -179,4 +179,22 @@ describe("Sidebar", () => {
     renderSidebar();
     expect(screen.getByText(/⌘K/)).toBeInTheDocument();
   });
+
+  it("should have aria-label on nav items with counts", () => {
+    renderSidebar();
+    const reviewButton = screen.getByRole("button", { name: /to review \(3\)/i });
+    expect(reviewButton).toBeInTheDocument();
+  });
+
+  it("should have aria-label on workspaces section", () => {
+    renderSidebar();
+    const section = screen.getByRole("region", { name: /workspaces/i });
+    expect(section).toBeInTheDocument();
+  });
+
+  it("should have aria-label on repos section", async () => {
+    renderSidebar();
+    const section = await screen.findByRole("region", { name: /repos/i });
+    expect(section).toBeInTheDocument();
+  });
 });

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -98,8 +98,8 @@ export function Sidebar(): ReactElement {
 
       {/* Workspaces section */}
       {workspaces.length > 0 && (
-        <div className="flex flex-col gap-1">
-          <h3 className="px-2 text-[10px] font-semibold uppercase tracking-wider text-dim">
+        <div role="region" aria-labelledby="sidebar-workspaces-heading" className="flex flex-col gap-1">
+          <h3 id="sidebar-workspaces-heading" className="px-2 text-[10px] font-semibold uppercase tracking-wider text-dim">
             Workspaces
           </h3>
           <WorkspaceList
@@ -111,8 +111,8 @@ export function Sidebar(): ReactElement {
 
       {/* Repos section */}
       {repos.length > 0 && (
-        <div className="flex flex-col gap-1">
-          <h3 className="px-2 text-[10px] font-semibold uppercase tracking-wider text-dim">
+        <div role="region" aria-labelledby="sidebar-repos-heading" className="flex flex-col gap-1">
+          <h3 id="sidebar-repos-heading" className="px-2 text-[10px] font-semibold uppercase tracking-wider text-dim">
             Repos
           </h3>
           <RepoList repos={repos} onToggleRepo={handleToggleRepo} />

--- a/src/components/StatsBar/StatsBar.test.tsx
+++ b/src/components/StatsBar/StatsBar.test.tsx
@@ -177,4 +177,19 @@ describe("StatsBar", () => {
 
     expect(screen.getByText(/never synced/i)).toBeInTheDocument();
   });
+
+  it("should have role=region and aria-label on stats container", () => {
+    (useGitHubData as Mock).mockReturnValue({
+      stats: MOCK_STATS,
+      dashboard: { syncedAt: "2026-03-28T10:00:00Z" },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<StatsBar />, { wrapper: createWrapper() });
+
+    const statsBar = screen.getByTestId("stats-bar");
+    expect(statsBar).toHaveAttribute("role", "region");
+    expect(statsBar).toHaveAttribute("aria-label", "Statistics");
+  });
 });

--- a/src/components/StatsBar/StatsBar.tsx
+++ b/src/components/StatsBar/StatsBar.tsx
@@ -56,6 +56,8 @@ export function StatsBar(): ReactElement {
   return (
     <div
       data-testid="stats-bar"
+      role="region"
+      aria-label="Statistics"
       className="flex items-center justify-between border-b border-border px-4 py-2"
     >
       <div className="flex items-center gap-6">

--- a/src/components/atoms/EmptyState.test.tsx
+++ b/src/components/atoms/EmptyState.test.tsx
@@ -12,4 +12,9 @@ describe("EmptyState", () => {
     const { container } = render(<EmptyState message="Empty" />);
     expect(container.firstChild).toHaveClass("text-center");
   });
+
+  it("should have role=status for screen readers", () => {
+    render(<EmptyState message="No reviews pending" />);
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
 });

--- a/src/components/atoms/EmptyState.tsx
+++ b/src/components/atoms/EmptyState.tsx
@@ -6,7 +6,7 @@ interface EmptyStateProps {
 
 export function EmptyState({ message }: EmptyStateProps): ReactElement {
   return (
-    <div className="flex items-center justify-center py-12 text-center text-sm text-dim">
+    <div role="status" className="flex items-center justify-center py-12 text-center text-sm text-dim">
       {message}
     </div>
   );


### PR DESCRIPTION
## Summary
- Add `aria-label` on card links (`ReviewCard`, `MyPrCard`, `IssueCard`) for screen reader identification
- Add `aria-hidden="true"` on decorative dots (CI dots, review dots, state dots)
- Add `role="status"` on `EmptyState` for live region announcements
- Add `role="region"` with `aria-labelledby` on Sidebar sections (Workspaces, Repos)
- Add `role="region"` with `aria-label="Statistics"` on `StatsBar`
- Add `aria-label` with count on `NavItem` buttons (e.g., "To Review (3)")

## Test plan
- [x] 12 new ARIA accessibility tests added across 7 test files
- [x] All 447 tests pass
- [x] oxlint: 0 errors (1 pre-existing warning)
- [ ] Manual keyboard navigation testing (Tab, Enter, Esc)
- [ ] Screen reader testing (NVDA/VoiceOver)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ARIA roles and labels across the UI to improve screen reader support and clarify interactive elements. Addresses Linear T-088 and hides decorative dots from assistive tech.

- **New Features**
  - Added aria-labels to card links in `ReviewCard`, `MyPrCard`, and `IssueCard` (includes author/state where relevant).
  - Marked CI/review/issue state dots as aria-hidden.
  - Set `EmptyState` to role="status".
  - Labeled Sidebar sections (Workspaces, Repos) as role="region" with aria-labelledby.
  - Marked `StatsBar` as role="region" with aria-label "Statistics".
  - Added aria-label with count on `NavItem` buttons only when count > 0.

<sup>Written for commit fe58fd1102fcaa93bdd5bf4b4a7ae1d45fdd92fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility: links now expose descriptive labels (issue/PR number, title, state/author), visual status indicators are hidden from screen readers, and sidebar, stats, and empty-state areas declare appropriate roles and region labels.

* **Tests**
  * Added accessibility tests validating link labels, hidden status indicators, semantic regions, and status roles across components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->