### PR TITLE
feat(logging): implement structured logging with tracing (T-090)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9,17 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.17",
- "once_cell",
- "version_check",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -50,23 +39,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "android_log-sys"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84521a3cf562bc62942e294181d9eef17eb38ceb8c68677bc49f144e4c3d4f8d"
-
-[[package]]
-name = "android_logger"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb4e440d04be07da1f1bf44fb4495ebd58669372fe0cffa6e48595ac5bd88a3"
-dependencies = [
- "android_log-sys",
- "env_filter",
- "log",
-]
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -80,12 +52,6 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "assert-json-diff"
@@ -343,18 +309,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,30 +340,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "borsh"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
-dependencies = [
- "borsh-derive",
- "bytes",
- "cfg_aliases 0.2.1",
-]
-
-[[package]]
-name = "borsh-derive"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
-dependencies = [
- "once_cell",
- "proc-macro-crate 3.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -435,40 +365,6 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
-
-[[package]]
-name = "byte-unit"
-version = "5.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c6d47a4e2961fb8721bcfc54feae6455f2f64e7054f9bc67e875f0e77f4c58d"
-dependencies = [
- "rust_decimal",
- "schemars 1.2.1",
- "serde",
- "utf8-width",
-]
-
-[[package]]
-name = "bytecheck"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
-dependencies = [
- "bytecheck_derive",
- "ptr_meta",
- "simdutf8",
-]
-
-[[package]]
-name = "bytecheck_derive"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "bytemuck"
@@ -1152,16 +1048,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_filter"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1233,15 +1119,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
-]
-
-[[package]]
-name = "fern"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4316185f709b23713e41e3195f90edef7fb00c3ed4adc79769cf09cc762a3b29"
-dependencies = [
- "log",
 ]
 
 [[package]]
@@ -1351,12 +1228,6 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futf"
@@ -1862,9 +1733,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "hashbrown"
@@ -2528,9 +2396,6 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
-dependencies = [
- "value-bag",
-]
 
 [[package]]
 name = "lru-slab"
@@ -2590,6 +2455,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -2765,6 +2639,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "num-bigint-dig"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2836,15 +2719,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "num_threads"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -3429,7 +3303,6 @@ dependencies = [
  "chrono",
  "graphql_client",
  "keyring",
- "log",
  "mockito",
  "notify-rust",
  "page_size",
@@ -3441,10 +3314,12 @@ dependencies = [
  "sqlx",
  "tauri",
  "tauri-build",
- "tauri-plugin-log",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
  "uuid",
 ]
 
@@ -3514,26 +3389,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "ptr_meta"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
-dependencies = [
- "ptr_meta_derive",
-]
-
-[[package]]
-name = "ptr_meta_derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -3630,12 +3485,6 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-
-[[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -3832,15 +3681,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
-name = "rend"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
-dependencies = [
- "bytecheck",
-]
-
-[[package]]
 name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3898,35 +3738,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rkyv"
-version = "0.7.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
-dependencies = [
- "bitvec",
- "bytecheck",
- "bytes",
- "hashbrown 0.12.3",
- "ptr_meta",
- "rend",
- "rkyv_derive",
- "seahash",
- "tinyvec",
- "uuid",
-]
-
-[[package]]
-name = "rkyv_derive"
-version = "0.7.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3944,22 +3755,6 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rust_decimal"
-version = "1.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61f703d19852dbf87cbc513643fa81428361eb6940f1ac14fd58155d295a3eb0"
-dependencies = [
- "arrayvec",
- "borsh",
- "bytes",
- "num-traits",
- "rand 0.8.5",
- "rkyv",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -4151,12 +3946,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "seahash"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "security-framework"
@@ -4441,6 +4230,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shared_library"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4487,12 +4285,6 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
-
-[[package]]
-name = "simdutf8"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
@@ -5007,12 +4799,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5130,45 +4916,6 @@ dependencies = [
  "syn 2.0.117",
  "tauri-codegen",
  "tauri-utils",
-]
-
-[[package]]
-name = "tauri-plugin"
-version = "2.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddde7d51c907b940fb573006cdda9a642d6a7c8153657e88f8a5c3c9290cd4aa"
-dependencies = [
- "anyhow",
- "glob",
- "plist",
- "schemars 0.8.22",
- "serde",
- "serde_json",
- "tauri-utils",
- "toml 0.9.12+spec-1.1.0",
- "walkdir",
-]
-
-[[package]]
-name = "tauri-plugin-log"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7545bd67f070a4500432c826e2e0682146a1d6712aee22a2786490156b574d93"
-dependencies = [
- "android_logger",
- "byte-unit",
- "fern",
- "log",
- "objc2",
- "objc2-foundation",
- "serde",
- "serde_json",
- "serde_repr",
- "swift-rs",
- "tauri",
- "tauri-plugin",
- "thiserror 2.0.18",
- "time",
 ]
 
 [[package]]
@@ -5358,6 +5105,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5365,9 +5121,7 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
- "libc",
  "num-conv",
- "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -5640,6 +5394,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5657,6 +5423,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -5828,12 +5624,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
-name = "utf8-width"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5852,10 +5642,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "value-bag"
-version = "1.12.0"
+name = "valuable"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -6880,15 +6670,6 @@ dependencies = [
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
-]
-
-[[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,9 +18,7 @@ tauri-build = { version = "2.5.6" }
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-log = "0.4"
 tauri = { version = "2.10.3", features = ["tray-icon"] }
-tauri-plugin-log = "2"
 thiserror = "2.0.18"
 sqlx = { version = "0.8.6", features = ["migrate", "runtime-tokio", "sqlite"] }
 chrono = "0.4.44"
@@ -32,6 +30,9 @@ graphql_client = { version = "0.16.0", features = ["graphql_query_derive"] }
 notify-rust = "4.12.0"
 portable-pty = "0.9.0"
 regex = "1.12.3"
+tracing = "0.1.44"
+tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
+tracing-appender = "0.2.4"
 [target.'cfg(target_os = "linux")'.dependencies]
 page_size = "0.6.0"
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,6 +33,7 @@ regex = "1.12.3"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 tracing-appender = "0.2.4"
+
 [target.'cfg(target_os = "linux")'.dependencies]
 page_size = "0.6.0"
 

--- a/src-tauri/src/cache/config.rs
+++ b/src-tauri/src/cache/config.rs
@@ -77,41 +77,26 @@ pub async fn get_config(pool: &SqlitePool) -> Result<AppConfig, AppError> {
 
     for row in rows {
         match row.key.as_str() {
-            KEY_POLL_INTERVAL => match row.value.parse::<u64>() {
-                Ok(v) => config.poll_interval_secs = clamp_poll_interval(v),
-                Err(_) => warn!(
-                    "ignoring non-parseable config value for '{}': '{}', using default",
-                    KEY_POLL_INTERVAL, row.value
-                ),
-            },
-            KEY_MAX_WORKSPACES => match row.value.parse::<u32>() {
-                Ok(v) => config.max_active_workspaces = clamp_max_workspaces(v),
-                Err(_) => warn!(
-                    "ignoring non-parseable config value for '{}': '{}', using default",
-                    KEY_MAX_WORKSPACES, row.value
-                ),
-            },
-            KEY_ARCHIVE_DELAY => match row.value.parse::<u64>() {
-                Ok(v) => config.archive_delay_hours = v,
-                Err(_) => warn!(
-                    "ignoring non-parseable config value for '{}': '{}', using default",
-                    KEY_ARCHIVE_DELAY, row.value
-                ),
-            },
-            KEY_ARCHIVE_DELAY_CLOSED => match row.value.parse::<u64>() {
-                Ok(v) => config.archive_delay_closed_hours = v,
-                Err(_) => warn!(
-                    "ignoring non-parseable config value for '{}': '{}', using default",
-                    KEY_ARCHIVE_DELAY_CLOSED, row.value
-                ),
-            },
-            KEY_AUTO_SUSPEND => match row.value.parse::<u64>() {
-                Ok(v) => config.auto_suspend_minutes = clamp_auto_suspend(v),
-                Err(_) => warn!(
-                    "ignoring non-parseable config value for '{}': '{}', using default",
-                    KEY_AUTO_SUSPEND, row.value
-                ),
-            },
+            KEY_POLL_INTERVAL => if let Ok(v) = row.value.parse::<u64>() { config.poll_interval_secs = clamp_poll_interval(v) } else { warn!(
+                "ignoring non-parseable config value for '{}': '{}', using default",
+                KEY_POLL_INTERVAL, row.value
+            ); },
+            KEY_MAX_WORKSPACES => if let Ok(v) = row.value.parse::<u32>() { config.max_active_workspaces = clamp_max_workspaces(v) } else { warn!(
+                "ignoring non-parseable config value for '{}': '{}', using default",
+                KEY_MAX_WORKSPACES, row.value
+            ); },
+            KEY_ARCHIVE_DELAY => if let Ok(v) = row.value.parse::<u64>() { config.archive_delay_hours = v } else { warn!(
+                "ignoring non-parseable config value for '{}': '{}', using default",
+                KEY_ARCHIVE_DELAY, row.value
+            ); },
+            KEY_ARCHIVE_DELAY_CLOSED => if let Ok(v) = row.value.parse::<u64>() { config.archive_delay_closed_hours = v } else { warn!(
+                "ignoring non-parseable config value for '{}': '{}', using default",
+                KEY_ARCHIVE_DELAY_CLOSED, row.value
+            ); },
+            KEY_AUTO_SUSPEND => if let Ok(v) = row.value.parse::<u64>() { config.auto_suspend_minutes = clamp_auto_suspend(v) } else { warn!(
+                "ignoring non-parseable config value for '{}': '{}', using default",
+                KEY_AUTO_SUSPEND, row.value
+            ); },
             KEY_GITHUB_TOKEN => {
                 config.github_token = Some(row.value);
             }

--- a/src-tauri/src/cache/config.rs
+++ b/src-tauri/src/cache/config.rs
@@ -1,5 +1,5 @@
-use log::warn;
 use sqlx::SqlitePool;
+use tracing::warn;
 
 use crate::error::AppError;
 use crate::types::AppConfig;

--- a/src-tauri/src/cache/config.rs
+++ b/src-tauri/src/cache/config.rs
@@ -77,26 +77,56 @@ pub async fn get_config(pool: &SqlitePool) -> Result<AppConfig, AppError> {
 
     for row in rows {
         match row.key.as_str() {
-            KEY_POLL_INTERVAL => if let Ok(v) = row.value.parse::<u64>() { config.poll_interval_secs = clamp_poll_interval(v) } else { warn!(
-                "ignoring non-parseable config value for '{}': '{}', using default",
-                KEY_POLL_INTERVAL, row.value
-            ); },
-            KEY_MAX_WORKSPACES => if let Ok(v) = row.value.parse::<u32>() { config.max_active_workspaces = clamp_max_workspaces(v) } else { warn!(
-                "ignoring non-parseable config value for '{}': '{}', using default",
-                KEY_MAX_WORKSPACES, row.value
-            ); },
-            KEY_ARCHIVE_DELAY => if let Ok(v) = row.value.parse::<u64>() { config.archive_delay_hours = v } else { warn!(
-                "ignoring non-parseable config value for '{}': '{}', using default",
-                KEY_ARCHIVE_DELAY, row.value
-            ); },
-            KEY_ARCHIVE_DELAY_CLOSED => if let Ok(v) = row.value.parse::<u64>() { config.archive_delay_closed_hours = v } else { warn!(
-                "ignoring non-parseable config value for '{}': '{}', using default",
-                KEY_ARCHIVE_DELAY_CLOSED, row.value
-            ); },
-            KEY_AUTO_SUSPEND => if let Ok(v) = row.value.parse::<u64>() { config.auto_suspend_minutes = clamp_auto_suspend(v) } else { warn!(
-                "ignoring non-parseable config value for '{}': '{}', using default",
-                KEY_AUTO_SUSPEND, row.value
-            ); },
+            KEY_POLL_INTERVAL => {
+                if let Ok(v) = row.value.parse::<u64>() {
+                    config.poll_interval_secs = clamp_poll_interval(v);
+                } else {
+                    warn!(
+                        "ignoring non-parseable config value for '{}': '{}', using default",
+                        KEY_POLL_INTERVAL, row.value
+                    );
+                }
+            }
+            KEY_MAX_WORKSPACES => {
+                if let Ok(v) = row.value.parse::<u32>() {
+                    config.max_active_workspaces = clamp_max_workspaces(v);
+                } else {
+                    warn!(
+                        "ignoring non-parseable config value for '{}': '{}', using default",
+                        KEY_MAX_WORKSPACES, row.value
+                    );
+                }
+            }
+            KEY_ARCHIVE_DELAY => {
+                if let Ok(v) = row.value.parse::<u64>() {
+                    config.archive_delay_hours = v;
+                } else {
+                    warn!(
+                        "ignoring non-parseable config value for '{}': '{}', using default",
+                        KEY_ARCHIVE_DELAY, row.value
+                    );
+                }
+            }
+            KEY_ARCHIVE_DELAY_CLOSED => {
+                if let Ok(v) = row.value.parse::<u64>() {
+                    config.archive_delay_closed_hours = v;
+                } else {
+                    warn!(
+                        "ignoring non-parseable config value for '{}': '{}', using default",
+                        KEY_ARCHIVE_DELAY_CLOSED, row.value
+                    );
+                }
+            }
+            KEY_AUTO_SUSPEND => {
+                if let Ok(v) = row.value.parse::<u64>() {
+                    config.auto_suspend_minutes = clamp_auto_suspend(v);
+                } else {
+                    warn!(
+                        "ignoring non-parseable config value for '{}': '{}', using default",
+                        KEY_AUTO_SUSPEND, row.value
+                    );
+                }
+            }
             KEY_GITHUB_TOKEN => {
                 config.github_token = Some(row.value);
             }

--- a/src-tauri/src/cache/sync.rs
+++ b/src-tauri/src/cache/sync.rs
@@ -39,6 +39,7 @@ use crate::types::{Activity, ActivityType, DashboardStats, Repo};
 /// PRs that were merged/closed since the last sync drop out of `state:open`
 /// searches but remain in the cache with their last known state. A full
 /// reconciliation pass is deferred to a future task.
+#[tracing::instrument(skip(client, pool))]
 pub async fn sync_dashboard(
     client: &GitHubClient,
     pool: &SqlitePool,

--- a/src-tauri/src/cache/sync.rs
+++ b/src-tauri/src/cache/sync.rs
@@ -39,7 +39,7 @@ use crate::types::{Activity, ActivityType, DashboardStats, Repo};
 /// PRs that were merged/closed since the last sync drop out of `state:open`
 /// searches but remain in the cache with their last known state. A full
 /// reconciliation pass is deferred to a future task.
-#[tracing::instrument(skip(client, pool))]
+#[tracing::instrument(skip(client, pool, username))]
 pub async fn sync_dashboard(
     client: &GitHubClient,
     pool: &SqlitePool,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2,10 +2,10 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
-use log::warn;
 use serde::Serialize;
 use sqlx::SqlitePool;
 use tauri::{Emitter, Manager};
+use tracing::warn;
 
 use crate::cache::activity::{mark_all_read, mark_read};
 use crate::cache::config::{get_config, set_config};
@@ -630,7 +630,7 @@ pub(crate) async fn workspace_open_inner(
     )
     .await
     {
-        log::warn!("LRU eviction failed: {e}");
+        warn!("LRU eviction failed: {e}");
     }
 
     Ok(OpenWorkspaceResponse {
@@ -660,7 +660,7 @@ fn spawn_suspension_note(pool: &SqlitePool, ws: &Workspace) {
             )
             .await
             {
-                log::warn!("failed to generate suspension note for '{ws_id}': {e}");
+                warn!("failed to generate suspension note for '{ws_id}': {e}");
             }
         });
     }
@@ -679,7 +679,7 @@ pub(crate) async fn workspace_suspend_inner(
     if let Some(pty_id) = pty_state.unregister(workspace_id)
         && let Err(e) = pty_state.manager.kill(&pty_id)
     {
-        log::warn!("failed to kill PTY {pty_id} during suspend: {e}");
+        warn!("failed to kill PTY {pty_id} during suspend: {e}");
     }
 
     // Atomic transition: WHERE state = 'active' prevents TOCTOU races
@@ -749,7 +749,7 @@ pub(crate) async fn workspace_resume_inner(
         Ok(ws) => ws,
         Err(e) => {
             if let Err(kill_err) = pty_state.manager.kill(&pty_id) {
-                log::warn!("failed to kill orphaned PTY {pty_id} after DB error: {kill_err}");
+                warn!("failed to kill orphaned PTY {pty_id} after DB error: {kill_err}");
             }
             return Err(e);
         }
@@ -788,7 +788,7 @@ pub(crate) async fn workspace_archive_inner(
     if let Some(pty_id) = pty_state.unregister(&ws.id)
         && let Err(e) = pty_state.manager.kill(&pty_id)
     {
-        log::warn!("failed to kill PTY {pty_id} during archive: {e}");
+        warn!("failed to kill PTY {pty_id} during archive: {e}");
     }
 
     // Remove worktree from disk.
@@ -800,10 +800,10 @@ pub(crate) async fn workspace_archive_inner(
         if wt_path.exists()
             && let Err(e) = worktree::remove_worktree(repo_path, &wt_path).await
         {
-            log::warn!("failed to remove worktree during archive: {e}");
+            warn!("failed to remove worktree during archive: {e}");
         }
     } else if ws.worktree_path.is_some() && repo_local_path.is_none() {
-        log::warn!(
+        warn!(
             "repo has no local_path — worktree for workspace '{}' will not be removed from disk",
             ws.id
         );
@@ -834,7 +834,7 @@ pub async fn workspace_open(
             data: String::from_utf8_lossy(data).to_string(),
         };
         if let Err(e) = handle.emit("workspace:stdout", &payload) {
-            log::warn!("failed to emit workspace:stdout: {e}");
+            warn!("failed to emit workspace:stdout: {e}");
         }
     };
 
@@ -862,7 +862,7 @@ pub async fn workspace_suspend(
         new_state: ws.state,
     };
     if let Err(e) = app_handle.emit("workspace:state_changed", &payload) {
-        log::warn!("failed to emit workspace:state_changed: {e}");
+        warn!("failed to emit workspace:state_changed: {e}");
     }
     Ok(())
 }
@@ -887,7 +887,7 @@ pub async fn workspace_resume(
             data: String::from_utf8_lossy(data).to_string(),
         };
         if let Err(e) = handle.emit("workspace:stdout", &payload) {
-            log::warn!("failed to emit workspace:stdout: {e}");
+            warn!("failed to emit workspace:stdout: {e}");
         }
     };
 
@@ -900,7 +900,7 @@ pub async fn workspace_resume(
         new_state: WorkspaceState::Active,
     };
     if let Err(e) = app_handle.emit("workspace:state_changed", &payload) {
-        log::warn!("failed to emit workspace:state_changed: {e}");
+        warn!("failed to emit workspace:state_changed: {e}");
     }
 
     Ok(resp)
@@ -929,7 +929,7 @@ pub async fn workspace_archive(
     {
         Ok(repo) => repo.local_path.as_deref().map(PathBuf::from),
         Err(e) => {
-            log::warn!(
+            warn!(
                 "could not fetch repo '{}' for worktree removal — skipping: {e}",
                 ws.repo_id
             );
@@ -946,7 +946,7 @@ pub async fn workspace_archive(
         new_state: archived.state,
     };
     if let Err(e) = app_handle.emit("workspace:state_changed", &payload) {
-        log::warn!("failed to emit workspace:state_changed: {e}");
+        warn!("failed to emit workspace:state_changed: {e}");
     }
     Ok(())
 }
@@ -1007,14 +1007,14 @@ pub(crate) async fn workspace_cleanup_inner(
             match crate::cache::repos::get_repo(pool, &ws.repo_id).await {
                 Ok(repo) => repo.local_path.as_deref().map(PathBuf::from),
                 Err(e) => {
-                    log::warn!("cleanup: could not fetch repo '{}': {e}", ws.repo_id);
+                    warn!("cleanup: could not fetch repo '{}': {e}", ws.repo_id);
                     None
                 }
             };
 
         match workspace_archive_inner(pool, pty_state, &ws, local_path.as_deref()).await {
             Ok(_) => archived_ids.push(ws.id.clone()),
-            Err(e) => log::warn!("cleanup: failed to archive workspace '{}': {e}", ws.id),
+            Err(e) => warn!("cleanup: failed to archive workspace '{}': {e}", ws.id),
         }
     }
 
@@ -1048,7 +1048,7 @@ pub async fn workspace_cleanup(
             new_state: WorkspaceState::Archived,
         };
         if let Err(e) = app_handle.emit("workspace:state_changed", &payload) {
-            log::warn!("cleanup: failed to emit workspace:state_changed for '{ws_id}': {e}");
+            warn!("cleanup: failed to emit workspace:state_changed for '{ws_id}': {e}");
         }
     }
 
@@ -1076,7 +1076,7 @@ pub async fn pty_write(
         && pty_state.should_touch_last_active(&ws_id)
         && let Err(e) = crate::cache::workspaces::update_last_active(&pool, &ws_id).await
     {
-        log::warn!("pty_write: failed to touch last_active_at for workspace '{ws_id}': {e}");
+        warn!("pty_write: failed to touch last_active_at for workspace '{ws_id}': {e}");
     }
 
     Ok(())

--- a/src-tauri/src/github/polling.rs
+++ b/src-tauri/src/github/polling.rs
@@ -7,9 +7,9 @@
 
 use std::time::Duration;
 
-use log::{info, warn};
 use sqlx::SqlitePool;
 use tauri::{AppHandle, Emitter};
+use tracing::{info, warn};
 
 use crate::cache::config::get_config;
 use crate::cache::sync::sync_dashboard;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -174,12 +174,12 @@ fn log_dir_path() -> std::path::PathBuf {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // Initialize structured logging before Tauri setup.
+    // The guard must live for the full process lifetime to flush pending log events.
+    let _log_guard = init_tracing();
+
     tauri::Builder::default()
         .setup(|app| {
-            // Initialize structured logging with tracing.
-            // The guard must live for the process lifetime to flush pending log events.
-            let _log_guard = init_tracing();
-
             // Initialize SQLite database
             let data_dir = app.path().app_data_dir()?;
             std::fs::create_dir_all(&data_dir)?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -114,24 +114,30 @@ async fn try_start_polling(app_handle: tauri::AppHandle, pool: sqlx::SqlitePool)
     }
 }
 
-/// Initialize the tracing subscriber with console output and rotating file appender.
+/// Initialize the tracing subscriber with console output and non-blocking rotating file appender.
 ///
 /// - Reads `RUST_LOG` env for level filtering (defaults to `info`).
 /// - In debug builds, also logs to stdout with ANSI colors.
-/// - Always writes to a daily-rotating file in `~/.local/share/prism/logs/`.
-fn init_tracing() {
+/// - Always writes to a daily-rotating file in the platform-specific data dir.
+///
+/// Returns a [`WorkerGuard`] that **must** be held for the process lifetime;
+/// dropping it flushes and stops the background writer thread.
+fn init_tracing() -> tracing_appender::non_blocking::WorkerGuard {
     use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
 
     let log_dir = log_dir_path();
-    std::fs::create_dir_all(&log_dir).ok();
+    if let Err(e) = std::fs::create_dir_all(&log_dir) {
+        eprintln!("failed to create log directory {}: {e}", log_dir.display());
+    }
 
     let file_appender = tracing_appender::rolling::daily(&log_dir, "prism.log");
+    let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
 
     let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
 
     let registry = tracing_subscriber::registry()
         .with(env_filter)
-        .with(fmt::layer().with_writer(file_appender).with_ansi(false));
+        .with(fmt::layer().with_writer(non_blocking).with_ansi(false));
 
     if cfg!(debug_assertions) {
         registry
@@ -140,17 +146,27 @@ fn init_tracing() {
     } else {
         registry.init();
     }
+
+    guard
 }
 
-/// Returns the log directory path (`~/.local/share/prism/logs/` on Linux).
+/// Returns the platform-specific log directory path.
+///
+/// - Linux: `$XDG_DATA_HOME/prism/logs` or `~/.local/share/prism/logs`
+/// - macOS: `~/Library/Application Support/prism/logs`
+/// - Windows: `%APPDATA%/prism/logs`
 fn log_dir_path() -> std::path::PathBuf {
     if let Ok(data_home) = std::env::var("XDG_DATA_HOME") {
         return std::path::PathBuf::from(data_home).join("prism/logs");
     }
+    #[cfg(target_os = "windows")]
+    if let Ok(appdata) = std::env::var("APPDATA") {
+        return std::path::PathBuf::from(appdata).join("prism\\logs");
+    }
     if let Ok(home) = std::env::var("HOME") {
         #[cfg(target_os = "macos")]
         return std::path::PathBuf::from(&home).join("Library/Application Support/prism/logs");
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(not(any(target_os = "macos", target_os = "windows")))]
         return std::path::PathBuf::from(&home).join(".local/share/prism/logs");
     }
     std::path::PathBuf::from("prism-logs")
@@ -160,8 +176,9 @@ fn log_dir_path() -> std::path::PathBuf {
 pub fn run() {
     tauri::Builder::default()
         .setup(|app| {
-            // Initialize structured logging with tracing
-            init_tracing();
+            // Initialize structured logging with tracing.
+            // The guard must live for the process lifetime to flush pending log events.
+            let _log_guard = init_tracing();
 
             // Initialize SQLite database
             let data_dir = app.path().app_data_dir()?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,9 +12,9 @@ mod workspace;
 use std::sync::Mutex;
 use std::sync::atomic::AtomicBool;
 
-use log::info;
 use sqlx::SqlitePool;
 use tauri::Manager;
+use tracing::info;
 
 /// Guards against concurrent force-sync invocations from the tray or IPC.
 pub(crate) struct SyncInFlight(pub(crate) AtomicBool);
@@ -78,7 +78,7 @@ async fn try_start_polling(app_handle: tauri::AppHandle, pool: sqlx::SqlitePool)
         }
         Err(e) => {
             *e.into_inner() = Some(username.clone());
-            log::warn!("GithubUsername mutex was poisoned; recovered");
+            tracing::warn!("GithubUsername mutex was poisoned; recovered");
         }
     }
 
@@ -86,7 +86,7 @@ async fn try_start_polling(app_handle: tauri::AppHandle, pool: sqlx::SqlitePool)
     let client = match GitHubClient::new(&token) {
         Ok(c) => c,
         Err(e) => {
-            log::warn!("failed to create GitHub client at startup: {e}");
+            tracing::warn!("failed to create GitHub client at startup: {e}");
             return;
         }
     };
@@ -109,22 +109,59 @@ async fn try_start_polling(app_handle: tauri::AppHandle, pool: sqlx::SqlitePool)
                 old.abort();
                 info!("replaced existing polling task after poison recovery; aborted previous");
             }
-            log::warn!("PollingHandle mutex was poisoned; recovered");
+            tracing::warn!("PollingHandle mutex was poisoned; recovered");
         }
     }
+}
+
+/// Initialize the tracing subscriber with console output and rotating file appender.
+///
+/// - Reads `RUST_LOG` env for level filtering (defaults to `info`).
+/// - In debug builds, also logs to stdout with ANSI colors.
+/// - Always writes to a daily-rotating file in `~/.local/share/prism/logs/`.
+fn init_tracing() {
+    use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
+
+    let log_dir = log_dir_path();
+    std::fs::create_dir_all(&log_dir).ok();
+
+    let file_appender = tracing_appender::rolling::daily(&log_dir, "prism.log");
+
+    let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+
+    let registry = tracing_subscriber::registry()
+        .with(env_filter)
+        .with(fmt::layer().with_writer(file_appender).with_ansi(false));
+
+    if cfg!(debug_assertions) {
+        registry
+            .with(fmt::layer().with_writer(std::io::stdout))
+            .init();
+    } else {
+        registry.init();
+    }
+}
+
+/// Returns the log directory path (`~/.local/share/prism/logs/` on Linux).
+fn log_dir_path() -> std::path::PathBuf {
+    if let Ok(data_home) = std::env::var("XDG_DATA_HOME") {
+        return std::path::PathBuf::from(data_home).join("prism/logs");
+    }
+    if let Ok(home) = std::env::var("HOME") {
+        #[cfg(target_os = "macos")]
+        return std::path::PathBuf::from(&home).join("Library/Application Support/prism/logs");
+        #[cfg(not(target_os = "macos"))]
+        return std::path::PathBuf::from(&home).join(".local/share/prism/logs");
+    }
+    std::path::PathBuf::from("prism-logs")
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
         .setup(|app| {
-            if cfg!(debug_assertions) {
-                app.handle().plugin(
-                    tauri_plugin_log::Builder::default()
-                        .level(log::LevelFilter::Info)
-                        .build(),
-                )?;
-            }
+            // Initialize structured logging with tracing
+            init_tracing();
 
             // Initialize SQLite database
             let data_dir = app.path().app_data_dir()?;

--- a/src-tauri/src/notifications.rs
+++ b/src-tauri/src/notifications.rs
@@ -1,9 +1,9 @@
 #![allow(dead_code)] // Call-site integration deferred to polling loop wiring task
 
-use log::{info, warn};
 use serde::Serialize;
 use sqlx::SqlitePool;
 use tauri::Emitter;
+use tracing::{info, warn};
 
 use crate::cache::notifications::{
     clear_notification, clear_stale_notifications, try_claim_notification,

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -71,17 +71,14 @@ pub fn update_tray_badge(app_handle: &tauri::AppHandle, pending_count: u32) -> R
 #[allow(clippy::needless_pass_by_value)] // Signature imposed by Tauri on_menu_event callback
 fn handle_menu_event(app: &tauri::AppHandle, event: tauri::menu::MenuEvent) {
     match event.id().as_ref() {
-        MENU_SHOW => match app.get_webview_window("main") {
-            Some(window) => {
-                if let Err(e) = window.show() {
-                    warn!("tray: failed to show window: {e}");
-                }
-                if let Err(e) = window.set_focus() {
-                    warn!("tray: failed to focus window: {e}");
-                }
+        MENU_SHOW => if let Some(window) = app.get_webview_window("main") {
+            if let Err(e) = window.show() {
+                warn!("tray: failed to show window: {e}");
             }
-            None => warn!("tray: main window not found for MENU_SHOW"),
-        },
+            if let Err(e) = window.set_focus() {
+                warn!("tray: failed to focus window: {e}");
+            }
+        } else { warn!("tray: main window not found for MENU_SHOW") },
         MENU_FORCE_SYNC => {
             let handle = app.clone();
             tauri::async_runtime::spawn(async move {
@@ -115,24 +112,21 @@ fn handle_tray_icon_event(tray: &tauri::tray::TrayIcon, event: TrayIconEvent) {
     } = event
     {
         let app = tray.app_handle();
-        match app.get_webview_window("main") {
-            Some(window) => {
-                let visible = window.is_visible().unwrap_or(false);
-                if visible {
-                    if let Err(e) = window.hide() {
-                        warn!("tray: failed to hide window: {e}");
-                    }
-                } else {
-                    if let Err(e) = window.show() {
-                        warn!("tray: failed to show window: {e}");
-                    }
-                    if let Err(e) = window.set_focus() {
-                        warn!("tray: failed to focus window: {e}");
-                    }
+        if let Some(window) = app.get_webview_window("main") {
+            let visible = window.is_visible().unwrap_or(false);
+            if visible {
+                if let Err(e) = window.hide() {
+                    warn!("tray: failed to hide window: {e}");
+                }
+            } else {
+                if let Err(e) = window.show() {
+                    warn!("tray: failed to show window: {e}");
+                }
+                if let Err(e) = window.set_focus() {
+                    warn!("tray: failed to focus window: {e}");
                 }
             }
-            None => warn!("tray: main window not found for tray icon click"),
-        }
+        } else { warn!("tray: main window not found for tray icon click") }
     }
 }
 

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -71,14 +71,18 @@ pub fn update_tray_badge(app_handle: &tauri::AppHandle, pending_count: u32) -> R
 #[allow(clippy::needless_pass_by_value)] // Signature imposed by Tauri on_menu_event callback
 fn handle_menu_event(app: &tauri::AppHandle, event: tauri::menu::MenuEvent) {
     match event.id().as_ref() {
-        MENU_SHOW => if let Some(window) = app.get_webview_window("main") {
-            if let Err(e) = window.show() {
-                warn!("tray: failed to show window: {e}");
+        MENU_SHOW => {
+            if let Some(window) = app.get_webview_window("main") {
+                if let Err(e) = window.show() {
+                    warn!("tray: failed to show window: {e}");
+                }
+                if let Err(e) = window.set_focus() {
+                    warn!("tray: failed to focus window: {e}");
+                }
+            } else {
+                warn!("tray: main window not found for MENU_SHOW");
             }
-            if let Err(e) = window.set_focus() {
-                warn!("tray: failed to focus window: {e}");
-            }
-        } else { warn!("tray: main window not found for MENU_SHOW") },
+        }
         MENU_FORCE_SYNC => {
             let handle = app.clone();
             tauri::async_runtime::spawn(async move {
@@ -126,7 +130,9 @@ fn handle_tray_icon_event(tray: &tauri::tray::TrayIcon, event: TrayIconEvent) {
                     warn!("tray: failed to focus window: {e}");
                 }
             }
-        } else { warn!("tray: main window not found for tray icon click") }
+        } else {
+            warn!("tray: main window not found for tray icon click");
+        }
     }
 }
 

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -1,7 +1,7 @@
-use log::warn;
 use tauri::Manager;
 use tauri::menu::{Menu, MenuItem, PredefinedMenuItem};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
+use tracing::warn;
 
 pub(crate) const TRAY_ID: &str = "prism_tray";
 pub(crate) const MENU_SHOW: &str = "show_prism";

--- a/src-tauri/src/workspace/lifecycle.rs
+++ b/src-tauri/src/workspace/lifecycle.rs
@@ -1,7 +1,7 @@
 use chrono::{Duration, SecondsFormat, Utc};
-use log::{info, warn};
 use sqlx::SqlitePool;
 use tauri::Manager;
+use tracing::{info, warn};
 
 use crate::commands::{PtyManagerState, workspace_cleanup_inner, workspace_suspend_inner};
 use crate::error::AppError;
@@ -110,6 +110,7 @@ pub(crate) async fn enforce_max_active(
 /// workspaces whose PRs have been merged/closed past the configured delay.
 ///
 /// Returns `(suspended_ids, archived_ids)`.
+#[tracing::instrument(skip(pool, pty_state))]
 pub(crate) async fn run_lifecycle_tick(
     pool: &SqlitePool,
     pty_state: &PtyManagerState,

--- a/src-tauri/src/workspace/pty.rs
+++ b/src-tauri/src/workspace/pty.rs
@@ -67,6 +67,7 @@ impl PtyManager {
     /// Panics if called outside a Tokio runtime context (uses
     /// `tokio::task::spawn_blocking` internally).
     #[allow(dead_code)]
+    #[tracing::instrument(skip(self, on_output), fields(cwd = %cwd.display()))]
     pub fn spawn(
         &self,
         cwd: &Path,
@@ -123,7 +124,7 @@ impl PtyManager {
                     Ok(0) => break,
                     Ok(n) => on_output(&id_for_task, &buf[..n]),
                     Err(e) => {
-                        log::warn!("pty reader error for {id_for_task}: {e}");
+                        tracing::warn!("pty reader error for {id_for_task}: {e}");
                         break;
                     }
                 }
@@ -236,6 +237,7 @@ impl PtyManager {
     /// The map lock is released before performing the kill syscall.
     /// Sets the `killed` flag so `Drop` does not issue a redundant kill.
     #[allow(dead_code)]
+    #[tracing::instrument(skip(self))]
     pub fn kill(&self, pty_id: &str) -> Result<(), AppError> {
         let mut handle = {
             let mut ptys = self

--- a/src-tauri/src/workspace/pty.rs
+++ b/src-tauri/src/workspace/pty.rs
@@ -67,7 +67,7 @@ impl PtyManager {
     /// Panics if called outside a Tokio runtime context (uses
     /// `tokio::task::spawn_blocking` internally).
     #[allow(dead_code)]
-    #[tracing::instrument(skip(self, on_output), fields(cwd = %cwd.display()))]
+    #[tracing::instrument(skip(self, on_output, cwd))]
     pub fn spawn(
         &self,
         cwd: &Path,


### PR DESCRIPTION
## Summary

• Replace `log` + `tauri-plugin-log` with `tracing` + `tracing-subscriber` + `tracing-appender` for structured logging
• Add rotating daily log file output to `~/.local/share/prism/logs/prism.log`
• Initialize tracing subscriber in debug builds with stdout output + ANSI colors
• Filter logs via `RUST_LOG` env variable (defaults to `info` level)
• Add `#[tracing::instrument]` spans on critical functions: `sync_dashboard`, `run_lifecycle_tick`, `pty.spawn`, `pty.kill`
• Migrate all logging calls from `log::*` to `tracing::*` (8 files)

## Type

feat

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements structured logging with `tracing` (T-090) across the Tauri backend. Replaces `log`/`tauri-plugin-log`, adds daily rotating file logs, env-based filtering, and colored stdout in debug, with a non-blocking file writer kept for the process lifetime.

- **New Features**
  - Structured logging via `tracing`, `tracing-subscriber` (env-filter), and `tracing-appender`; `WorkerGuard` is held in `run()` to keep the writer alive.
  - Daily-rotating `prism.log` in the app data dir; debug builds also log to stdout with ANSI colors; filter via `RUST_LOG` (default: info).
  - Added #[tracing::instrument] to `sync_dashboard`, `run_lifecycle_tick`, `PtyManager::spawn`, `PtyManager::kill`.
  - Replaced all `log::*` with `tracing::*` and cleaned up clippy warnings; minor formatting and missing semicolons fixed.

- **Dependencies**
  - Removed `log` and `tauri-plugin-log`.
  - Added `tracing`, `tracing-subscriber` (with `env-filter`), `tracing-appender`.

<sup>Written for commit 601eb04d09268b5bc7e15f2d537a7888dc0a6be9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Replaced the logging backend with the tracing ecosystem, enabling structured logs, configurable log levels via RUST_LOG, and daily rotated log files (with stdout in debug builds).

* **Refactor**
  * Added runtime tracing instrumentation across dashboard sync, lifecycle ticks, PTY operations, and command paths to improve diagnostics and observability without changing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->