### PR TITLE
feat(ui): wire StatsBar component into App layout

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -12,6 +12,18 @@ vi.mock("./lib/tauri", async (importOriginal) => {
   };
 });
 
+vi.mock("./hooks/useGitHubData", () => ({
+  useGitHubData: vi.fn().mockReturnValue({
+    dashboard: { syncedAt: "2026-03-28T10:00:00Z", reviewRequests: [], myPullRequests: [], assignedIssues: [], recentActivity: [], workspaces: [] },
+    stats: { pendingReviews: 3, openPrs: 5, openIssues: 2, activeWorkspaces: 1, unreadActivity: 0 },
+    isLoading: false,
+    error: null,
+    authExpired: false,
+    forceSync: vi.fn(),
+    isSyncing: false,
+  }),
+}));
+
 function renderApp() {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -55,7 +67,7 @@ describe("App layout", () => {
 
   it("should render overview for default view", async () => {
     renderApp();
-    expect(await screen.findByText(/loading/i)).toBeInTheDocument();
+    expect(await screen.findByTestId("overview")).toBeInTheDocument();
   });
 
   it("should render my-prs view", async () => {
@@ -93,6 +105,19 @@ describe("App layout", () => {
     renderApp();
     expect(await screen.findByTestId("sidebar")).toBeInTheDocument();
     expect(await screen.findByTestId("workspace-view")).toBeInTheDocument();
+  });
+
+  it("should render stats bar on dashboard views", async () => {
+    useDashboardStore.setState({ currentView: "reviews" });
+    renderApp();
+    expect(await screen.findByTestId("stats-bar")).toBeInTheDocument();
+  });
+
+  it("should not render stats bar in workspace mode", async () => {
+    useDashboardStore.setState({ currentView: "workspaces" });
+    renderApp();
+    await screen.findByTestId("workspace-view");
+    expect(screen.queryByTestId("stats-bar")).not.toBeInTheDocument();
   });
 });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { authGetStatus, markAllActivityRead } from "./lib/tauri";
 import { useGitHubData } from "./hooks/useGitHubData";
 import { AuthSetup } from "./components/AuthSetup/AuthSetup";
+import { StatsBar } from "./components/StatsBar";
 import { Sidebar } from "./components/Sidebar";
 import { Overview } from "./components/Overview";
 import { ReviewQueue } from "./components/ReviewQueue";
@@ -233,12 +234,15 @@ function App(): ReactElement {
         <Sidebar />
       </aside>
 
-      <main className={isWorkspace ? "flex-1" : "min-w-0 flex-1"}>
-        <ChunkErrorBoundary key={currentView}>
-          <Suspense fallback={<LazyFallback />}>
-            <MainContent view={currentView} onBackToDashboard={handleEscape} />
-          </Suspense>
-        </ChunkErrorBoundary>
+      <main className={isWorkspace ? "flex-1" : "flex min-w-0 flex-1 flex-col"}>
+        {!isWorkspace && <StatsBar />}
+        <div className={isWorkspace ? "h-full" : "min-h-0 flex-1 overflow-y-auto"}>
+          <ChunkErrorBoundary key={currentView}>
+            <Suspense fallback={<LazyFallback />}>
+              <MainContent view={currentView} onBackToDashboard={handleEscape} />
+            </Suspense>
+          </ChunkErrorBoundary>
+        </div>
       </main>
 
       <Toast />


### PR DESCRIPTION
## Summary

- Wire the existing `StatsBar` component into `App.tsx` main content area
- Shows 4 stats (pending reviews highlighted, open PRs, issues, workspaces) + "synced Xs ago"
- Hidden in workspace mode (which has its own `WorkspaceStatusBar`)
- Proper flex-col layout with `min-h-0 flex-1 overflow-y-auto` for scroll handling

## Changes

- `src/App.tsx` — Import + render `<StatsBar />` above `MainContent`, conditional on `!isWorkspace`
- `src/App.test.tsx` — Add `useGitHubData` mock + 2 integration tests (stats bar visible/hidden)

## Test plan

- [x] All 457 tests pass (`npx vitest run`)
- [x] StatsBar renders on dashboard views (reviews, overview, issues, etc.)
- [x] StatsBar hidden in workspace mode
- [x] Scroll behavior preserved with flex-col layout
- [x] No TypeScript regressions (pre-existing errors only)
- [x] oxlint clean on changed files

Closes #100

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wired the `StatsBar` into the main app so dashboard views show pending reviews, open PRs, issues, active workspaces, and last sync time. Keeps workspace mode unchanged and makes the content area scrollable.

- **New Features**
  - Render `StatsBar` above dashboard `MainContent`; hidden in workspace mode (uses `WorkspaceStatusBar`).
  - Update main layout to a flex column with `min-h-0 flex-1 overflow-y-auto` for proper scrolling.
  - Add `App.test.tsx` tests with a `useGitHubData` mock to verify stats bar visibility on dashboard and absence in workspace.

<sup>Written for commit 9da64cd60c4e332666a81a548fe326b91eb16f69. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Stats bar now displays in review views (non-workspace mode) for quick access to metrics
  * Main interface layout restructured with improved scrolling capabilities and better content organization

* **Tests**
  * Expanded test coverage to validate stats bar visibility across different view modes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->