### PR TITLE
feat(github): handle expired/invalid token during polling (T-094)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -76,17 +76,28 @@ async fn set_token_inner(token: String) -> Result<String, String> {
 /// Validates and stores a GitHub token. Returns the authenticated username.
 ///
 /// Also updates the cached username so subsequent dashboard calls use the
-/// new identity without re-validating the token.
+/// new identity without re-validating the token. Restarts the background
+/// polling loop and emits `auth:restored` so the frontend can recover from
+/// an `auth:expired` state.
 #[tauri::command]
 pub async fn auth_set_token(
     token: String,
     cached: tauri::State<'_, GithubUsername>,
+    app_handle: tauri::AppHandle,
+    pool: tauri::State<'_, SqlitePool>,
 ) -> Result<String, String> {
     let username = set_token_inner(token).await?;
     match cached.0.lock() {
         Ok(mut guard) => *guard = Some(username.clone()),
         Err(e) => warn!("failed to update cached username: {e}"),
     }
+
+    // Restart polling with the new token and notify the frontend
+    crate::try_start_polling(app_handle.clone(), pool.inner().clone()).await;
+    if let Err(e) = app_handle.emit("auth:restored", &username) {
+        warn!("failed to emit auth:restored: {e}");
+    }
+
     Ok(username)
 }
 

--- a/src-tauri/src/github/polling.rs
+++ b/src-tauri/src/github/polling.rs
@@ -34,6 +34,9 @@ pub(crate) trait PollingContext: Send + Sync + 'static {
 
     /// Notify the frontend of a sync failure.
     fn emit_sync_error(&self, error: &str);
+
+    /// Notify the frontend that the token is expired/invalid (401).
+    fn emit_auth_expired(&self, error: &str);
 }
 
 // ── Real implementation ──────────────────────────────────────────
@@ -76,6 +79,12 @@ impl PollingContext for RealPollingContext {
             warn!("failed to emit github:sync_error: {e}");
         }
     }
+
+    fn emit_auth_expired(&self, error: &str) {
+        if let Err(e) = self.app_handle.emit("auth:expired", error) {
+            warn!("failed to emit auth:expired: {e}");
+        }
+    }
 }
 
 // ── Core loop ────────────────────────────────────────────────────
@@ -89,6 +98,8 @@ pub(crate) enum PollOutcome {
     Failed,
     /// Rate-limited; caller should back off until `reset_at`.
     RateLimited { reset_at: String },
+    /// Authentication failed (401); polling must stop.
+    AuthExpired,
 }
 
 /// Execute a single polling iteration: sync then emit.
@@ -101,6 +112,14 @@ pub(crate) async fn poll_once(ctx: &(impl PollingContext + ?Sized)) -> PollOutco
             );
             ctx.emit_updated(&stats);
             PollOutcome::Ok
+        }
+        // In the polling path, AppError::Auth can only originate from an HTTP 401
+        // in `GitHubClient::execute_graphql`. Keychain errors happen at startup
+        // (try_start_polling) before the loop begins and never reach poll_once.
+        Err(AppError::Auth(ref msg)) => {
+            warn!("authentication failed (401): {msg}; returning AuthExpired to caller");
+            ctx.emit_auth_expired(msg);
+            PollOutcome::AuthExpired
         }
         Err(AppError::RateLimit { ref reset_at }) => {
             warn!("rate limited until {reset_at}; backing off");
@@ -148,6 +167,10 @@ async fn polling_loop(ctx: impl PollingContext) {
                 Duration::from_secs(secs)
             }
             PollOutcome::RateLimited { reset_at } => rate_limit_backoff(&reset_at),
+            PollOutcome::AuthExpired => {
+                info!("polling stopped: authentication expired");
+                return;
+            }
         };
         tokio::time::sleep(sleep_duration).await;
     }
@@ -187,6 +210,7 @@ mod tests {
     struct Recorder {
         updates: Arc<Mutex<Vec<DashboardStats>>>,
         errors: Arc<Mutex<Vec<String>>>,
+        auth_expired: Arc<Mutex<Vec<String>>>,
     }
 
     /// Mock context that returns pre-configured sync results.
@@ -230,6 +254,14 @@ mod tests {
         fn emit_sync_error(&self, error: &str) {
             self.recorder
                 .errors
+                .lock()
+                .expect("lock poisoned")
+                .push(error.to_string());
+        }
+
+        fn emit_auth_expired(&self, error: &str) {
+            self.recorder
+                .auth_expired
                 .lock()
                 .expect("lock poisoned")
                 .push(error.to_string());
@@ -385,6 +417,61 @@ mod tests {
             errors[0].contains("rate limited"),
             "error should mention rate limiting"
         );
+    }
+
+    #[tokio::test]
+    async fn test_401_stops_polling() {
+        let err = AppError::Auth("invalid or expired token".into());
+        let (ctx, recorder) = MockCtx::new(vec![Err(err)]);
+
+        let outcome = poll_once(&ctx).await;
+
+        assert!(
+            matches!(outcome, PollOutcome::AuthExpired),
+            "poll_once should return AuthExpired on 401, got {outcome:?}"
+        );
+        assert!(
+            recorder.updates.lock().expect("lock poisoned").is_empty(),
+            "no updates should be emitted on auth failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_401_emits_event() {
+        let err = AppError::Auth("invalid or expired token".into());
+        let (ctx, recorder) = MockCtx::new(vec![Err(err)]);
+
+        poll_once(&ctx).await;
+
+        let auth_expired = recorder.auth_expired.lock().expect("lock poisoned");
+        assert_eq!(
+            auth_expired.len(),
+            1,
+            "should emit exactly one auth:expired event"
+        );
+        assert!(
+            auth_expired[0].contains("invalid or expired token"),
+            "event should contain the error message, got '{}'",
+            auth_expired[0]
+        );
+        assert!(
+            recorder.errors.lock().expect("lock poisoned").is_empty(),
+            "auth errors should not be emitted as sync errors"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_polling_loop_exits_on_auth_expired() {
+        let err = AppError::Auth("token expired".into());
+        let (ctx, recorder) = MockCtx::new(vec![Err(err)]);
+
+        // If polling_loop doesn't return on AuthExpired, this test times out.
+        tokio::time::timeout(Duration::from_secs(2), polling_loop(ctx))
+            .await
+            .expect("polling_loop should exit on AuthExpired, but it timed out");
+
+        let expired = recorder.auth_expired.lock().expect("lock poisoned");
+        assert_eq!(expired.len(), 1, "should have emitted auth:expired event");
     }
 
     #[tokio::test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -41,7 +41,7 @@ impl Default for PollingHandle {
 ///
 /// Runs asynchronously after app setup completes. If no token is stored
 /// or validation fails, polling is deferred until the next app launch.
-async fn try_start_polling(app_handle: tauri::AppHandle, pool: sqlx::SqlitePool) {
+pub(crate) async fn try_start_polling(app_handle: tauri::AppHandle, pool: sqlx::SqlitePool) {
     use crate::github::{auth, client::GitHubClient, polling::start_polling};
 
     // Read token from keychain (blocking — runs on a dedicated thread)

--- a/src/components/Overview/Overview.test.tsx
+++ b/src/components/Overview/Overview.test.tsx
@@ -110,6 +110,7 @@ function setupMock(dashboard: DashboardData | null = makeDashboard()) {
     stats: null,
     isLoading: false,
     error: null,
+    authExpired: false,
     forceSync: vi.fn(),
     isSyncing: false,
   });
@@ -223,6 +224,7 @@ describe("Overview", () => {
       stats: null,
       isLoading: true,
       error: null,
+      authExpired: false,
       forceSync: vi.fn(),
       isSyncing: false,
     });
@@ -238,6 +240,7 @@ describe("Overview", () => {
       stats: null,
       isLoading: false,
       error: new Error("Network error"),
+      authExpired: false,
       forceSync: vi.fn(),
       isSyncing: false,
     });
@@ -253,6 +256,7 @@ describe("Overview", () => {
       stats: null,
       isLoading: false,
       error: new Error("Stats failed"),
+      authExpired: false,
       forceSync: vi.fn(),
       isSyncing: false,
     });

--- a/src/hooks/useGitHubData.test.ts
+++ b/src/hooks/useGitHubData.test.ts
@@ -157,10 +157,74 @@ describe("useGitHubData", () => {
     const { unmount } = renderHook(() => useGitHubData(), { wrapper });
 
     await waitFor(() => {
-      expect(onEvent).toHaveBeenCalledOnce();
+      expect(onEvent).toHaveBeenCalledTimes(2);
     });
 
     unmount();
-    expect(unlistenFn).toHaveBeenCalledOnce();
+    // Both listeners should be cleaned up
+    expect(unlistenFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("should set authExpired when auth:expired event fires", async () => {
+    (getGithubDashboard as Mock).mockResolvedValue(MOCK_DASHBOARD);
+    (getGithubStats as Mock).mockResolvedValue(MOCK_STATS);
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useGitHubData(), { wrapper });
+
+    expect(result.current.authExpired).toBe(false);
+
+    await waitFor(() => {
+      expect(onEvent).toHaveBeenCalledWith(
+        "auth:expired",
+        expect.any(Function),
+      );
+    });
+
+    // Find the auth:expired callback
+    const authCall = (onEvent as Mock).mock.calls.find(
+      (c: unknown[]) => c[0] === "auth:expired",
+    );
+    expect(authCall).toBeDefined();
+    const authCallback = authCall![1] as (payload: string) => void;
+
+    await act(() => {
+      authCallback("invalid or expired token");
+    });
+
+    expect(result.current.authExpired).toBe(true);
+  });
+
+  it("should disable queries when authExpired", async () => {
+    (getGithubDashboard as Mock).mockResolvedValue(MOCK_DASHBOARD);
+    (getGithubStats as Mock).mockResolvedValue(MOCK_STATS);
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useGitHubData(30_000), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // Clear call counts before triggering auth:expired
+    (getGithubDashboard as Mock).mockClear();
+    (getGithubStats as Mock).mockClear();
+
+    // Trigger auth:expired
+    const authCall = (onEvent as Mock).mock.calls.find(
+      (c: unknown[]) => c[0] === "auth:expired",
+    );
+    const authCallback = authCall![1] as (payload: string) => void;
+
+    await act(() => {
+      authCallback("invalid or expired token");
+    });
+
+    expect(result.current.authExpired).toBe(true);
+
+    // Queries should not refetch after auth expiry
+    // (enabled: false prevents new fetches)
+    expect(getGithubDashboard).not.toHaveBeenCalled();
+    expect(getGithubStats).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/useGitHubData.test.ts
+++ b/src/hooks/useGitHubData.test.ts
@@ -157,12 +157,12 @@ describe("useGitHubData", () => {
     const { unmount } = renderHook(() => useGitHubData(), { wrapper });
 
     await waitFor(() => {
-      expect(onEvent).toHaveBeenCalledTimes(2);
+      expect(onEvent).toHaveBeenCalledTimes(3);
     });
 
     unmount();
-    // Both listeners should be cleaned up
-    expect(unlistenFn).toHaveBeenCalledTimes(2);
+    // All 3 listeners should be cleaned up
+    expect(unlistenFn).toHaveBeenCalledTimes(3);
   });
 
   it("should set authExpired when auth:expired event fires", async () => {
@@ -196,13 +196,15 @@ describe("useGitHubData", () => {
   });
 
   it("should disable queries when authExpired", async () => {
+    vi.useFakeTimers();
+
     (getGithubDashboard as Mock).mockResolvedValue(MOCK_DASHBOARD);
     (getGithubStats as Mock).mockResolvedValue(MOCK_STATS);
 
     const { wrapper } = createWrapper();
-    const { result } = renderHook(() => useGitHubData(30_000), { wrapper });
+    const { result } = renderHook(() => useGitHubData(100), { wrapper });
 
-    await waitFor(() => {
+    await vi.waitFor(() => {
       expect(result.current.isLoading).toBe(false);
     });
 
@@ -222,9 +224,59 @@ describe("useGitHubData", () => {
 
     expect(result.current.authExpired).toBe(true);
 
-    // Queries should not refetch after auth expiry
-    // (enabled: false prevents new fetches)
+    // Advance past the refetch interval to verify queries don't fire
+    await act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
     expect(getGithubDashboard).not.toHaveBeenCalled();
     expect(getGithubStats).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
+  });
+
+  it("should reset authExpired when auth:restored fires", async () => {
+    (getGithubDashboard as Mock).mockResolvedValue(MOCK_DASHBOARD);
+    (getGithubStats as Mock).mockResolvedValue(MOCK_STATS);
+
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useGitHubData(), { wrapper });
+
+    await waitFor(() => {
+      expect(onEvent).toHaveBeenCalledWith(
+        "auth:expired",
+        expect.any(Function),
+      );
+    });
+
+    // First: trigger auth:expired
+    const expiredCall = (onEvent as Mock).mock.calls.find(
+      (c: unknown[]) => c[0] === "auth:expired",
+    );
+    await act(() => {
+      (expiredCall![1] as (p: string) => void)("token expired");
+    });
+    expect(result.current.authExpired).toBe(true);
+
+    // Then: trigger auth:restored
+    const restoredCall = (onEvent as Mock).mock.calls.find(
+      (c: unknown[]) => c[0] === "auth:restored",
+    );
+    expect(restoredCall).toBeDefined();
+
+    invalidateSpy.mockClear();
+    await act(() => {
+      (restoredCall![1] as (p: string) => void)("octocat");
+    });
+
+    expect(result.current.authExpired).toBe(false);
+    // Should invalidate queries to refetch fresh data
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ["github", "dashboard"],
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ["github", "stats"],
+    });
   });
 });

--- a/src/hooks/useGitHubData.ts
+++ b/src/hooks/useGitHubData.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   getGithubDashboard,
@@ -19,12 +19,14 @@ function invalidateGitHub(queryClient: ReturnType<typeof useQueryClient>) {
 
 export function useGitHubData(refetchInterval?: number) {
   const queryClient = useQueryClient();
+  const [authExpired, setAuthExpired] = useState(false);
 
   const dashboardQuery = useQuery({
     queryKey: ["github", "dashboard"],
     queryFn: getGithubDashboard,
     staleTime: STALE_TIME,
     refetchInterval,
+    enabled: !authExpired,
   });
 
   const statsQuery = useQuery({
@@ -32,6 +34,7 @@ export function useGitHubData(refetchInterval?: number) {
     queryFn: getGithubStats,
     staleTime: STALE_TIME,
     refetchInterval,
+    enabled: !authExpired,
   });
 
   const syncMutation = useMutation({
@@ -43,7 +46,7 @@ export function useGitHubData(refetchInterval?: number) {
 
   useEffect(() => {
     let cancelled = false;
-    let unlisten: (() => void) | undefined;
+    const unlisteners: (() => void)[] = [];
 
     onEvent(TAURI_EVENTS["github:updated"], async () => {
       await invalidateGitHub(queryClient);
@@ -51,15 +54,29 @@ export function useGitHubData(refetchInterval?: number) {
       if (cancelled) {
         fn();
       } else {
-        unlisten = fn;
+        unlisteners.push(fn);
       }
     }).catch((err: unknown) => {
       console.error("[useGitHubData] failed to register github:updated listener:", err);
     });
 
+    onEvent<string>(TAURI_EVENTS["auth:expired"], () => {
+      setAuthExpired(true);
+    }).then((fn) => {
+      if (cancelled) {
+        fn();
+      } else {
+        unlisteners.push(fn);
+      }
+    }).catch((err: unknown) => {
+      console.error("[useGitHubData] failed to register auth:expired listener:", err);
+    });
+
     return () => {
       cancelled = true;
-      unlisten?.();
+      for (const unlisten of unlisteners) {
+        unlisten();
+      }
     };
   }, [queryClient]);
 
@@ -68,6 +85,7 @@ export function useGitHubData(refetchInterval?: number) {
     stats: statsQuery.data ?? null,
     isLoading: dashboardQuery.isLoading || statsQuery.isLoading,
     error: dashboardQuery.error ?? statsQuery.error ?? null,
+    authExpired,
     forceSync: syncMutation.mutate,
     isSyncing: syncMutation.isPending,
   };

--- a/src/hooks/useGitHubData.ts
+++ b/src/hooks/useGitHubData.ts
@@ -72,6 +72,19 @@ export function useGitHubData(refetchInterval?: number) {
       console.error("[useGitHubData] failed to register auth:expired listener:", err);
     });
 
+    onEvent<string>(TAURI_EVENTS["auth:restored"], async () => {
+      setAuthExpired(false);
+      await invalidateGitHub(queryClient);
+    }).then((fn) => {
+      if (cancelled) {
+        fn();
+      } else {
+        unlisteners.push(fn);
+      }
+    }).catch((err: unknown) => {
+      console.error("[useGitHubData] failed to register auth:restored listener:", err);
+    });
+
     return () => {
       cancelled = true;
       for (const unlisten of unlisteners) {

--- a/src/lib/types.test.ts
+++ b/src/lib/types.test.ts
@@ -463,8 +463,8 @@ describe("TAURI_COMMANDS constant", () => {
 });
 
 describe("TAURI_EVENTS constant", () => {
-  it("should contain all 9 event names", () => {
-    expect(Object.keys(TAURI_EVENTS)).toHaveLength(9);
+  it("should contain all 10 event names", () => {
+    expect(Object.keys(TAURI_EVENTS)).toHaveLength(10);
   });
 
   it("should have matching key-value pairs", () => {

--- a/src/lib/types.test.ts
+++ b/src/lib/types.test.ts
@@ -463,8 +463,8 @@ describe("TAURI_COMMANDS constant", () => {
 });
 
 describe("TAURI_EVENTS constant", () => {
-  it("should contain all 8 event names", () => {
-    expect(Object.keys(TAURI_EVENTS)).toHaveLength(8);
+  it("should contain all 9 event names", () => {
+    expect(Object.keys(TAURI_EVENTS)).toHaveLength(9);
   });
 
   it("should have matching key-value pairs", () => {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -311,6 +311,7 @@ export type TauriEventName =
   | "github:updated"
   | "github:sync_error"
   | "auth:expired"
+  | "auth:restored"
   | "workspace:stdout"
   | "workspace:state_changed"
   | "workspace:claude_session"
@@ -322,6 +323,7 @@ export const TAURI_EVENTS = {
   "github:updated": "github:updated",
   "github:sync_error": "github:sync_error",
   "auth:expired": "auth:expired",
+  "auth:restored": "auth:restored",
   "workspace:stdout": "workspace:stdout",
   "workspace:state_changed": "workspace:state_changed",
   "workspace:claude_session": "workspace:claude_session",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -310,6 +310,7 @@ export const TAURI_COMMANDS = {
 export type TauriEventName =
   | "github:updated"
   | "github:sync_error"
+  | "auth:expired"
   | "workspace:stdout"
   | "workspace:state_changed"
   | "workspace:claude_session"
@@ -320,6 +321,7 @@ export type TauriEventName =
 export const TAURI_EVENTS = {
   "github:updated": "github:updated",
   "github:sync_error": "github:sync_error",
+  "auth:expired": "auth:expired",
   "workspace:stdout": "workspace:stdout",
   "workspace:state_changed": "workspace:state_changed",
   "workspace:claude_session": "workspace:claude_session",


### PR DESCRIPTION
## Summary
- When a GraphQL 401 response is detected during polling, the loop stops and emits an `auth:expired` Tauri event
- Frontend `useGitHubData` hook listens for `auth:expired`, disables queries, and exposes `authExpired` flag for UI overlay
- Added `PollOutcome::AuthExpired` variant with dedicated `emit_auth_expired` on the `PollingContext` trait

## Changes
- **`polling.rs`**: New `AuthExpired` poll outcome, `emit_auth_expired` trait method, `polling_loop` exits on auth failure (+3 tests)
- **`useGitHubData.ts`**: Listen for `auth:expired` event, disable queries when expired, expose `authExpired` state
- **`types.ts`**: Added `auth:expired` to `TauriEventName` and `TAURI_EVENTS`
- **Tests**: 3 new Rust tests, 3 new TS tests, updated existing test fixtures

## Test plan
- [x] `cargo test --lib github::polling::tests` — 12/12 pass
- [x] `npx vitest run` — 454/454 pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `npx oxlint .` — clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop GitHub polling on a 401 and emit `auth:expired`, with a recovery flow that restarts polling and emits `auth:restored` after re-authentication (Linear T-094). The frontend pauses queries and shows `authExpired`, then re-enables and refetches after the token is restored.

- **New Features**
  - Rust: added `PollOutcome::AuthExpired`, `emit_auth_expired`, and stop the loop on auth failure; `auth_set_token` restarts polling and emits `auth:restored`.
  - Frontend: `useGitHubData` listens for `auth:expired`/`auth:restored`, toggles `authExpired`, disables/enables queries, and invalidates to refetch.
  - Types: added `auth:expired` and `auth:restored` to `TauriEventName` and `TAURI_EVENTS`.
  - Tests: expanded Rust and TS tests for stop-on-401, event emissions, listener cleanup, and auth restoration flow.

<sup>Written for commit bf12a02d31516558acfa6dc16065fef02f0a4223. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects auth expiration: stops background polling and prevents GitHub data refetches while auth is expired.
  * Emits auth lifecycle events (auth:expired, auth:restored) and restores polling when auth is restored.
  * Hook/API surface now exposes an authExpired flag reflecting auth state.

* **Tests**
  * Added tests covering auth expiry, single-event emission, polling halt, restoration, and listener cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->