### PR TITLE
feat: integrate tauri-plugin-pilot for debug-mode UI testing

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -540,7 +540,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2363,9 +2363,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libloading"
@@ -3380,6 +3380,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-opener",
+ "tauri-plugin-pilot",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -5024,6 +5025,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-pilot"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5b37a5ea5bafec2ee876738114f24eb173d3929d7fd2b7c0729409973a7e58"
+dependencies = [
+ "libc",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6104,7 +6121,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -35,6 +35,7 @@ tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 tracing-appender = "0.2.4"
 tauri-plugin-opener = "2.5.3"
 futures = "0.3.32"
+tauri-plugin-pilot = "0.1.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 page_size = "0.6.0"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,6 +7,7 @@
     "core:default",
     "core:tray:default",
     "core:menu:default",
-    "opener:default"
+    "opener:default",
+    "pilot:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -178,8 +178,14 @@ pub fn run() {
     // The guard must live for the full process lifetime to flush pending log events.
     let _log_guard = init_tracing();
 
-    tauri::Builder::default()
-        .plugin(tauri_plugin_opener::init())
+    let mut builder = tauri::Builder::default().plugin(tauri_plugin_opener::init());
+
+    #[cfg(debug_assertions)]
+    {
+        builder = builder.plugin(tauri_plugin_pilot::init());
+    }
+
+    builder
         .setup(|app| {
             // Initialize SQLite database
             let data_dir = app.path().app_data_dir()?;


### PR DESCRIPTION
## Summary
- Add `tauri-plugin-pilot` (v0.1.0 from crates.io) for runtime UI testing and automation
- Plugin is gated behind `#[cfg(debug_assertions)]` — never included in release builds
- Add `pilot:default` capability permission

## Test plan
- [ ] `cargo build` succeeds in debug mode with plugin active
- [ ] `cargo build --release` succeeds without pilot plugin
- [ ] Plugin socket is available at runtime in dev mode

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Integrates `tauri-plugin-pilot` to enable runtime UI testing in debug builds. Release builds are unchanged.

- **New Features**
  - Added `tauri-plugin-pilot@0.1.0`, loaded only with `#[cfg(debug_assertions)]`.
  - Pilot socket available in dev for UI automation.
  - Added `pilot:default` capability to the `default` profile.

<sup>Written for commit 921048f8fe9ea88cf024b335d413babb5c4e34e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional "pilot" capability to enable new assistant-style functionality.
  * The pilot capability is exposed in development builds for testing.

* **Chores**
  * Updated app capabilities to include the pilot permission by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->