### PR TITLE
feat(github): auto-discover user repositories on sync

### DIFF
--- a/src-tauri/src/cache/repos.rs
+++ b/src-tauri/src/cache/repos.rs
@@ -46,8 +46,8 @@ const REPO_COLS: &str =
 #[allow(dead_code)]
 pub async fn upsert_repo(pool: &SqlitePool, repo: &Repo) -> Result<Repo, AppError> {
     let sql = format!(
-        "INSERT INTO repos (id, org, name, full_name, url, default_branch, is_archived)
-         VALUES ($1, $2, $3, $4, $5, $6, $7)
+        "INSERT INTO repos (id, org, name, full_name, url, default_branch, is_archived, enabled)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
          ON CONFLICT(id) DO UPDATE SET
              org = excluded.org,
              name = excluded.name,
@@ -66,6 +66,7 @@ pub async fn upsert_repo(pool: &SqlitePool, repo: &Repo) -> Result<Repo, AppErro
         .bind(&repo.url)
         .bind(&repo.default_branch)
         .bind(repo.is_archived)
+        .bind(repo.enabled)
         .fetch_one(pool)
         .await?;
 

--- a/src-tauri/src/cache/sync.rs
+++ b/src-tauri/src/cache/sync.rs
@@ -43,9 +43,16 @@ async fn should_sync_repos(pool: &SqlitePool) -> bool {
     chrono::Utc::now().signed_duration_since(last).num_seconds() > REPO_SYNC_INTERVAL_SECS
 }
 
-/// Record that a repo discovery run completed just now.
-async fn mark_repo_sync_done(pool: &SqlitePool) {
-    let now = chrono::Utc::now().to_rfc3339();
+/// Record a repo-sync timestamp. On failure, advances the clock by a shorter
+/// cooldown (5 min) to avoid hammering the API on every poll tick while still
+/// retrying sooner than the full 1-hour interval.
+async fn mark_repo_sync_done(pool: &SqlitePool, failed: bool) {
+    let ts = if failed {
+        (chrono::Utc::now() + chrono::Duration::seconds(REPO_SYNC_INTERVAL_SECS - 300)).to_rfc3339()
+    } else {
+        chrono::Utc::now().to_rfc3339()
+    };
+    let now = ts;
     let _ = sqlx::query(
         "INSERT INTO config (key, value) VALUES ($1, $2)
          ON CONFLICT(key) DO UPDATE SET value = excluded.value",
@@ -72,7 +79,9 @@ pub async fn sync_repos(client: &GitHubClient, pool: &SqlitePool) -> Result<usiz
 
         for node in repos_connection.nodes.into_iter().flatten().flatten() {
             let repo = Repo {
-                id: node.id,
+                // Use name_with_owner as ID to match the convention used by
+                // map_pr/map_issue (which set repo_id = repository.nameWithOwner).
+                id: node.name_with_owner.clone(),
                 org: node.owner.login,
                 name: node.name,
                 full_name: node.name_with_owner,
@@ -82,6 +91,8 @@ pub async fn sync_repos(client: &GitHubClient, pool: &SqlitePool) -> Result<usiz
                     .map(|r| r.name)
                     .unwrap_or_else(|| "main".to_string()),
                 is_archived: node.is_archived,
+                // Not bound by upsert_repo — schema DEFAULT 1 applies on insert,
+                // ON CONFLICT preserves existing user choice.
                 enabled: true,
                 local_path: None,
                 last_sync_at: None,
@@ -128,9 +139,12 @@ pub async fn sync_dashboard(
         match sync_repos(client, pool).await {
             Ok(n) => {
                 tracing::info!("repo discovery: {n} repos synced");
-                mark_repo_sync_done(pool).await;
+                mark_repo_sync_done(pool, false).await;
             }
-            Err(e) => tracing::warn!("repo discovery failed, using cached repos: {e}"),
+            Err(e) => {
+                tracing::warn!("repo discovery failed, using cached repos: {e}");
+                mark_repo_sync_done(pool, true).await;
+            }
         }
     }
     let repos = list_repos(pool).await?;
@@ -1305,7 +1319,7 @@ mod tests {
         assert_eq!(count, 1);
         let repos = crate::cache::repos::list_repos(&pool).await.unwrap();
         assert_eq!(repos.len(), 1);
-        assert_eq!(repos[0].id, "R_1");
+        assert_eq!(repos[0].id, "acme/alpha");
         assert_eq!(repos[0].name, "alpha");
         assert_eq!(repos[0].org, "acme");
         assert_eq!(repos[0].full_name, "acme/alpha");
@@ -1323,7 +1337,7 @@ mod tests {
         // Pre-insert the repo, then explicitly disable it
         let (pool, _tmp) = test_pool().await;
         let existing = Repo {
-            id: "R_1".to_string(),
+            id: "acme/alpha".to_string(),
             org: "acme".to_string(),
             name: "alpha".to_string(),
             full_name: "acme/alpha".to_string(),
@@ -1336,7 +1350,7 @@ mod tests {
         };
         upsert_repo(&pool, &existing).await.unwrap();
         // Disable it — simulating a user choosing not to track this repo
-        crate::cache::repos::set_repo_enabled(&pool, "R_1", false)
+        crate::cache::repos::set_repo_enabled(&pool, "acme/alpha", false)
             .await
             .unwrap();
 
@@ -1441,6 +1455,35 @@ mod tests {
 
         let repos = crate::cache::repos::list_repos(&pool).await.unwrap();
         assert_eq!(repos[0].default_branch, "main");
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_sync_repos_stops_on_null_cursor_with_has_next_page() {
+        let mut server = mockito::Server::new_async().await;
+        // hasNextPage=true but endCursor=null — should stop, not loop forever
+        let body = user_repos_response(
+            serde_json::json!([repo_node("R_1", "alpha", "acme", false)]),
+            true,
+            None,
+        );
+        let mock = server
+            .mock("POST", "/graphql")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(body)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let (pool, _tmp) = test_pool().await;
+        let client =
+            GitHubClient::with_url("ghp_test_token", format!("{}/graphql", server.url())).unwrap();
+
+        let count = sync_repos(&client, &pool).await.unwrap();
+
+        assert_eq!(count, 1);
+        mock.assert_async().await;
         pool.close().await;
     }
 }

--- a/src-tauri/src/cache/sync.rs
+++ b/src-tauri/src/cache/sync.rs
@@ -12,39 +12,127 @@ use crate::cache::activity::upsert_activity;
 use crate::cache::dashboard::compute_dashboard_stats;
 use crate::cache::issues::upsert_issue;
 use crate::cache::pull_requests::upsert_pull_request;
-use crate::cache::repos::list_repos;
+use crate::cache::repos::{list_repos, upsert_repo};
 use crate::cache::reviews::upsert_review;
 use crate::error::AppError;
 use crate::github::client::GitHubClient;
 use crate::github::models::{map_issue, map_pr, map_review};
 use crate::github::queries::dashboard_data::{self, IssueFields, PrFields};
 use crate::github::queries::recent_activity;
-use crate::github::queries::{DashboardData, RecentActivity};
+use crate::github::queries::user_repos;
+use crate::github::queries::{DashboardData, RecentActivity, UserRepos};
 use crate::types::{Activity, ActivityType, DashboardStats, Repo};
+
+/// Minimum interval between repo discovery runs (1 hour).
+const REPO_SYNC_INTERVAL_SECS: i64 = 3600;
+const REPO_SYNC_KEY: &str = "last_repo_sync_at";
+
+/// Check if enough time has elapsed since the last repo discovery run.
+async fn should_sync_repos(pool: &SqlitePool) -> bool {
+    let row: Option<(String,)> = sqlx::query_as("SELECT value FROM config WHERE key = $1")
+        .bind(REPO_SYNC_KEY)
+        .fetch_optional(pool)
+        .await
+        .ok()
+        .flatten();
+
+    let Some((ts,)) = row else { return true };
+    let Ok(last) = chrono::DateTime::parse_from_rfc3339(&ts) else {
+        return true;
+    };
+    chrono::Utc::now().signed_duration_since(last).num_seconds() > REPO_SYNC_INTERVAL_SECS
+}
+
+/// Record that a repo discovery run completed just now.
+async fn mark_repo_sync_done(pool: &SqlitePool) {
+    let now = chrono::Utc::now().to_rfc3339();
+    let _ = sqlx::query(
+        "INSERT INTO config (key, value) VALUES ($1, $2)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+    )
+    .bind(REPO_SYNC_KEY)
+    .bind(&now)
+    .execute(pool)
+    .await;
+}
+
+/// Fetch all repositories the viewer has access to from GitHub and upsert them
+/// into the local cache. Returns the number of repos processed.
+pub async fn sync_repos(client: &GitHubClient, pool: &SqlitePool) -> Result<usize, AppError> {
+    let mut count = 0usize;
+    let mut cursor: Option<String> = None;
+
+    loop {
+        let variables = user_repos::Variables {
+            first: 100,
+            after: cursor.clone(),
+        };
+        let data = client.execute_graphql::<UserRepos>(variables).await?;
+        let repos_connection = data.viewer.repositories;
+
+        for node in repos_connection.nodes.into_iter().flatten().flatten() {
+            let repo = Repo {
+                id: node.id,
+                org: node.owner.login,
+                name: node.name,
+                full_name: node.name_with_owner,
+                url: node.url,
+                default_branch: node
+                    .default_branch_ref
+                    .map(|r| r.name)
+                    .unwrap_or_else(|| "main".to_string()),
+                is_archived: node.is_archived,
+                enabled: true,
+                local_path: None,
+                last_sync_at: None,
+            };
+            upsert_repo(pool, &repo).await?;
+            count += 1;
+        }
+
+        if repos_connection.page_info.has_next_page {
+            match repos_connection.page_info.end_cursor {
+                Some(c) => cursor = Some(c),
+                None => {
+                    tracing::warn!("hasNextPage=true but endCursor is null — stopping pagination");
+                    break;
+                }
+            }
+        } else {
+            break;
+        }
+    }
+
+    Ok(count)
+}
 
 /// Synchronize dashboard data from GitHub API into the local cache.
 ///
-/// 1. Read enabled repos from DB
-/// 2. Build GitHub search query variables
-/// 3. Execute GraphQL `DashboardData` query
-/// 4. Persist all data atomically in a single transaction
-/// 5. Update `last_sync_at` per repo (same transaction)
-/// 6. Return dashboard stats
-///
-/// Note: the `first: 100` page size may truncate results for users with
-/// very large dashboards. Pagination support is deferred to a future task
-/// (requires adding `after` cursor variables to the GraphQL query).
-///
-/// Note: this sync only upserts data present in the current API response.
-/// PRs that were merged/closed since the last sync drop out of `state:open`
-/// searches but remain in the cache with their last known state. A full
-/// reconciliation pass is deferred to a future task.
+/// 1. Discover/update repos from GitHub (sync_repos)
+/// 2. Read enabled repos from DB
+/// 3. Build GitHub search query variables
+/// 4. Execute GraphQL `DashboardData` query
+/// 5. Persist all data atomically in a single transaction
+/// 6. Update `last_sync_at` per repo (same transaction)
+/// 7. Return dashboard stats
 #[tracing::instrument(skip(client, pool, username))]
 pub async fn sync_dashboard(
     client: &GitHubClient,
     pool: &SqlitePool,
     username: &str,
 ) -> Result<DashboardStats, AppError> {
+    // Discover/update repos from GitHub — non-blocking so dashboard sync
+    // continues even if repo discovery fails (network error, rate limit, etc.)
+    let should_sync = should_sync_repos(pool).await;
+    if should_sync {
+        match sync_repos(client, pool).await {
+            Ok(n) => {
+                tracing::info!("repo discovery: {n} repos synced");
+                mark_repo_sync_done(pool).await;
+            }
+            Err(e) => tracing::warn!("repo discovery failed, using cached repos: {e}"),
+        }
+    }
     let repos = list_repos(pool).await?;
     let enabled: Vec<&Repo> = repos.iter().filter(|r| r.enabled).collect();
 
@@ -467,6 +555,18 @@ mod tests {
         (pool, tmp)
     }
 
+    /// Pre-mark repo sync as done so `should_sync_repos` returns false.
+    /// Use in dashboard tests to avoid unrelated sync_repos GraphQL calls.
+    async fn skip_repo_sync(pool: &SqlitePool) {
+        let now = chrono::Utc::now().to_rfc3339();
+        sqlx::query("INSERT INTO config (key, value) VALUES ($1, $2) ON CONFLICT(key) DO UPDATE SET value = excluded.value")
+            .bind(REPO_SYNC_KEY)
+            .bind(&now)
+            .execute(pool)
+            .await
+            .unwrap();
+    }
+
     fn sample_repo() -> Repo {
         Repo {
             id: "org/repo".to_string(),
@@ -678,6 +778,7 @@ mod tests {
             .await;
 
         let (pool, _tmp) = test_pool().await;
+        skip_repo_sync(&pool).await; // avoid sync_repos making extra requests
         let repo = sample_repo();
         upsert_repo(&pool, &repo).await.unwrap();
 
@@ -1142,5 +1243,204 @@ mod tests {
             validate_since("2026-03-01T10:00:00Z extra").is_err(),
             "space in value"
         );
+    }
+
+    // ── sync_repos tests ─────────────────────────────────────────────
+
+    fn user_repos_response(
+        nodes: serde_json::Value,
+        has_next_page: bool,
+        end_cursor: Option<&str>,
+    ) -> String {
+        serde_json::json!({
+            "data": {
+                "viewer": {
+                    "repositories": {
+                        "pageInfo": {
+                            "hasNextPage": has_next_page,
+                            "endCursor": end_cursor
+                        },
+                        "nodes": nodes
+                    }
+                }
+            }
+        })
+        .to_string()
+    }
+
+    fn repo_node(id: &str, name: &str, org: &str, archived: bool) -> serde_json::Value {
+        serde_json::json!({
+            "id": id,
+            "name": name,
+            "nameWithOwner": format!("{org}/{name}"),
+            "url": format!("https://github.com/{org}/{name}"),
+            "defaultBranchRef": { "name": "main" },
+            "isArchived": archived,
+            "owner": { "__typename": "Organization", "login": org }
+        })
+    }
+
+    #[tokio::test]
+    async fn test_sync_repos_inserts_new_repos() {
+        let mut server = mockito::Server::new_async().await;
+        let body = user_repos_response(
+            serde_json::json!([repo_node("R_1", "alpha", "acme", false)]),
+            false,
+            None,
+        );
+        let mock = server
+            .mock("POST", "/graphql")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(body)
+            .create_async()
+            .await;
+
+        let (pool, _tmp) = test_pool().await;
+        let client =
+            GitHubClient::with_url("ghp_test_token", format!("{}/graphql", server.url())).unwrap();
+
+        let count = sync_repos(&client, &pool).await.unwrap();
+
+        assert_eq!(count, 1);
+        let repos = crate::cache::repos::list_repos(&pool).await.unwrap();
+        assert_eq!(repos.len(), 1);
+        assert_eq!(repos[0].id, "R_1");
+        assert_eq!(repos[0].name, "alpha");
+        assert_eq!(repos[0].org, "acme");
+        assert_eq!(repos[0].full_name, "acme/alpha");
+        assert_eq!(repos[0].default_branch, "main");
+        assert!(!repos[0].is_archived);
+        assert!(repos[0].enabled, "new repos should default to enabled");
+        mock.assert_async().await;
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_sync_repos_preserves_enabled_state() {
+        let mut server = mockito::Server::new_async().await;
+
+        // Pre-insert the repo, then explicitly disable it
+        let (pool, _tmp) = test_pool().await;
+        let existing = Repo {
+            id: "R_1".to_string(),
+            org: "acme".to_string(),
+            name: "alpha".to_string(),
+            full_name: "acme/alpha".to_string(),
+            url: "https://github.com/acme/alpha".to_string(),
+            default_branch: "main".to_string(),
+            is_archived: false,
+            enabled: true,
+            local_path: None,
+            last_sync_at: None,
+        };
+        upsert_repo(&pool, &existing).await.unwrap();
+        // Disable it — simulating a user choosing not to track this repo
+        crate::cache::repos::set_repo_enabled(&pool, "R_1", false)
+            .await
+            .unwrap();
+
+        let body = user_repos_response(
+            serde_json::json!([repo_node("R_1", "alpha", "acme", false)]),
+            false,
+            None,
+        );
+        let _mock = server
+            .mock("POST", "/graphql")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(body)
+            .create_async()
+            .await;
+
+        let client =
+            GitHubClient::with_url("ghp_test_token", format!("{}/graphql", server.url())).unwrap();
+        sync_repos(&client, &pool).await.unwrap();
+
+        let repos = crate::cache::repos::list_repos(&pool).await.unwrap();
+        assert_eq!(repos.len(), 1);
+        assert!(
+            !repos[0].enabled,
+            "upsert should preserve local enabled=false state"
+        );
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_sync_repos_pagination() {
+        let mut server = mockito::Server::new_async().await;
+
+        // First page: hasNextPage=true, endCursor="cursor1"
+        let page1 = user_repos_response(
+            serde_json::json!([repo_node("R_1", "alpha", "acme", false)]),
+            true,
+            Some("cursor1"),
+        );
+        // Second page: hasNextPage=false
+        let page2 = user_repos_response(
+            serde_json::json!([repo_node("R_2", "beta", "acme", false)]),
+            false,
+            None,
+        );
+
+        // Both pages hit the same endpoint — mockito sequences them
+        let mock1 = server
+            .mock("POST", "/graphql")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(page1)
+            .create_async()
+            .await;
+        let mock2 = server
+            .mock("POST", "/graphql")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(page2)
+            .create_async()
+            .await;
+
+        let (pool, _tmp) = test_pool().await;
+        let client =
+            GitHubClient::with_url("ghp_test_token", format!("{}/graphql", server.url())).unwrap();
+
+        let count = sync_repos(&client, &pool).await.unwrap();
+
+        assert_eq!(count, 2, "both pages should be fetched");
+        let repos = crate::cache::repos::list_repos(&pool).await.unwrap();
+        assert_eq!(repos.len(), 2);
+        mock1.assert_async().await;
+        mock2.assert_async().await;
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_sync_repos_missing_default_branch_falls_back_to_main() {
+        let mut server = mockito::Server::new_async().await;
+        let node = serde_json::json!({
+            "id": "R_1",
+            "name": "noBranch",
+            "nameWithOwner": "acme/noBranch",
+            "url": "https://github.com/acme/noBranch",
+            "defaultBranchRef": null,
+            "isArchived": false,
+            "owner": { "__typename": "Organization", "login": "acme" }
+        });
+        let body = user_repos_response(serde_json::json!([node]), false, None);
+        let _mock = server
+            .mock("POST", "/graphql")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(body)
+            .create_async()
+            .await;
+
+        let (pool, _tmp) = test_pool().await;
+        let client =
+            GitHubClient::with_url("ghp_test_token", format!("{}/graphql", server.url())).unwrap();
+        sync_repos(&client, &pool).await.unwrap();
+
+        let repos = crate::cache::repos::list_repos(&pool).await.unwrap();
+        assert_eq!(repos[0].default_branch, "main");
+        pool.close().await;
     }
 }

--- a/src-tauri/src/cache/sync.rs
+++ b/src-tauri/src/cache/sync.rs
@@ -48,7 +48,7 @@ async fn should_sync_repos(pool: &SqlitePool) -> bool {
 /// retrying sooner than the full 1-hour interval.
 async fn mark_repo_sync_done(pool: &SqlitePool, failed: bool) {
     let ts = if failed {
-        (chrono::Utc::now() + chrono::Duration::seconds(REPO_SYNC_INTERVAL_SECS - 300)).to_rfc3339()
+        (chrono::Utc::now() - chrono::Duration::seconds(REPO_SYNC_INTERVAL_SECS - 300)).to_rfc3339()
     } else {
         chrono::Utc::now().to_rfc3339()
     };
@@ -91,8 +91,7 @@ pub async fn sync_repos(client: &GitHubClient, pool: &SqlitePool) -> Result<usiz
                     .map(|r| r.name)
                     .unwrap_or_else(|| "main".to_string()),
                 is_archived: node.is_archived,
-                // Not bound by upsert_repo — schema DEFAULT 1 applies on insert,
-                // ON CONFLICT preserves existing user choice.
+                // Bound on INSERT; ON CONFLICT preserves existing user choice.
                 enabled: true,
                 local_path: None,
                 last_sync_at: None,

--- a/src-tauri/src/cache/sync.rs
+++ b/src-tauri/src/cache/sync.rs
@@ -88,8 +88,7 @@ pub async fn sync_repos(client: &GitHubClient, pool: &SqlitePool) -> Result<usiz
                 url: node.url,
                 default_branch: node
                     .default_branch_ref
-                    .map(|r| r.name)
-                    .unwrap_or_else(|| "main".to_string()),
+                    .map_or_else(|| "main".to_string(), |r| r.name),
                 is_archived: node.is_archived,
                 // Bound on INSERT; ON CONFLICT preserves existing user choice.
                 enabled: true,
@@ -101,12 +100,11 @@ pub async fn sync_repos(client: &GitHubClient, pool: &SqlitePool) -> Result<usiz
         }
 
         if repos_connection.page_info.has_next_page {
-            match repos_connection.page_info.end_cursor {
-                Some(c) => cursor = Some(c),
-                None => {
-                    tracing::warn!("hasNextPage=true but endCursor is null — stopping pagination");
-                    break;
-                }
+            if let Some(c) = repos_connection.page_info.end_cursor {
+                cursor = Some(c);
+            } else {
+                tracing::warn!("hasNextPage=true but endCursor is null — stopping pagination");
+                break;
             }
         } else {
             break;
@@ -118,7 +116,7 @@ pub async fn sync_repos(client: &GitHubClient, pool: &SqlitePool) -> Result<usiz
 
 /// Synchronize dashboard data from GitHub API into the local cache.
 ///
-/// 1. Discover/update repos from GitHub (sync_repos)
+/// 1. Discover/update repos from GitHub (`sync_repos`)
 /// 2. Read enabled repos from DB
 /// 3. Build GitHub search query variables
 /// 4. Execute GraphQL `DashboardData` query

--- a/src-tauri/src/github/graphql/schema.graphql
+++ b/src-tauri/src/github/graphql/schema.graphql
@@ -97,11 +97,23 @@ interface Actor {
   avatarUrl: URI
 }
 
+enum RepositoryAffiliation {
+  OWNER
+  COLLABORATOR
+  ORGANIZATION_MEMBER
+}
+
+type RepositoryConnection {
+  pageInfo: PageInfo!
+  nodes: [Repository]
+}
+
 type User implements Node & Actor {
   id: ID!
   login: String!
   avatarUrl: URI
   name: String
+  repositories(first: Int, after: String, ownerAffiliations: [RepositoryAffiliation]): RepositoryConnection!
 }
 
 type Bot implements Node & Actor {

--- a/src-tauri/src/github/graphql/user_repos.graphql
+++ b/src-tauri/src/github/graphql/user_repos.graphql
@@ -1,0 +1,24 @@
+query UserRepos($first: Int!, $after: String) {
+  viewer {
+    repositories(first: $first, after: $after, ownerAffiliations: [OWNER, COLLABORATOR, ORGANIZATION_MEMBER]) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      nodes {
+        id
+        name
+        nameWithOwner
+        url
+        defaultBranchRef {
+          name
+        }
+        isArchived
+        owner {
+          __typename
+          login
+        }
+      }
+    }
+  }
+}

--- a/src-tauri/src/github/queries.rs
+++ b/src-tauri/src/github/queries.rs
@@ -33,6 +33,15 @@ pub struct RecentActivity;
 )]
 pub struct PullRequestDetail;
 
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/github/graphql/schema.graphql",
+    query_path = "src/github/graphql/user_repos.graphql",
+    response_derives = "Debug, Clone",
+    variables_derives = "Debug"
+)]
+pub struct UserRepos;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -15,6 +15,8 @@
         "title": "PRism",
         "width": 1400,
         "height": 900,
+        "minWidth": 1024,
+        "minHeight": 600,
         "resizable": true,
         "fullscreen": false
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,8 +8,9 @@ import {
   type ReactElement,
   type ReactNode,
 } from "react";
-import { useQuery } from "@tanstack/react-query";
-import { authGetStatus } from "./lib/tauri";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { authGetStatus, markAllActivityRead } from "./lib/tauri";
+import { useGitHubData } from "./hooks/useGitHubData";
 import { AuthSetup } from "./components/AuthSetup/AuthSetup";
 import { Sidebar } from "./components/Sidebar";
 import { Overview } from "./components/Overview";
@@ -98,22 +99,37 @@ interface MainContentProps {
 }
 
 function MainContent({ view, onBackToDashboard }: MainContentProps): ReactElement {
+  const { dashboard } = useGitHubData();
+  const queryClient = useQueryClient();
+
+  const markAllRead = useMutation({
+    mutationFn: markAllActivityRead,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["github", "dashboard"] });
+      queryClient.invalidateQueries({ queryKey: ["github", "stats"] });
+    },
+  });
+
   switch (view) {
     case "overview":
       return <Overview />;
     case "reviews":
-      return <ReviewQueue reviews={[]} onOpen={openUrl} />;
+      return <ReviewQueue reviews={dashboard?.reviewRequests ?? []} onOpen={openUrl} />;
     case "mine":
-      return <MyPRs prs={[]} onOpen={openUrl} />;
+      return <MyPRs prs={dashboard?.myPullRequests ?? []} onOpen={openUrl} />;
     case "issues":
-      return <Issues issues={[]} onOpen={openUrl} />;
+      return <Issues issues={dashboard?.assignedIssues ?? []} onOpen={openUrl} />;
     case "feed":
-      return <ActivityFeed activities={[]} onMarkAllRead={() => {}} />;
+      return (
+        <ActivityFeed
+          activities={dashboard?.recentActivity ?? []}
+          onMarkAllRead={() => markAllRead.mutate()}
+        />
+      );
     case "workspaces":
-      // TODO(T-082): wire real workspace data from TanStack Query
       return (
         <WorkspaceView
-          workspaces={[]}
+          workspaces={dashboard?.workspaces ?? []}
           statusInfo={{}}
           onBackToDashboard={onBackToDashboard}
         />

--- a/src/components/ActivityFeed/ActivityFeed.tsx
+++ b/src/components/ActivityFeed/ActivityFeed.tsx
@@ -39,8 +39,8 @@ export function ActivityFeed({ activities, onMarkAllRead }: ActivityFeedProps): 
     <section data-testid="activity-feed" className="flex flex-col gap-2">
       <SectionHead title="Activity" count={visible.length} />
 
-      <div className="flex items-center gap-1">
-        <div className="flex gap-1" role="group" aria-label="Filter by type">
+      <div className="flex min-w-0 flex-wrap items-center gap-1">
+        <div className="flex flex-wrap gap-1" role="group" aria-label="Filter by type">
           {FILTER_LABELS.map((f) => (
             <button
               key={f}

--- a/src/components/ActivityFeed/ActivityFeed.tsx
+++ b/src/components/ActivityFeed/ActivityFeed.tsx
@@ -49,7 +49,7 @@ export function ActivityFeed({ activities, onMarkAllRead }: ActivityFeedProps): 
               onClick={() => setFilter(f)}
               className={`rounded px-2 py-0.5 text-xs capitalize transition-colors ${
                 filter === f
-                  ? "bg-accent text-white"
+                  ? "bg-accent text-bg font-semibold"
                   : "text-dim hover:text-foreground"
               }`}
             >

--- a/src/components/ActivityFeed/ActivityFeed.tsx
+++ b/src/components/ActivityFeed/ActivityFeed.tsx
@@ -47,7 +47,7 @@ export function ActivityFeed({ activities, onMarkAllRead }: ActivityFeedProps): 
               type="button"
               aria-pressed={filter === f}
               onClick={() => setFilter(f)}
-              className={`rounded px-2 py-0.5 text-xs capitalize ${
+              className={`rounded px-2 py-0.5 text-xs capitalize transition-colors ${
                 filter === f
                   ? "bg-accent text-white"
                   : "text-dim hover:text-foreground"
@@ -68,7 +68,7 @@ export function ActivityFeed({ activities, onMarkAllRead }: ActivityFeedProps): 
       </div>
 
       {visible.length === 0 ? (
-        <EmptyState message="No activity to display" />
+        <EmptyState icon="◌" message="No activity to display" />
       ) : (
         <div className="flex flex-col gap-1">
           {visible.map((activity) => (

--- a/src/components/Issues/IssueCard.tsx
+++ b/src/components/Issues/IssueCard.tsx
@@ -43,8 +43,8 @@ export function IssueCard({ issue, onOpen }: IssueCardProps): ReactElement {
         <span className="shrink-0 truncate text-xs text-dim">{issue.repoId}</span>
         {issue.labels.length > 0 && (
           <span className="flex min-w-0 items-center gap-1 overflow-hidden">
-            {issue.labels.map((label, idx) => (
-              <LabelTag key={`${label}-${idx}`} name={label} />
+            {issue.labels.map((label) => (
+              <LabelTag key={`${issue.id}:${label}`} name={label} />
             ))}
           </span>
         )}

--- a/src/components/Issues/IssueCard.tsx
+++ b/src/components/Issues/IssueCard.tsx
@@ -20,42 +20,38 @@ export function IssueCard({ issue, onOpen }: IssueCardProps): ReactElement {
   }
 
   return (
-    <div
+    <a
       data-testid="issue-card"
-      className="flex items-center gap-3 rounded border border-border px-3 py-2 hover:bg-surface-hover"
+      href={issue.url}
+      onClick={handleClick}
+      aria-label={`Issue #${issue.number}: ${issue.title} (${issue.state})`}
+      className="flex min-w-0 cursor-pointer flex-col gap-1 rounded border border-border px-3 py-2 no-underline hover:bg-surface-hover"
     >
-      <a
-        href={issue.url}
-        onClick={handleClick}
-        aria-label={`Issue #${issue.number}: ${issue.title} (${issue.state})`}
-        className="flex min-w-0 flex-1 cursor-pointer items-center gap-3 no-underline"
-      >
+      <div className="flex min-w-0 items-center gap-2">
         <span
           data-testid="issue-state-dot"
           aria-hidden="true"
           className={`h-2.5 w-2.5 shrink-0 rounded-full ${STATE_DOT_COLOR[issue.state]}`}
         />
-
+        <span className="shrink-0 text-xs text-dim">#{issue.number}</span>
         <span className="min-w-0 truncate text-sm font-medium text-foreground">
           {issue.title}
         </span>
+      </div>
 
-        <span className="shrink-0 text-xs text-dim">#{issue.number}</span>
-
-        <span className="shrink-0 text-xs text-dim">{issue.repoId}</span>
-
+      <div className="flex min-w-0 items-center gap-2 pl-[18px]">
+        <span className="shrink-0 truncate text-xs text-dim">{issue.repoId}</span>
         {issue.labels.length > 0 && (
-          <span className="flex items-center gap-1">
+          <span className="flex min-w-0 items-center gap-1 overflow-hidden">
             {issue.labels.map((label, idx) => (
               <LabelTag key={`${label}-${idx}`} name={label} />
             ))}
           </span>
         )}
-
-        <span data-testid="time-ago" className="shrink-0 text-xs text-dim">
+        <span data-testid="time-ago" className="ml-auto shrink-0 text-xs text-dim">
           {timeAgo(issue.updatedAt)}
         </span>
-      </a>
-    </div>
+      </div>
+    </a>
   );
 }

--- a/src/components/Issues/Issues.tsx
+++ b/src/components/Issues/Issues.tsx
@@ -47,7 +47,7 @@ export function Issues({ issues, onOpen }: IssuesProps): ReactElement {
           onClick={() => setTab("open")}
           className={`rounded px-2 py-0.5 text-xs transition-colors ${
             tab === "open"
-              ? "bg-accent text-white"
+              ? "bg-accent text-bg font-semibold"
               : "text-dim hover:text-foreground"
           }`}
         >
@@ -59,7 +59,7 @@ export function Issues({ issues, onOpen }: IssuesProps): ReactElement {
           onClick={() => setTab("closed")}
           className={`rounded px-2 py-0.5 text-xs transition-colors ${
             tab === "closed"
-              ? "bg-accent text-white"
+              ? "bg-accent text-bg font-semibold"
               : "text-dim hover:text-foreground"
           }`}
         >

--- a/src/components/Issues/Issues.tsx
+++ b/src/components/Issues/Issues.tsx
@@ -45,7 +45,7 @@ export function Issues({ issues, onOpen }: IssuesProps): ReactElement {
           type="button"
           aria-pressed={tab === "open"}
           onClick={() => setTab("open")}
-          className={`rounded px-2 py-0.5 text-xs ${
+          className={`rounded px-2 py-0.5 text-xs transition-colors ${
             tab === "open"
               ? "bg-accent text-white"
               : "text-dim hover:text-foreground"
@@ -57,7 +57,7 @@ export function Issues({ issues, onOpen }: IssuesProps): ReactElement {
           type="button"
           aria-pressed={tab === "closed"}
           onClick={() => setTab("closed")}
-          className={`rounded px-2 py-0.5 text-xs ${
+          className={`rounded px-2 py-0.5 text-xs transition-colors ${
             tab === "closed"
               ? "bg-accent text-white"
               : "text-dim hover:text-foreground"
@@ -68,7 +68,7 @@ export function Issues({ issues, onOpen }: IssuesProps): ReactElement {
       </div>
 
       {visible.length === 0 ? (
-        <EmptyState message="No issues to display" />
+        <EmptyState icon="◎" message="No issues to display" />
       ) : (
         <div className="flex flex-col gap-1">
           {visible.map((issue) => (

--- a/src/components/MyPRs/MyPRs.tsx
+++ b/src/components/MyPRs/MyPRs.tsx
@@ -51,7 +51,7 @@ export function MyPRs({
           type="button"
           aria-pressed={tab === "open"}
           onClick={() => setTab("open")}
-          className={`rounded px-2 py-0.5 text-xs ${
+          className={`rounded px-2 py-0.5 text-xs transition-colors ${
             tab === "open"
               ? "bg-accent text-white"
               : "text-dim hover:text-foreground"
@@ -63,7 +63,7 @@ export function MyPRs({
           type="button"
           aria-pressed={tab === "merged"}
           onClick={() => setTab("merged")}
-          className={`rounded px-2 py-0.5 text-xs ${
+          className={`rounded px-2 py-0.5 text-xs transition-colors ${
             tab === "merged"
               ? "bg-accent text-white"
               : "text-dim hover:text-foreground"
@@ -74,7 +74,7 @@ export function MyPRs({
       </div>
 
       {visible.length === 0 ? (
-        <EmptyState message="No pull requests to display" />
+        <EmptyState icon="↗" message="No pull requests to display" />
       ) : (
         <div className="flex flex-col gap-1">
           {visible.map((pr) => (

--- a/src/components/MyPRs/MyPRs.tsx
+++ b/src/components/MyPRs/MyPRs.tsx
@@ -53,7 +53,7 @@ export function MyPRs({
           onClick={() => setTab("open")}
           className={`rounded px-2 py-0.5 text-xs transition-colors ${
             tab === "open"
-              ? "bg-accent text-white"
+              ? "bg-accent text-bg font-semibold"
               : "text-dim hover:text-foreground"
           }`}
         >
@@ -65,7 +65,7 @@ export function MyPRs({
           onClick={() => setTab("merged")}
           className={`rounded px-2 py-0.5 text-xs transition-colors ${
             tab === "merged"
-              ? "bg-accent text-white"
+              ? "bg-accent text-bg font-semibold"
               : "text-dim hover:text-foreground"
           }`}
         >

--- a/src/components/MyPRs/MyPrCard.tsx
+++ b/src/components/MyPRs/MyPrCard.tsx
@@ -73,40 +73,41 @@ export function MyPrCard({
           className={`h-2.5 w-2.5 shrink-0 rounded-full ${CI_DOT_COLOR[pr.ciStatus]}`}
         />
 
-        <span
-          className={`min-w-0 truncate text-sm font-medium text-foreground${merged ? " line-through" : ""}`}
-        >
-          {pr.title}
-        </span>
-
-        <span className="shrink-0 text-xs text-dim">#{pr.number}</span>
-
-        {pr.additions !== undefined && pr.deletions !== undefined && (
-          <Diff additions={pr.additions} deletions={pr.deletions} />
-        )}
-
-        <CI status={pr.ciStatus} />
-
-        <span className="flex items-center gap-0.5">
-          {reviewDots.map((dot) => (
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          <div className="flex min-w-0 items-center gap-2">
             <span
-              key={dot.key}
-              data-testid="review-dot"
-              aria-hidden="true"
-              className={`h-2 w-2 rounded-full ${dot.color}`}
-            />
-          ))}
-        </span>
+              className={`min-w-0 truncate text-sm font-medium text-foreground${merged ? " line-through" : ""}`}
+            >
+              {pr.title}
+            </span>
+            <span className="shrink-0 text-xs text-dim">#{pr.number}</span>
+            {isMergeable(data) && (
+              <span className="shrink-0 rounded bg-green/20 px-1.5 py-0.5 text-xs font-semibold text-green">
+                MERGEABLE
+              </span>
+            )}
+          </div>
 
-        {isMergeable(data) && (
-          <span className="shrink-0 rounded bg-green/20 px-1.5 py-0.5 text-xs font-semibold text-green">
-            MERGEABLE
-          </span>
-        )}
-
-        <span data-testid="time-ago" className="shrink-0 text-xs text-dim">
-          {timeAgo(pr.updatedAt)}
-        </span>
+          <div className="flex items-center gap-2 text-xs text-dim">
+            {pr.additions !== undefined && pr.deletions !== undefined && (
+              <Diff additions={pr.additions} deletions={pr.deletions} />
+            )}
+            <CI status={pr.ciStatus} />
+            <span className="flex items-center gap-0.5">
+              {reviewDots.map((dot) => (
+                <span
+                  key={dot.key}
+                  data-testid="review-dot"
+                  aria-hidden="true"
+                  className={`h-2 w-2 rounded-full ${dot.color}`}
+                />
+              ))}
+            </span>
+            <span data-testid="time-ago" className="ml-auto shrink-0">
+              {timeAgo(pr.updatedAt)}
+            </span>
+          </div>
+        </div>
       </a>
 
       {workspace && (

--- a/src/components/Overview/Overview.tsx
+++ b/src/components/Overview/Overview.tsx
@@ -59,7 +59,7 @@ export function Overview(): ReactElement {
         <MyPRs prs={prs} onOpen={openUrl} />
       </div>
 
-      <div className="flex w-[340px] shrink-0 flex-col gap-6">
+      <div className="flex w-[300px] min-w-0 flex-col gap-6">
         <Issues issues={issues} onOpen={openUrl} />
         <ActivityFeed activities={activities} onMarkAllRead={() => markAllRead.mutate()} />
       </div>

--- a/src/components/ReviewQueue/ReviewQueue.tsx
+++ b/src/components/ReviewQueue/ReviewQueue.tsx
@@ -107,7 +107,7 @@ export function ReviewQueue({
               onClick={() =>
                 setFilter({ priority: f === "all" ? undefined : f })
               }
-              className={`rounded px-2 py-0.5 text-xs ${
+              className={`rounded px-2 py-0.5 text-xs transition-colors ${
                 priorityFilter === f
                   ? "bg-accent text-white"
                   : "text-dim hover:text-foreground"
@@ -138,7 +138,7 @@ export function ReviewQueue({
       </div>
 
       {sorted.length === 0 ? (
-        <EmptyState message="No reviews to display" />
+        <EmptyState icon="✓" message="No pending reviews — you're all caught up!" />
       ) : (
         <div className="flex flex-col gap-1">
           {sorted.map((review) => (

--- a/src/components/ReviewQueue/ReviewQueue.tsx
+++ b/src/components/ReviewQueue/ReviewQueue.tsx
@@ -109,7 +109,7 @@ export function ReviewQueue({
               }
               className={`rounded px-2 py-0.5 text-xs transition-colors ${
                 priorityFilter === f
-                  ? "bg-accent text-white"
+                  ? "bg-accent text-bg font-semibold"
                   : "text-dim hover:text-foreground"
               }`}
             >

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -111,13 +111,16 @@ export function Sidebar(): ReactElement {
         </div>
       )}
 
-      {/* Repos section */}
-      {repos.length > 0 && (
-        <div role="region" aria-labelledby="sidebar-repos-heading" className="flex flex-col gap-1">
+      {/* Repos section — enabled repos only; full management in Settings */}
+      {repos.filter((r) => r.enabled).length > 0 && (
+        <div role="region" aria-labelledby="sidebar-repos-heading" className="flex min-h-0 flex-col gap-1">
           <h3 id="sidebar-repos-heading" className="px-2 text-[10px] font-semibold uppercase tracking-wider text-dim">
             Repos
+            <span className="ml-1 text-dim/60">{repos.filter((r) => r.enabled).length}</span>
           </h3>
-          <RepoList repos={repos} onToggleRepo={handleToggleRepo} />
+          <div className="max-h-[200px] overflow-y-auto">
+            <RepoList repos={repos.filter((r) => r.enabled)} onToggleRepo={handleToggleRepo} />
+          </div>
         </div>
       )}
 

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -132,7 +132,7 @@ export function Sidebar(): ReactElement {
           onClick={toggleFocusMode}
           className={`w-full rounded px-2 py-1 text-xs font-medium ${
             focusMode
-              ? "bg-accent text-white"
+              ? "bg-accent text-bg font-semibold"
               : "text-dim hover:text-foreground"
           }`}
         >

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -74,6 +74,7 @@ export function Sidebar(): ReactElement {
     (ws) => ws.state !== "archived",
   );
   const repos = reposQuery.data ?? [];
+  const enabledRepos = repos.filter((r) => r.enabled);
   const username = authQuery.data?.username ?? null;
 
   return (
@@ -112,14 +113,14 @@ export function Sidebar(): ReactElement {
       )}
 
       {/* Repos section — enabled repos only; full management in Settings */}
-      {repos.filter((r) => r.enabled).length > 0 && (
+      {enabledRepos.length > 0 && (
         <div role="region" aria-labelledby="sidebar-repos-heading" className="flex min-h-0 flex-col gap-1">
           <h3 id="sidebar-repos-heading" className="px-2 text-[10px] font-semibold uppercase tracking-wider text-dim">
             Repos
-            <span className="ml-1 text-dim/60">{repos.filter((r) => r.enabled).length}</span>
+            <span className="ml-1 text-dim/60">{enabledRepos.length}</span>
           </h3>
           <div className="max-h-[200px] overflow-y-auto">
-            <RepoList repos={repos.filter((r) => r.enabled)} onToggleRepo={handleToggleRepo} />
+            <RepoList repos={enabledRepos} onToggleRepo={handleToggleRepo} />
           </div>
         </div>
       )}

--- a/src/components/StatsBar/StatsBar.tsx
+++ b/src/components/StatsBar/StatsBar.tsx
@@ -85,7 +85,7 @@ export function StatsBar(): ReactElement {
       </div>
       <div className="flex items-center gap-3">
         {focusMode && (
-          <span className="rounded bg-accent px-2 py-0.5 text-xs font-bold text-white">
+          <span className="rounded bg-accent px-2 py-0.5 text-xs font-bold text-bg">
             FOCUS MODE
           </span>
         )}

--- a/src/components/atoms/EmptyState.tsx
+++ b/src/components/atoms/EmptyState.tsx
@@ -8,7 +8,7 @@ interface EmptyStateProps {
 export function EmptyState({ message, icon }: EmptyStateProps): ReactElement {
   return (
     <div role="status" className="flex flex-col items-center justify-center gap-1 py-8 text-center">
-      {icon && <span className="text-lg">{icon}</span>}
+      {icon && <span aria-hidden="true" className="text-lg">{icon}</span>}
       <span className="text-sm text-dim">{message}</span>
     </div>
   );

--- a/src/components/atoms/EmptyState.tsx
+++ b/src/components/atoms/EmptyState.tsx
@@ -2,12 +2,14 @@ import type { ReactElement } from "react";
 
 interface EmptyStateProps {
   readonly message: string;
+  readonly icon?: string;
 }
 
-export function EmptyState({ message }: EmptyStateProps): ReactElement {
+export function EmptyState({ message, icon }: EmptyStateProps): ReactElement {
   return (
-    <div role="status" className="flex items-center justify-center py-12 text-center text-sm text-dim">
-      {message}
+    <div role="status" className="flex flex-col items-center justify-center gap-1 py-8 text-center">
+      {icon && <span className="text-lg">{icon}</span>}
+      <span className="text-sm text-dim">{message}</span>
     </div>
   );
 }

--- a/src/hooks/useGitHubData.test.ts
+++ b/src/hooks/useGitHubData.test.ts
@@ -117,6 +117,9 @@ describe("useGitHubData", () => {
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ["github", "stats"],
     });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ["repos"],
+    });
   });
 
   it("should force sync via mutation", async () => {
@@ -146,6 +149,9 @@ describe("useGitHubData", () => {
     });
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ["github", "stats"],
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ["repos"],
     });
   });
 
@@ -277,6 +283,9 @@ describe("useGitHubData", () => {
     });
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ["github", "stats"],
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ["repos"],
     });
   });
 });

--- a/src/hooks/useGitHubData.ts
+++ b/src/hooks/useGitHubData.ts
@@ -14,6 +14,7 @@ function invalidateGitHub(queryClient: ReturnType<typeof useQueryClient>) {
   return Promise.all([
     queryClient.invalidateQueries({ queryKey: ["github", "dashboard"] }),
     queryClient.invalidateQueries({ queryKey: ["github", "stats"] }),
+    queryClient.invalidateQueries({ queryKey: ["repos"] }),
   ]);
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -42,3 +42,15 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
+
+/* ── Focus ring global ────────────────────────── */
+:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+/* ── Scrollbar dark theme ─────────────────────── */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-border) transparent;
+}


### PR DESCRIPTION
## Summary

- Add `UserRepos` GraphQL query to fetch all viewer repositories with cursor-based pagination
- Integrate `sync_repos()` into `sync_dashboard()` — repos are discovered/updated on each sync cycle (rate-limited to 1h via config key)
- New repos default to `enabled=true`; existing user choices (enabled/disabled) are preserved on conflict via `upsert_repo`
- Frontend invalidates `["repos"]` TanStack Query cache on `github:updated` event so sidebar and Settings refresh automatically
- Guard against infinite loop on `hasNextPage=true` + `endCursor=null` edge case
- `sync_repos` failure is non-blocking — dashboard sync continues with cached repos

## Test plan

- [x] Rust: 4 new tests for `sync_repos` (field mapping, pagination, enabled preservation, null defaultBranch fallback)
- [x] Rust: existing `sync_dashboard` tests pass (28/28 sync tests green)
- [x] TypeScript: 3 updated tests verify `["repos"]` invalidation on github:updated, forceSync, and auth:restored events
- [x] Full suite: 333/334 Rust (1 pre-existing), 455/455 TS
- [ ] Manual: connect GitHub account → verify all repos appear in sidebar
- [ ] Manual: disable repo in Settings → verify it stays disabled after next sync

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-discovers all GitHub repositories the user can access during each dashboard sync so new repos show up automatically. Also wires real dashboard data into Reviews, My PRs, Issues, and Activity, and polishes the UI for readability and accessibility while preserving existing enable/disable choices.

- **New Features**
  - Added `UserRepos` GraphQL query with cursor-based pagination to fetch viewer repositories.
  - Runs `sync_repos()` at the start of `sync_dashboard()`, rate-limited to 1 hour; failures are non-blocking and back off for ~5 minutes.
  - Upserts repos with `enabled=true` by default and preserves existing enabled state on conflicts.
  - Frontend invalidates `["repos"]` on `github:updated`, force sync, and auth restore so the sidebar and Settings refresh.
  - Hooked up real dashboard data to Reviews, My PRs, Issues, and Activity; “Mark all read” updates dashboard and stats.

- **Bug Fixes**
  - Use `nameWithOwner` as the repo ID to match PR/issue mapping and avoid foreign key mismatches.
  - Prevent infinite pagination when `hasNextPage=true` but `endCursor=null`; fix cooldown math so failure retries happen in ~5 minutes.
  - Bind the repo `enabled` flag in `upsert_repo` so the struct value is persisted and user choices are preserved.
  - UI/UX fixes: prevent horizontal scroll in Overview; allow filter buttons to wrap; two-line layouts for `IssueCard`/`MyPrCard`; Sidebar shows only enabled repos with a scrollable list and count; add global focus-visible ring, minimum window size, dark scrollbars, transition colors, and `EmptyState` icons (icons marked aria-hidden); fix text contrast on `bg-accent` buttons with `text-bg`; stable keys for Issue labels.
  - Clean up `sync.rs` to resolve clippy warnings and improve readability.

<sup>Written for commit 033fd53eed90f7a2e51d0c1592e880603ceb4644. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Paginated GitHub repo discovery with rate-limited sync, faster retry on failures, and default-branch fallback to "main".
  * GraphQL repository pagination and additional repo cache invalidation key added.
  * Empty-state components can show an optional icon; minimum app window dimensions set.

* **UI Improvements**
  * Various layout and styling refinements (ActivityFeed, Issues, PRs, Sidebar, Overview, ReviewQueue, StatsBar).
  * Global focus and scrollbar styling standardized.
  * Main content now uses real GitHub-backed data and "mark all read" is wired.

* **Bug Fixes**
  * Pagination safety to avoid infinite loops; discovery failures fall back to cached repos and schedule earlier retry.

* **Tests**
  * Expanded tests for repo discovery, pagination, insertion, and state preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->