### PR TITLE
test(github): add rate limit backoff and recovery tests (T-093)

### DIFF
--- a/src-tauri/src/github/polling.rs
+++ b/src-tauri/src/github/polling.rs
@@ -81,6 +81,7 @@ impl PollingContext for RealPollingContext {
 // ── Core loop ────────────────────────────────────────────────────
 
 /// Result of a single polling iteration.
+#[derive(Debug)]
 pub(crate) enum PollOutcome {
     /// Sync succeeded.
     Ok,
@@ -350,5 +351,69 @@ mod tests {
             60,
             "unparseable timestamp should fall back to 60s"
         );
+    }
+
+    #[tokio::test]
+    async fn test_rate_limit_triggers_backoff() {
+        let reset_at = (chrono::Utc::now() + chrono::Duration::seconds(90)).to_rfc3339();
+        let err = AppError::RateLimit {
+            reset_at: reset_at.clone(),
+        };
+        let (ctx, recorder) = MockCtx::new(vec![Err(err)]);
+
+        let outcome = poll_once(&ctx).await;
+
+        // poll_once returns RateLimited with the correct reset_at
+        let returned_reset = match outcome {
+            PollOutcome::RateLimited { reset_at } => reset_at,
+            other => panic!("expected RateLimited, got {other:?}"),
+        };
+        assert_eq!(returned_reset, reset_at, "reset_at should be forwarded");
+
+        // rate_limit_backoff computes a duration close to the reset window
+        let backoff = rate_limit_backoff(&returned_reset);
+        assert!(
+            backoff.as_secs() > 80 && backoff.as_secs() <= 90,
+            "backoff should be ~90s, got {}s",
+            backoff.as_secs()
+        );
+
+        // sync_error event was emitted with rate limit message
+        let errors = recorder.errors.lock().unwrap();
+        assert_eq!(errors.len(), 1);
+        assert!(
+            errors[0].contains("rate limited"),
+            "error should mention rate limiting"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_rate_limit_recovery() {
+        let stats = make_stats(4);
+        let err = AppError::RateLimit {
+            reset_at: "2026-03-31T12:00:00Z".into(),
+        };
+        let (ctx, recorder) = MockCtx::new(vec![Err(err), Ok(stats.clone())]);
+
+        // First poll: rate limited
+        let first = poll_once(&ctx).await;
+        assert!(
+            matches!(first, PollOutcome::RateLimited { .. }),
+            "first poll should be rate limited"
+        );
+
+        // Second poll: recovered
+        let second = poll_once(&ctx).await;
+        assert!(
+            matches!(second, PollOutcome::Ok),
+            "second poll should succeed after recovery"
+        );
+
+        // Verify events: one error then one update
+        let errors = recorder.errors.lock().unwrap();
+        assert_eq!(errors.len(), 1, "only one error event");
+        let updates = recorder.updates.lock().unwrap();
+        assert_eq!(updates.len(), 1, "one successful update after recovery");
+        assert_eq!(updates[0], stats, "recovered stats should match");
     }
 }

--- a/src-tauri/src/github/polling.rs
+++ b/src-tauri/src/github/polling.rs
@@ -355,7 +355,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_rate_limit_triggers_backoff() {
-        let reset_at = (chrono::Utc::now() + chrono::Duration::seconds(90)).to_rfc3339();
+        let reset_at = (chrono::Utc::now() + chrono::Duration::seconds(300)).to_rfc3339();
         let err = AppError::RateLimit {
             reset_at: reset_at.clone(),
         };
@@ -373,8 +373,8 @@ mod tests {
         // rate_limit_backoff computes a duration close to the reset window
         let backoff = rate_limit_backoff(&returned_reset);
         assert!(
-            backoff.as_secs() > 80 && backoff.as_secs() <= 90,
-            "backoff should be ~90s, got {}s",
+            backoff.as_secs() > 250 && backoff.as_secs() <= 300,
+            "backoff should be ~300s, got {}s",
             backoff.as_secs()
         );
 
@@ -390,9 +390,8 @@ mod tests {
     #[tokio::test]
     async fn test_rate_limit_recovery() {
         let stats = make_stats(4);
-        let err = AppError::RateLimit {
-            reset_at: "2026-03-31T12:00:00Z".into(),
-        };
+        let reset_at = (chrono::Utc::now() + chrono::Duration::hours(1)).to_rfc3339();
+        let err = AppError::RateLimit { reset_at };
         let (ctx, recorder) = MockCtx::new(vec![Err(err), Ok(stats.clone())]);
 
         // First poll: rate limited


### PR DESCRIPTION
## Summary
- Add `test_rate_limit_triggers_backoff()` verifying the full chain: `AppError::RateLimit` → `PollOutcome::RateLimited` → `rate_limit_backoff()` computes correct duration
- Add `test_rate_limit_recovery()` verifying polling resumes normally after a rate limit window
- Derive `Debug` on `PollOutcome` for test diagnostics

Note: The rate limit detection (client.rs), backoff logic, and event emission (polling.rs) were already implemented as part of T-029/T-034. This task adds the specific integration tests required by the backlog.

## Test plan
- [x] `cargo test --lib github::polling` — 9 tests pass (7 existing + 2 new)
- [x] `cargo test --lib` — 317 tests pass, no regressions
- [x] `cargo clippy -- -D warnings` — clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements T-093 by adding integration tests to verify GitHub polling backs off on rate limits and resumes after the reset window. Makes the tests CI-stable by using a 300s future reset with a wider tolerance and dynamic future timestamps, and derives `Debug` on `PollOutcome` for clearer output.

<sup>Written for commit 3ad3422efc57f54a8639e700b93cf018832667d1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for rate-limit handling: verifies backoff timing when rate limited and that recovery resumes normal updates.
  * Improved test diagnostics to aid debugging of poll outcomes and emitted events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->