### PR TITLE
feat(ui): integrate command palette with cmdk (T-064)

### DIFF
--- a/src/components/CommandPalette/CommandPalette.test.tsx
+++ b/src/components/CommandPalette/CommandPalette.test.tsx
@@ -280,6 +280,7 @@ describe("CommandPalette", () => {
       "_blank",
       "noopener,noreferrer",
     );
+    expect(mockSetView).not.toHaveBeenCalled();
     expect(onOpenChange).toHaveBeenCalledWith(false);
 
     openSpy.mockRestore();

--- a/src/components/CommandPalette/CommandPalette.test.tsx
+++ b/src/components/CommandPalette/CommandPalette.test.tsx
@@ -1,14 +1,38 @@
 import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { CommandPalette } from "./CommandPalette";
 
 vi.mock("../../hooks/useGitHubData", () => ({
   useGitHubData: vi.fn(),
 }));
 
+vi.mock("../../lib/tauri", () => ({
+  listRepos: vi.fn(),
+}));
+
+const mockSetView = vi.fn();
+vi.mock("../../stores/dashboard", () => ({
+  useDashboardStore: { getState: () => ({ setView: mockSetView }) },
+  DashboardView: {},
+}));
+
 import { useGitHubData } from "../../hooks/useGitHubData";
+import { listRepos } from "../../lib/tauri";
 import type { DashboardData, PullRequestWithReview, Issue } from "../../lib/types";
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+});
+
+function renderPalette(props: { open: boolean; onOpenChange: (open: boolean) => void }) {
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <CommandPalette {...props} />
+    </QueryClientProvider>,
+  );
+}
 
 function makePr(overrides: Partial<PullRequestWithReview> = {}): PullRequestWithReview {
   return {
@@ -69,9 +93,26 @@ function makeDashboard(
   };
 }
 
+const mockRepo = {
+  id: "repo-1",
+  name: "prism",
+  org: "mpiton",
+  fullName: "mpiton/prism",
+  url: "",
+  defaultBranch: "main",
+  isArchived: false,
+  enabled: true,
+  localPath: null,
+  lastSyncAt: null,
+};
+
 describe("CommandPalette", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    queryClient.clear();
+    mockSetView.mockReset();
+
+    (listRepos as Mock).mockResolvedValue([mockRepo]);
 
     (useGitHubData as Mock).mockReturnValue({
       dashboard: makeDashboard(),
@@ -84,17 +125,22 @@ describe("CommandPalette", () => {
   });
 
   it("should not render when closed", () => {
-    render(<CommandPalette open={false} onOpenChange={() => {}} />);
+    renderPalette({ open: false, onOpenChange: () => {} });
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
   it("should render dialog and search input when open", () => {
-    const { rerender } = render(
-      <CommandPalette open={false} onOpenChange={() => {}} />,
-    );
+    const { rerender } = renderPalette({
+      open: false,
+      onOpenChange: () => {},
+    });
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
 
-    rerender(<CommandPalette open={true} onOpenChange={() => {}} />);
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <CommandPalette open={true} onOpenChange={() => {}} />
+      </QueryClientProvider>,
+    );
     expect(screen.getByRole("dialog")).toBeInTheDocument();
     expect(screen.getByPlaceholderText(/search/i)).toBeInTheDocument();
   });
@@ -102,7 +148,7 @@ describe("CommandPalette", () => {
   it("should close on Esc", async () => {
     const user = userEvent.setup();
     const onOpenChange = vi.fn();
-    render(<CommandPalette open={true} onOpenChange={onOpenChange} />);
+    renderPalette({ open: true, onOpenChange });
 
     await user.keyboard("{Escape}");
     expect(onOpenChange).toHaveBeenCalledWith(false);
@@ -132,12 +178,11 @@ describe("CommandPalette", () => {
     });
 
     const user = userEvent.setup();
-    render(<CommandPalette open={true} onOpenChange={() => {}} />);
+    renderPalette({ open: true, onOpenChange: () => {} });
 
     const input = screen.getByPlaceholderText(/search/i);
     await user.type(input, "login");
 
-    // "Fix login bug" should be visible, "Add search feature" should not
     expect(screen.getByText(/Fix login bug/)).toBeInTheDocument();
     expect(screen.queryByText(/Add search feature/)).not.toBeInTheDocument();
   });
@@ -155,7 +200,7 @@ describe("CommandPalette", () => {
     });
 
     const user = userEvent.setup();
-    render(<CommandPalette open={true} onOpenChange={() => {}} />);
+    renderPalette({ open: true, onOpenChange: () => {} });
 
     const input = screen.getByPlaceholderText(/search/i);
     await user.type(input, "99");
@@ -163,7 +208,53 @@ describe("CommandPalette", () => {
     expect(screen.getByText(/Dashboard crashes on empty data/)).toBeInTheDocument();
   });
 
-  it("should open selected item", async () => {
+  it("should navigate to reviews section when selecting a PR", async () => {
+    const pr = makePr();
+
+    (useGitHubData as Mock).mockReturnValue({
+      dashboard: makeDashboard({ reviewRequests: [pr] }),
+      stats: null,
+      isLoading: false,
+      error: null,
+      forceSync: vi.fn(),
+      isSyncing: false,
+    });
+
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    renderPalette({ open: true, onOpenChange });
+
+    const item = screen.getByText(/Fix login bug/);
+    await user.click(item);
+
+    expect(mockSetView).toHaveBeenCalledWith("reviews");
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("should navigate to issues section when selecting an issue", async () => {
+    const issue = makeIssue();
+
+    (useGitHubData as Mock).mockReturnValue({
+      dashboard: makeDashboard({ assignedIssues: [issue] }),
+      stats: null,
+      isLoading: false,
+      error: null,
+      forceSync: vi.fn(),
+      isSyncing: false,
+    });
+
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    renderPalette({ open: true, onOpenChange });
+
+    const item = screen.getByText(/Dashboard crashes on empty data/);
+    await user.click(item);
+
+    expect(mockSetView).toHaveBeenCalledWith("issues");
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("should open selected item in browser on Cmd+Enter", async () => {
     const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
     const pr = makePr();
 
@@ -178,10 +269,11 @@ describe("CommandPalette", () => {
 
     const user = userEvent.setup();
     const onOpenChange = vi.fn();
-    render(<CommandPalette open={true} onOpenChange={onOpenChange} />);
+    renderPalette({ open: true, onOpenChange });
 
-    const item = screen.getByText(/Fix login bug/);
-    await user.click(item);
+    // Navigate to item via keyboard (arrow down selects first item)
+    await user.keyboard("{ArrowDown}");
+    await user.keyboard("{Meta>}{Enter}{/Meta}");
 
     expect(openSpy).toHaveBeenCalledWith(
       "https://github.com/org/repo/pull/42",
@@ -195,7 +287,7 @@ describe("CommandPalette", () => {
 
   it("should show empty state when no results match", async () => {
     const user = userEvent.setup();
-    render(<CommandPalette open={true} onOpenChange={() => {}} />);
+    renderPalette({ open: true, onOpenChange: () => {} });
 
     const input = screen.getByPlaceholderText(/search/i);
     await user.type(input, "zzzznonexistent");
@@ -215,7 +307,7 @@ describe("CommandPalette", () => {
       isSyncing: false,
     });
 
-    render(<CommandPalette open={true} onOpenChange={() => {}} />);
+    renderPalette({ open: true, onOpenChange: () => {} });
 
     expect(screen.getByText(/Fix login bug/)).toBeInTheDocument();
     expect(screen.getByText(/#42/)).toBeInTheDocument();
@@ -233,7 +325,7 @@ describe("CommandPalette", () => {
       isSyncing: false,
     });
 
-    render(<CommandPalette open={true} onOpenChange={() => {}} />);
+    renderPalette({ open: true, onOpenChange: () => {} });
 
     expect(screen.getByText(/Dashboard crashes on empty data/)).toBeInTheDocument();
     expect(screen.getByText(/#99/)).toBeInTheDocument();
@@ -254,10 +346,49 @@ describe("CommandPalette", () => {
       isSyncing: false,
     });
 
-    render(<CommandPalette open={true} onOpenChange={() => {}} />);
+    renderPalette({ open: true, onOpenChange: () => {} });
 
-    // Should only appear once
     const items = screen.getAllByText(/Fix login bug/);
     expect(items).toHaveLength(1);
+  });
+
+  it("should display repo name for each item", async () => {
+    const pr = makePr();
+
+    (useGitHubData as Mock).mockReturnValue({
+      dashboard: makeDashboard({ reviewRequests: [pr] }),
+      stats: null,
+      isLoading: false,
+      error: null,
+      forceSync: vi.fn(),
+      isSyncing: false,
+    });
+
+    renderPalette({ open: true, onOpenChange: () => {} });
+
+    // Wait for the query to resolve
+    expect(await screen.findByText("prism")).toBeInTheDocument();
+  });
+
+  it("should group items under Pull Requests and Issues headings", () => {
+    const pr = makePr();
+    const issue = makeIssue();
+
+    (useGitHubData as Mock).mockReturnValue({
+      dashboard: makeDashboard({
+        reviewRequests: [pr],
+        assignedIssues: [issue],
+      }),
+      stats: null,
+      isLoading: false,
+      error: null,
+      forceSync: vi.fn(),
+      isSyncing: false,
+    });
+
+    renderPalette({ open: true, onOpenChange: () => {} });
+
+    expect(screen.getByText("Pull Requests")).toBeInTheDocument();
+    expect(screen.getByText("Issues")).toBeInTheDocument();
   });
 });

--- a/src/components/CommandPalette/CommandPalette.test.tsx
+++ b/src/components/CommandPalette/CommandPalette.test.tsx
@@ -231,6 +231,29 @@ describe("CommandPalette", () => {
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
+  it("should navigate to mine section when selecting a myPullRequests PR", async () => {
+    const pr = makePr();
+
+    (useGitHubData as Mock).mockReturnValue({
+      dashboard: makeDashboard({ myPullRequests: [pr] }),
+      stats: null,
+      isLoading: false,
+      error: null,
+      forceSync: vi.fn(),
+      isSyncing: false,
+    });
+
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    renderPalette({ open: true, onOpenChange });
+
+    const item = screen.getByText(/Fix login bug/);
+    await user.click(item);
+
+    expect(mockSetView).toHaveBeenCalledWith("mine");
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
   it("should navigate to issues section when selecting an issue", async () => {
     const issue = makeIssue();
 

--- a/src/components/CommandPalette/CommandPalette.tsx
+++ b/src/components/CommandPalette/CommandPalette.tsx
@@ -22,7 +22,11 @@ interface PaletteItem {
   readonly section: DashboardView;
 }
 
-function prToItem(pr: PullRequestWithReview, repoMap: Map<string, string>): PaletteItem {
+function prToItem(
+  pr: PullRequestWithReview,
+  repoMap: Map<string, string>,
+  section: DashboardView,
+): PaletteItem {
   return {
     id: pr.pullRequest.id,
     type: "pr",
@@ -30,7 +34,7 @@ function prToItem(pr: PullRequestWithReview, repoMap: Map<string, string>): Pale
     title: pr.pullRequest.title,
     url: pr.pullRequest.url,
     repoName: repoMap.get(pr.pullRequest.repoId) ?? pr.pullRequest.repoId,
-    section: "reviews",
+    section,
   };
 }
 
@@ -81,15 +85,26 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
 
   const repoMap = useMemo<Map<string, string>>(() => {
     if (!repos) return new Map();
-    return new Map(repos.map((r) => [r.id, r.name]));
+
+    const nameCounts = new Map<string, number>();
+    for (const repo of repos) {
+      nameCounts.set(repo.name, (nameCounts.get(repo.name) ?? 0) + 1);
+    }
+
+    return new Map(
+      repos.map((repo) => [
+        repo.id,
+        nameCounts.get(repo.name) === 1 ? repo.name : repo.fullName,
+      ]),
+    );
   }, [repos]);
 
   const { prItems, issueItems } = useMemo(() => {
     if (!dashboard) return { prItems: [], issueItems: [] };
 
     const allPrItems = deduplicateItems([
-      ...dashboard.reviewRequests.map((pr) => prToItem(pr, repoMap)),
-      ...dashboard.myPullRequests.map((pr) => prToItem(pr, repoMap)),
+      ...dashboard.reviewRequests.map((pr) => prToItem(pr, repoMap, "reviews")),
+      ...dashboard.myPullRequests.map((pr) => prToItem(pr, repoMap, "mine")),
     ]);
     const allIssueItems = deduplicateItems(
       dashboard.assignedIssues.map((issue) => issueToItem(issue, repoMap)),
@@ -104,7 +119,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
   );
 
   const findSelectedItem = useCallback(
-    () => allItems.find((item) => item.id === selectedValue) ?? null,
+    () => allItems.find((item) => item.id.toLowerCase() === selectedValue) ?? null,
     [allItems, selectedValue],
   );
 

--- a/src/components/CommandPalette/CommandPalette.tsx
+++ b/src/components/CommandPalette/CommandPalette.tsx
@@ -1,6 +1,10 @@
-import { useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { Command } from "cmdk";
+import { useQuery } from "@tanstack/react-query";
 import { useGitHubData } from "../../hooks/useGitHubData";
+import { listRepos } from "../../lib/tauri";
+import { useDashboardStore } from "../../stores/dashboard";
+import type { DashboardView } from "../../stores/dashboard";
 import type { PullRequestWithReview, Issue } from "../../lib/types";
 
 interface CommandPaletteProps {
@@ -14,25 +18,31 @@ interface PaletteItem {
   readonly number: number;
   readonly title: string;
   readonly url: string;
+  readonly repoName: string;
+  readonly section: DashboardView;
 }
 
-function prToItem(pr: PullRequestWithReview): PaletteItem {
+function prToItem(pr: PullRequestWithReview, repoMap: Map<string, string>): PaletteItem {
   return {
     id: pr.pullRequest.id,
     type: "pr",
     number: pr.pullRequest.number,
     title: pr.pullRequest.title,
     url: pr.pullRequest.url,
+    repoName: repoMap.get(pr.pullRequest.repoId) ?? pr.pullRequest.repoId,
+    section: "reviews",
   };
 }
 
-function issueToItem(issue: Issue): PaletteItem {
+function issueToItem(issue: Issue, repoMap: Map<string, string>): PaletteItem {
   return {
     id: issue.id,
     type: "issue",
     number: issue.number,
     title: issue.title,
     url: issue.url,
+    repoName: repoMap.get(issue.repoId) ?? issue.repoId,
+    section: "issues",
   };
 }
 
@@ -47,22 +57,51 @@ function deduplicateItems(items: readonly PaletteItem[]): readonly PaletteItem[]
 
 export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
   const { dashboard } = useGitHubData();
+  const { data: repos } = useQuery({ queryKey: ["repos"], queryFn: listRepos });
+  const [selectedValue, setSelectedValue] = useState("");
 
-  const items = useMemo<readonly PaletteItem[]>(() => {
-    if (!dashboard) return [];
+  const repoMap = useMemo<Map<string, string>>(() => {
+    if (!repos) return new Map();
+    return new Map(repos.map((r) => [r.id, r.name]));
+  }, [repos]);
 
-    const prItems = [
-      ...dashboard.reviewRequests.map(prToItem),
-      ...dashboard.myPullRequests.map(prToItem),
-    ];
-    const issueItems = dashboard.assignedIssues.map(issueToItem);
+  const { prItems, issueItems } = useMemo(() => {
+    if (!dashboard) return { prItems: [], issueItems: [] };
 
-    return deduplicateItems([...prItems, ...issueItems]);
-  }, [dashboard]);
+    const allPrItems = deduplicateItems([
+      ...dashboard.reviewRequests.map((pr) => prToItem(pr, repoMap)),
+      ...dashboard.myPullRequests.map((pr) => prToItem(pr, repoMap)),
+    ]);
+    const allIssueItems = dashboard.assignedIssues.map((issue) =>
+      issueToItem(issue, repoMap),
+    );
+
+    return { prItems: allPrItems, issueItems: allIssueItems };
+  }, [dashboard, repoMap]);
+
+  const allItems = useMemo(
+    () => [...prItems, ...issueItems],
+    [prItems, issueItems],
+  );
+
+  const findSelectedItem = useCallback(
+    () => allItems.find((item) => `${item.number} ${item.title}` === selectedValue) ?? null,
+    [allItems, selectedValue],
+  );
 
   function handleSelect(item: PaletteItem): void {
-    window.open(item.url, "_blank", "noopener,noreferrer");
+    useDashboardStore.getState().setView(item.section);
     onOpenChange(false);
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent): void {
+    if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+      const item = findSelectedItem();
+      if (item) {
+        window.open(item.url, "_blank", "noopener,noreferrer");
+        onOpenChange(false);
+      }
+    }
   }
 
   return (
@@ -70,7 +109,11 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
       open={open}
       onOpenChange={onOpenChange}
       label="Command palette"
+      aria-describedby={undefined}
       className="fixed inset-0 z-50 flex items-start justify-center pt-[20vh]"
+      onKeyDown={handleKeyDown}
+      value={selectedValue}
+      onValueChange={setSelectedValue}
     >
       <div className="w-full max-w-lg rounded-lg border border-border bg-bg shadow-xl">
         <Command.Input
@@ -82,22 +125,53 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
             No results found.
           </Command.Empty>
 
-          {items.map((item) => (
-            <Command.Item
-              key={item.id}
-              value={`${item.number} ${item.title}`}
-              onSelect={() => handleSelect(item)}
-              className="flex cursor-pointer items-center gap-2 rounded-md px-3 py-2 text-sm text-fg aria-selected:bg-fg/10"
-            >
-              <span className="shrink-0 text-fg/50">
-                #{item.number}
-              </span>
-              <span className="truncate">{item.title}</span>
-              <span className="ml-auto shrink-0 rounded bg-fg/10 px-1.5 py-0.5 text-xs uppercase text-fg/60">
-                {item.type}
-              </span>
-            </Command.Item>
-          ))}
+          {prItems.length > 0 && (
+            <Command.Group heading="Pull Requests">
+              {prItems.map((item) => (
+                <Command.Item
+                  key={item.id}
+                  value={`${item.number} ${item.title}`}
+                  onSelect={() => handleSelect(item)}
+                  className="flex cursor-pointer items-center gap-2 rounded-md px-3 py-2 text-sm text-fg aria-selected:bg-fg/10"
+                >
+                  <span className="shrink-0 text-fg/50">
+                    #{item.number}
+                  </span>
+                  <span className="truncate">{item.title}</span>
+                  <span className="shrink-0 rounded bg-fg/10 px-1.5 py-0.5 text-xs text-fg/60">
+                    {item.repoName}
+                  </span>
+                  <span className="ml-auto shrink-0 rounded bg-fg/10 px-1.5 py-0.5 text-xs uppercase text-fg/60">
+                    {item.type}
+                  </span>
+                </Command.Item>
+              ))}
+            </Command.Group>
+          )}
+
+          {issueItems.length > 0 && (
+            <Command.Group heading="Issues">
+              {issueItems.map((item) => (
+                <Command.Item
+                  key={item.id}
+                  value={`${item.number} ${item.title}`}
+                  onSelect={() => handleSelect(item)}
+                  className="flex cursor-pointer items-center gap-2 rounded-md px-3 py-2 text-sm text-fg aria-selected:bg-fg/10"
+                >
+                  <span className="shrink-0 text-fg/50">
+                    #{item.number}
+                  </span>
+                  <span className="truncate">{item.title}</span>
+                  <span className="shrink-0 rounded bg-fg/10 px-1.5 py-0.5 text-xs text-fg/60">
+                    {item.repoName}
+                  </span>
+                  <span className="ml-auto shrink-0 rounded bg-fg/10 px-1.5 py-0.5 text-xs uppercase text-fg/60">
+                    {item.type}
+                  </span>
+                </Command.Item>
+              ))}
+            </Command.Group>
+          )}
         </Command.List>
       </div>
     </Command.Dialog>

--- a/src/components/CommandPalette/CommandPalette.tsx
+++ b/src/components/CommandPalette/CommandPalette.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState, type ReactElement } from "react";
 import { Command } from "cmdk";
 import { useQuery } from "@tanstack/react-query";
 import { useGitHubData } from "../../hooks/useGitHubData";
@@ -55,10 +55,29 @@ function deduplicateItems(items: readonly PaletteItem[]): readonly PaletteItem[]
   });
 }
 
+function PaletteItemRow({ item }: { readonly item: PaletteItem }): ReactElement {
+  return (
+    <>
+      <span className="shrink-0 text-fg/50">#{item.number}</span>
+      <span className="truncate">{item.title}</span>
+      <span className="shrink-0 rounded bg-fg/10 px-1.5 py-0.5 text-xs text-fg/60">
+        {item.repoName}
+      </span>
+      <span className="ml-auto shrink-0 rounded bg-fg/10 px-1.5 py-0.5 text-xs uppercase text-fg/60">
+        {item.type}
+      </span>
+    </>
+  );
+}
+
 export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
   const { dashboard } = useGitHubData();
   const { data: repos } = useQuery({ queryKey: ["repos"], queryFn: listRepos });
   const [selectedValue, setSelectedValue] = useState("");
+
+  useEffect(() => {
+    if (!open) setSelectedValue("");
+  }, [open]);
 
   const repoMap = useMemo<Map<string, string>>(() => {
     if (!repos) return new Map();
@@ -72,8 +91,8 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
       ...dashboard.reviewRequests.map((pr) => prToItem(pr, repoMap)),
       ...dashboard.myPullRequests.map((pr) => prToItem(pr, repoMap)),
     ]);
-    const allIssueItems = dashboard.assignedIssues.map((issue) =>
-      issueToItem(issue, repoMap),
+    const allIssueItems = deduplicateItems(
+      dashboard.assignedIssues.map((issue) => issueToItem(issue, repoMap)),
     );
 
     return { prItems: allPrItems, issueItems: allIssueItems };
@@ -85,7 +104,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
   );
 
   const findSelectedItem = useCallback(
-    () => allItems.find((item) => `${item.number} ${item.title}` === selectedValue) ?? null,
+    () => allItems.find((item) => item.id === selectedValue) ?? null,
     [allItems, selectedValue],
   );
 
@@ -96,6 +115,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
 
   function handleKeyDown(e: React.KeyboardEvent): void {
     if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+      e.preventDefault();
       const item = findSelectedItem();
       if (item) {
         window.open(item.url, "_blank", "noopener,noreferrer");
@@ -130,20 +150,12 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
               {prItems.map((item) => (
                 <Command.Item
                   key={item.id}
-                  value={`${item.number} ${item.title}`}
+                  value={item.id}
+                  keywords={[String(item.number), item.title, item.repoName]}
                   onSelect={() => handleSelect(item)}
                   className="flex cursor-pointer items-center gap-2 rounded-md px-3 py-2 text-sm text-fg aria-selected:bg-fg/10"
                 >
-                  <span className="shrink-0 text-fg/50">
-                    #{item.number}
-                  </span>
-                  <span className="truncate">{item.title}</span>
-                  <span className="shrink-0 rounded bg-fg/10 px-1.5 py-0.5 text-xs text-fg/60">
-                    {item.repoName}
-                  </span>
-                  <span className="ml-auto shrink-0 rounded bg-fg/10 px-1.5 py-0.5 text-xs uppercase text-fg/60">
-                    {item.type}
-                  </span>
+                  <PaletteItemRow item={item} />
                 </Command.Item>
               ))}
             </Command.Group>
@@ -154,20 +166,12 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
               {issueItems.map((item) => (
                 <Command.Item
                   key={item.id}
-                  value={`${item.number} ${item.title}`}
+                  value={item.id}
+                  keywords={[String(item.number), item.title, item.repoName]}
                   onSelect={() => handleSelect(item)}
                   className="flex cursor-pointer items-center gap-2 rounded-md px-3 py-2 text-sm text-fg aria-selected:bg-fg/10"
                 >
-                  <span className="shrink-0 text-fg/50">
-                    #{item.number}
-                  </span>
-                  <span className="truncate">{item.title}</span>
-                  <span className="shrink-0 rounded bg-fg/10 px-1.5 py-0.5 text-xs text-fg/60">
-                    {item.repoName}
-                  </span>
-                  <span className="ml-auto shrink-0 rounded bg-fg/10 px-1.5 py-0.5 text-xs uppercase text-fg/60">
-                    {item.type}
-                  </span>
+                  <PaletteItemRow item={item} />
                 </Command.Item>
               ))}
             </Command.Group>


### PR DESCRIPTION
## Summary

- Enhanced `CommandPalette` component with repo name display, grouped items (Pull Requests / Issues), and section navigation
- Default action navigates to the relevant dashboard section (reviews/issues) instead of opening in browser
- Secondary action (`Cmd+Enter`) opens the selected item in the browser
- Fixed keyboard selection tracking for `Cmd+Enter` (uses cmdk's value state instead of mouse-only refs)
- Fixed Radix Dialog a11y warning (`aria-describedby`)

Closes #101

## Test plan

- [x] 14/14 CommandPalette tests pass (including 5 new tests)
- [x] 461/461 full test suite passes
- [x] oxlint: 0 errors, 0 warnings
- [ ] Manual: open app, press `Cmd+K`, verify grouped items with repo badges
- [ ] Manual: click item → navigates to section, `Cmd+Enter` → opens in browser
- [ ] Manual: search by title/number, verify filtering works across groups

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Integrates the command palette with `cmdk` and improves navigation: grouped PRs/issues, repo badges (with collision handling), and better keyboard actions. Implements Linear T-064 by routing selections to in-app views and supporting Cmd+Enter to open in the browser.

- **New Features**
  - Group results under “Pull Requests” and “Issues”.
  - Show repo name badges for each item (via `listRepos` + `@tanstack/react-query`), using full name when names collide.
  - Default select navigates to the dashboard section (“reviews”/“mine”/“issues”); Cmd+Enter opens the item in the browser.

- **Bug Fixes**
  - Stabilized selection and search: use item.id as `cmdk` value with keywords, case-insensitive match for selection, reset selection on close, and prevent default on Cmd+Enter to avoid triggering onSelect.
  - Deduplicate issues like PRs; suppress Radix Dialog `aria-describedby` warning.

<sup>Written for commit 1b9fb0bdaf18db01a9f8d3568004bdcaacbe0b65. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repository names now appear in the command palette for better context
  * Items are grouped into "Pull Requests" and "Issues" sections
  * Selecting an item switches the dashboard view and closes the palette
  * Ctrl/Cmd+Enter opens the selected item in a new tab and closes the palette

* **Tests**
  * Expanded coverage for selection flow, grouped results display, navigation side effects, and keyboard behavior; added mocks and async UI assertions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->