### PR TITLE
feat(ui): add ErrorBoundary component (T-091)

### DIFF
--- a/src/components/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.test.tsx
@@ -45,7 +45,11 @@ describe("ErrorBoundary", () => {
       </ErrorBoundary>,
     );
 
-    expect(console.error).toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalledWith(
+      "ErrorBoundary caught:",
+      expect.any(Error),
+      expect.objectContaining({ componentStack: expect.any(String) }),
+    );
   });
 
   it("should retry on button click", async () => {

--- a/src/components/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.test.tsx
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
+import type { ReactNode } from "react";
 import { ErrorBoundary } from "./ErrorBoundary";
 
 function ProblemChild(): never {
@@ -10,6 +11,10 @@ function ProblemChild(): never {
 describe("ErrorBoundary", () => {
   beforeEach(() => {
     vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("should render children when no error", () => {
@@ -46,7 +51,7 @@ describe("ErrorBoundary", () => {
   it("should retry on button click", async () => {
     let shouldThrow = true;
 
-    function MaybeThrow(): JSX.Element {
+    function MaybeThrow(): ReactNode {
       if (shouldThrow) {
         throw new Error("Test error");
       }

--- a/src/components/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { ErrorBoundary } from "./ErrorBoundary";
+
+function ProblemChild(): never {
+  throw new Error("Test error");
+}
+
+describe("ErrorBoundary", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  it("should render children when no error", () => {
+    render(
+      <ErrorBoundary>
+        <p>All good</p>
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText("All good")).toBeInTheDocument();
+  });
+
+  it("should render fallback on error", () => {
+    render(
+      <ErrorBoundary>
+        <ProblemChild />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+
+  it("should log error to console", () => {
+    render(
+      <ErrorBoundary>
+        <ProblemChild />
+      </ErrorBoundary>,
+    );
+
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it("should retry on button click", async () => {
+    let shouldThrow = true;
+
+    function MaybeThrow(): JSX.Element {
+      if (shouldThrow) {
+        throw new Error("Test error");
+      }
+      return <p>Recovered</p>;
+    }
+
+    render(
+      <ErrorBoundary>
+        <MaybeThrow />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+
+    shouldThrow = false;
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /retry/i }));
+
+    expect(screen.getByText("Recovered")).toBeInTheDocument();
+  });
+});

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,21 +1,22 @@
-import { Component, type ErrorInfo, type ReactElement, type ReactNode } from "react";
+import { Component, type ErrorInfo, type ReactNode } from "react";
 
 interface ErrorBoundaryProps {
   readonly children: ReactNode;
 }
 
 interface ErrorBoundaryState {
-  readonly hasError: boolean;
+  readonly error: Error | null;
+  readonly resetKey: number;
 }
 
 export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   constructor(props: ErrorBoundaryProps) {
     super(props);
-    this.state = { hasError: false };
+    this.state = { error: null, resetKey: 0 };
   }
 
-  static getDerivedStateFromError(): ErrorBoundaryState {
-    return { hasError: true };
+  static getDerivedStateFromError(error: Error): Partial<ErrorBoundaryState> {
+    return { error };
   }
 
   componentDidCatch(error: Error, info: ErrorInfo): void {
@@ -23,24 +24,28 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
   }
 
   render(): ReactNode {
-    if (this.state.hasError) {
+    if (this.state.error) {
       return (
         <div
           role="alert"
-          aria-live="assertive"
           className="flex h-screen flex-col items-center justify-center gap-4 bg-bg text-fg"
         >
           <p className="text-lg font-medium">Something went wrong</p>
           <button
             type="button"
             className="rounded border border-border px-4 py-2 text-sm hover:bg-bg-hover"
-            onClick={() => this.setState({ hasError: false })}
+            onClick={() =>
+              this.setState((prev) => ({
+                error: null,
+                resetKey: prev.resetKey + 1,
+              }))
+            }
           >
             Retry
           </button>
         </div>
       );
     }
-    return this.props.children;
+    return <div key={this.state.resetKey}>{this.props.children}</div>;
   }
 }

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,46 @@
+import { Component, type ErrorInfo, type ReactElement, type ReactNode } from "react";
+
+interface ErrorBoundaryProps {
+  readonly children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  readonly hasError: boolean;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error("ErrorBoundary caught:", error, info);
+  }
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      return (
+        <div
+          role="alert"
+          aria-live="assertive"
+          className="flex h-screen flex-col items-center justify-center gap-4 bg-bg text-fg"
+        >
+          <p className="text-lg font-medium">Something went wrong</p>
+          <button
+            type="button"
+            className="rounded border border-border px-4 py-2 text-sm hover:bg-bg-hover"
+            onClick={() => this.setState({ hasError: false })}
+          >
+            Retry
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,4 +1,4 @@
-import { Component, type ErrorInfo, type ReactNode } from "react";
+import { Component, Fragment, type ErrorInfo, type ReactNode } from "react";
 
 interface ErrorBoundaryProps {
   readonly children: ReactNode;
@@ -6,6 +6,8 @@ interface ErrorBoundaryProps {
 
 interface ErrorBoundaryState {
   readonly error: Error | null;
+  // Incrementing key forces React to unmount and remount the entire child tree,
+  // ensuring stale component state is discarded on retry.
   readonly resetKey: number;
 }
 
@@ -46,6 +48,6 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
         </div>
       );
     }
-    return <div key={this.state.resetKey}>{this.props.children}</div>;
+    return <Fragment key={this.state.resetKey}>{this.props.children}</Fragment>;
   }
 }

--- a/src/components/ErrorBoundary/index.ts
+++ b/src/components/ErrorBoundary/index.ts
@@ -1,0 +1,1 @@
+export { ErrorBoundary } from "./ErrorBoundary";

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ErrorBoundary } from "./components/ErrorBoundary";
 import "./index.css";
 import App from "./App";
 
@@ -8,8 +9,10 @@ const queryClient = new QueryClient();
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <App />
-    </QueryClientProvider>
+    <ErrorBoundary>
+      <QueryClientProvider client={queryClient}>
+        <App />
+      </QueryClientProvider>
+    </ErrorBoundary>
   </React.StrictMode>,
 );


### PR DESCRIPTION
## Summary
- Add `ErrorBoundary` class component that catches React runtime errors and displays a "Something went wrong" fallback with a Retry button
- Retry uses `resetKey` pattern to force full remount of the errored subtree
- Wrap entire app in `main.tsx` above `QueryClientProvider`
- Error is stored in state and logged to console via `componentDidCatch`

## Test plan
- [x] `it("should render children when no error")` — normal render path
- [x] `it("should render fallback on error")` — error caught, fallback displayed
- [x] `it("should log error to console")` — componentDidCatch fires
- [x] `it("should retry on button click")` — resetKey forces remount, recovered
- [x] 452 existing tests pass — no regressions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a global ErrorBoundary that catches React runtime errors and shows a simple fallback with a Retry button. Implements T-091 and wraps the entire app to improve crash recovery.

- **New Features**
  - Retry remounts the errored subtree using a keyed Fragment (resetKey) to clear state without extra DOM.
  - Boundary sits above QueryClientProvider and logs errors via componentDidCatch; tests cover normal, error, and retry flows.

- **Refactors**
  - Replace wrapper div with Fragment; add comment explaining resetKey; tighten console.error test assertion.

<sup>Written for commit a51dff824166a7400fc4aad526ff2166fd3c6c44. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App-wide error boundary added to catch runtime errors and show a full-screen fallback with “Something went wrong” and a “Retry” button; retry remounts content so recovered UI is shown.
  * Error events are logged for troubleshooting.

* **Tests**
  * New tests cover normal rendering, fallback UI on errors, console logging of caught errors, and recovery after retry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->