### PR TITLE
fix(workspace): resolve TypeScript errors in workspace frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ docs/
 # Claude Code local config
 # ──────────────────────────────────────
 .claude/
+skills-lock.json
 
 # ──────────────────────────────────────
 # Audit / telemetry

--- a/src-tauri/src/cache/dashboard.rs
+++ b/src-tauri/src/cache/dashboard.rs
@@ -311,6 +311,7 @@ mod tests {
             labels: vec![],
             additions: 50,
             deletions: 10,
+            head_ref_name: "fix/test-branch".to_string(),
             created_at: "2026-03-01T10:00:00Z".to_string(),
             updated_at: "2026-03-20T15:00:00Z".to_string(),
         }

--- a/src-tauri/src/cache/migrations/003_add_pr_head_ref_name.sql
+++ b/src-tauri/src/cache/migrations/003_add_pr_head_ref_name.sql
@@ -1,0 +1,2 @@
+-- Add head_ref_name (branch name) to pull_requests for workspace creation.
+ALTER TABLE pull_requests ADD COLUMN head_ref_name TEXT NOT NULL DEFAULT '';

--- a/src-tauri/src/cache/pull_requests.rs
+++ b/src-tauri/src/cache/pull_requests.rs
@@ -19,6 +19,7 @@ pub(crate) struct PullRequestRow {
     pub(crate) labels: String,
     pub(crate) additions: i64,
     pub(crate) deletions: i64,
+    pub(crate) head_ref_name: String,
     pub(crate) created_at: String,
     pub(crate) updated_at: String,
 }
@@ -109,6 +110,7 @@ impl TryFrom<PullRequestRow> for PullRequest {
             labels,
             additions,
             deletions,
+            head_ref_name: row.head_ref_name,
             created_at: row.created_at,
             updated_at: row.updated_at,
         })
@@ -116,7 +118,7 @@ impl TryFrom<PullRequestRow> for PullRequest {
 }
 
 /// Explicit column list for all SELECT queries.
-pub(crate) const PR_COLS: &str = "id, number, title, author, state, ci_status, priority, repo_id, url, labels, additions, deletions, created_at, updated_at";
+pub(crate) const PR_COLS: &str = "id, number, title, author, state, ci_status, priority, repo_id, url, labels, additions, deletions, head_ref_name, created_at, updated_at";
 
 /// Insert or update a pull request. On conflict (same `id`), updates all fields.
 /// Uses `RETURNING` for an atomic read-after-write.
@@ -134,8 +136,8 @@ where
         serde_json::to_string(&pr.labels).map_err(|e| AppError::Config(e.to_string()))?;
 
     let sql = format!(
-        "INSERT INTO pull_requests (id, number, title, author, state, ci_status, priority, repo_id, url, labels, additions, deletions, created_at, updated_at)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+        "INSERT INTO pull_requests (id, number, title, author, state, ci_status, priority, repo_id, url, labels, additions, deletions, head_ref_name, created_at, updated_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
          ON CONFLICT(id) DO UPDATE SET
              number = excluded.number,
              title = excluded.title,
@@ -147,6 +149,7 @@ where
              labels = excluded.labels,
              additions = excluded.additions,
              deletions = excluded.deletions,
+             head_ref_name = excluded.head_ref_name,
              updated_at = excluded.updated_at
          RETURNING {PR_COLS}"
     );
@@ -164,6 +167,7 @@ where
         .bind(&labels_json)
         .bind(i64::from(pr.additions))
         .bind(i64::from(pr.deletions))
+        .bind(&pr.head_ref_name)
         .bind(&pr.created_at)
         .bind(&pr.updated_at)
         .fetch_one(executor)
@@ -313,6 +317,7 @@ mod tests {
             labels: vec!["bug".to_string(), "urgent".to_string()],
             additions: 50,
             deletions: 10,
+            head_ref_name: format!("fix/pr-{number}"),
             created_at: "2026-03-01T10:00:00Z".to_string(),
             updated_at: "2026-03-20T15:00:00Z".to_string(),
         }

--- a/src-tauri/src/cache/reviews.rs
+++ b/src-tauri/src/cache/reviews.rs
@@ -294,6 +294,7 @@ mod tests {
             labels: vec![],
             additions: 50,
             deletions: 10,
+            head_ref_name: "fix/test-branch".to_string(),
             created_at: "2026-03-01T10:00:00Z".to_string(),
             updated_at: "2026-03-20T15:00:00Z".to_string(),
         }

--- a/src-tauri/src/cache/stats.rs
+++ b/src-tauri/src/cache/stats.rs
@@ -121,6 +121,7 @@ mod tests {
             labels: vec![],
             additions: 10,
             deletions: 5,
+            head_ref_name: "fix/test-branch".to_string(),
             created_at: hours_ago(48),
             updated_at: now_ts(),
         }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -583,26 +583,36 @@ pub(crate) async fn workspace_open_inner(
     req: &OpenWorkspaceRequest,
     on_pty_output: impl Fn(&str, &[u8]) + Send + 'static,
 ) -> Result<OpenWorkspaceResponse, AppError> {
-    // 1. Get repo and validate local_path
+    // 1. Get repo; clone if no local_path
     let repo = get_repo(pool, &req.repo_id).await?;
-    let local_path = repo.local_path.as_deref().ok_or_else(|| {
-        AppError::Workspace(format!(
-            "repo '{}' has no local_path configured",
-            req.repo_id
-        ))
-    })?;
-    let local_path = PathBuf::from(local_path);
 
     // 2. Read config (needed for base_dir and LRU limit)
     let config = get_config(pool).await?;
 
-    // 3. Create worktree
     let base_dir = config
         .workspaces_dir
         .as_deref()
         .map(PathBuf::from)
         .or_else(|| worktree::default_base_dir().ok())
         .ok_or_else(|| AppError::Workspace("cannot determine workspaces base directory".into()))?;
+
+    let local_path = if let Some(lp) = repo.local_path.as_deref() {
+        PathBuf::from(lp)
+    } else {
+        // Auto-clone: clone into {base_dir}/{repo_name}/repo
+        let repos_dir = base_dir.join(&repo.name);
+        let clone_path = worktree::clone_repo(&repo.url, "repo", &repos_dir).await?;
+        // Persist local_path so future opens skip the clone
+        crate::cache::repos::set_local_path(
+            pool,
+            &repo.id,
+            Some(clone_path.to_str().unwrap_or("")),
+        )
+        .await?;
+        clone_path
+    };
+
+    // 3. Create worktree
     let wt_path = worktree::create_worktree(
         &local_path,
         &req.branch,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -13,9 +13,7 @@ use crate::cache::dashboard::{assemble_dashboard_data, compute_dashboard_stats};
 use crate::cache::repos::{get_repo, list_repos, set_local_path, set_repo_enabled};
 use crate::cache::stats::compute_personal_stats;
 use crate::cache::sync::sync_dashboard;
-use crate::cache::workspaces::{
-    create_workspace, get_notes, list_workspaces, update_workspace_state,
-};
+use crate::cache::workspaces::{get_notes, list_workspaces, update_workspace_state};
 use crate::error::AppError;
 use crate::github::auth;
 use crate::github::client::GitHubClient;
@@ -610,17 +608,7 @@ pub(crate) async fn workspace_open_inner(
         clone_path
     };
 
-    // 3. Delete any archived workspace for this PR (UNIQUE constraint on repo_id + pr_number)
-    //    Done before worktree/PTY creation to avoid resource leaks on SQL failure.
-    sqlx::query(
-        "DELETE FROM workspaces WHERE repo_id = $1 AND pull_request_number = $2 AND state = 'archived'",
-    )
-    .bind(&req.repo_id)
-    .bind(req.pull_request_number)
-    .execute(pool)
-    .await?;
-
-    // 4. Create worktree
+    // 3. Create worktree
     let wt_path = worktree::create_worktree(
         &local_path,
         &req.branch,
@@ -639,19 +627,37 @@ pub(crate) async fn workspace_open_inner(
         }
     };
 
-    // 7. Create workspace in DB
+    // 5. Atomic DELETE archived + INSERT new workspace (transaction prevents
+    //    data loss if INSERT fails, and avoids resource leaks if DELETE fails).
     let now = chrono::Utc::now().to_rfc3339();
-    let ws = Workspace {
-        id: workspace_id.to_string(),
-        repo_id: req.repo_id.clone(),
-        pull_request_number: req.pull_request_number,
-        state: WorkspaceState::Active,
-        worktree_path: Some(wt_path.to_string_lossy().to_string()),
-        session_id: None,
-        created_at: now.clone(),
-        updated_at: now,
-    };
-    if let Err(e) = create_workspace(pool, &ws).await {
+    let insert_result: Result<(), AppError> = async {
+        let mut tx = pool.begin().await?;
+        sqlx::query(
+            "DELETE FROM workspaces WHERE repo_id = $1 AND pull_request_number = $2 AND state = 'archived'",
+        )
+        .bind(&req.repo_id)
+        .bind(req.pull_request_number)
+        .execute(&mut *tx)
+        .await?;
+        sqlx::query(
+            "INSERT INTO workspaces (id, repo_id, pull_request_number, state, worktree_path, session_id, created_at, updated_at)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+        )
+        .bind(workspace_id)
+        .bind(&req.repo_id)
+        .bind(req.pull_request_number)
+        .bind("active")
+        .bind(wt_path.to_string_lossy().as_ref())
+        .bind(Option::<&str>::None)
+        .bind(&now)
+        .bind(&now)
+        .execute(&mut *tx)
+        .await?;
+        tx.commit().await?;
+        Ok(())
+    }
+    .await;
+    if let Err(e) = insert_result {
         let _ = pty_state.manager.kill(&pty_id);
         let _ = worktree::remove_worktree(&local_path, &wt_path).await;
         return Err(e);
@@ -2007,8 +2013,8 @@ mod tests {
         // The error should be a Git error from the clone/worktree attempt,
         // not the old "no local_path" Workspace error.
         assert!(
-            !err.to_string().contains("no local_path"),
-            "should not get old 'no local_path' error, got: {err}"
+            matches!(err, AppError::Git(_)),
+            "expected Git error from clone/worktree path, got: {err}"
         );
 
         pool.close().await;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1986,7 +1986,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_workspace_open_no_local_path() {
+    async fn test_workspace_open_no_local_path_triggers_clone() {
         let (pool, _tmp) = test_pool().await;
         insert_test_repo(&pool, None).await;
 
@@ -1997,17 +1997,18 @@ mod tests {
             branch: "feature-42".into(),
         };
 
+        // With no local_path the function attempts an auto-clone.
+        // In CI without network access it will fail with a Git error
+        // (not a Workspace error), proving the clone path was taken.
         let ws_id = uuid::Uuid::new_v4().to_string();
         let result = workspace_open_inner(&pool, &pty_state, &ws_id, &req, |_, _| {}).await;
-        assert!(result.is_err());
+        assert!(result.is_err(), "should fail (no real clone target)");
         let err = result.unwrap_err();
+        // The error should be a Git error from the clone/worktree attempt,
+        // not the old "no local_path" Workspace error.
         assert!(
-            matches!(err, AppError::Workspace(_)),
-            "expected Workspace error, got: {err}"
-        );
-        assert!(
-            err.to_string().contains("no local_path"),
-            "error should mention local_path: {err}"
+            !err.to_string().contains("no local_path"),
+            "should not get old 'no local_path' error, got: {err}"
         );
 
         pool.close().await;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -597,8 +597,8 @@ pub(crate) async fn workspace_open_inner(
     let local_path = if let Some(lp) = repo.local_path.as_deref() {
         PathBuf::from(lp)
     } else {
-        // Auto-clone: clone into {base_dir}/{repo_name}/repo
-        let repos_dir = base_dir.join(&repo.name);
+        // Auto-clone: clone into {base_dir}/{org}/{repo}/repo
+        let repos_dir = base_dir.join(&repo.full_name);
         let clone_path = worktree::clone_repo(&repo.url, "repo", &repos_dir).await?;
         // Persist local_path so future opens skip the clone
         let clone_str = clone_path
@@ -2010,11 +2010,15 @@ mod tests {
         let result = workspace_open_inner(&pool, &pty_state, &ws_id, &req, |_, _| {}).await;
         assert!(result.is_err(), "should fail (no real clone target)");
         let err = result.unwrap_err();
-        // The error should be a Git error from the clone/worktree attempt,
-        // not the old "no local_path" Workspace error.
+        // The error comes from the clone/worktree attempt (Git or Workspace),
+        // never the old "no local_path" error.
         assert!(
-            matches!(err, AppError::Git(_)),
-            "expected Git error from clone/worktree path, got: {err}"
+            matches!(err, AppError::Git(_) | AppError::Workspace(_)),
+            "expected Git or Workspace error from clone path, got: {err}"
+        );
+        assert!(
+            !err.to_string().contains("no local_path"),
+            "should not get old 'no local_path' error, got: {err}"
         );
 
         pool.close().await;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -603,16 +603,24 @@ pub(crate) async fn workspace_open_inner(
         let repos_dir = base_dir.join(&repo.name);
         let clone_path = worktree::clone_repo(&repo.url, "repo", &repos_dir).await?;
         // Persist local_path so future opens skip the clone
-        crate::cache::repos::set_local_path(
-            pool,
-            &repo.id,
-            Some(clone_path.to_str().unwrap_or("")),
-        )
-        .await?;
+        let clone_str = clone_path
+            .to_str()
+            .ok_or_else(|| AppError::Workspace("clone path is not valid UTF-8".into()))?;
+        crate::cache::repos::set_local_path(pool, &repo.id, Some(clone_str)).await?;
         clone_path
     };
 
-    // 3. Create worktree
+    // 3. Delete any archived workspace for this PR (UNIQUE constraint on repo_id + pr_number)
+    //    Done before worktree/PTY creation to avoid resource leaks on SQL failure.
+    sqlx::query(
+        "DELETE FROM workspaces WHERE repo_id = $1 AND pull_request_number = $2 AND state = 'archived'",
+    )
+    .bind(&req.repo_id)
+    .bind(req.pull_request_number)
+    .execute(pool)
+    .await?;
+
+    // 4. Create worktree
     let wt_path = worktree::create_worktree(
         &local_path,
         &req.branch,
@@ -631,16 +639,7 @@ pub(crate) async fn workspace_open_inner(
         }
     };
 
-    // 5. Delete any archived workspace for this PR (UNIQUE constraint on repo_id + pr_number)
-    sqlx::query(
-        "DELETE FROM workspaces WHERE repo_id = $1 AND pull_request_number = $2 AND state = 'archived'",
-    )
-    .bind(&req.repo_id)
-    .bind(req.pull_request_number)
-    .execute(pool)
-    .await?;
-
-    // 6. Create workspace in DB
+    // 7. Create workspace in DB
     let now = chrono::Utc::now().to_rfc3339();
     let ws = Workspace {
         id: workspace_id.to_string(),

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2527,6 +2527,7 @@ mod tests {
             labels: vec![],
             additions: 10,
             deletions: 5,
+            head_ref_name: "fix/test-branch".to_string(),
             created_at: "2026-03-01T00:00:00Z".to_string(),
             updated_at: updated_at.to_string(),
         };

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -621,7 +621,16 @@ pub(crate) async fn workspace_open_inner(
         }
     };
 
-    // 5. Create workspace in DB
+    // 5. Delete any archived workspace for this PR (UNIQUE constraint on repo_id + pr_number)
+    sqlx::query(
+        "DELETE FROM workspaces WHERE repo_id = $1 AND pull_request_number = $2 AND state = 'archived'",
+    )
+    .bind(&req.repo_id)
+    .bind(req.pull_request_number)
+    .execute(pool)
+    .await?;
+
+    // 6. Create workspace in DB
     let now = chrono::Utc::now().to_rfc3339();
     let ws = Workspace {
         id: workspace_id.to_string(),

--- a/src-tauri/src/github/models.rs
+++ b/src-tauri/src/github/models.rs
@@ -121,6 +121,7 @@ pub fn map_pr(pr: &PrFields) -> Result<PullRequest, AppError> {
                 pr.id, pr.deletions
             ))
         })?,
+        head_ref_name: pr.head_ref_name.clone(),
         created_at: pr.created_at.clone(),
         updated_at: pr.updated_at.clone(),
     })

--- a/src-tauri/src/github/scoring.rs
+++ b/src-tauri/src/github/scoring.rs
@@ -105,6 +105,7 @@ mod tests {
             labels: overrides.labels.unwrap_or_default(),
             additions: overrides.additions.unwrap_or(50),
             deletions: overrides.deletions.unwrap_or(10),
+            head_ref_name: "fix/test-branch".to_string(),
             created_at: overrides
                 .created_at
                 .unwrap_or_else(|| "2026-03-25T10:00:00Z".to_string()),

--- a/src-tauri/src/notifications.rs
+++ b/src-tauri/src/notifications.rs
@@ -226,6 +226,7 @@ mod tests {
             labels: vec![],
             additions: 10,
             deletions: 5,
+            head_ref_name: "fix/test-branch".to_string(),
             created_at: "2026-03-29T10:00:00Z".to_string(),
             updated_at: "2026-03-29T10:00:00Z".to_string(),
         }

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -123,6 +123,7 @@ pub struct PullRequest {
     pub labels: Vec<String>,
     pub additions: u32,
     pub deletions: u32,
+    pub head_ref_name: String,
     pub created_at: String,
     pub updated_at: String,
 }
@@ -732,6 +733,7 @@ mod tests {
             labels: vec!["enhancement".to_string(), "frontend".to_string()],
             additions: 50,
             deletions: 10,
+            head_ref_name: "fix/test-branch".to_string(),
             created_at: "2026-03-24T10:00:00Z".to_string(),
             updated_at: "2026-03-24T12:00:00Z".to_string(),
         };
@@ -899,6 +901,7 @@ mod tests {
                 labels: vec!["enhancement".to_string()],
                 additions: 50,
                 deletions: 10,
+                head_ref_name: "fix/test-branch".to_string(),
                 created_at: "2026-03-24T10:00:00Z".to_string(),
                 updated_at: "2026-03-24T12:00:00Z".to_string(),
             },
@@ -939,6 +942,7 @@ mod tests {
                 labels: vec![],
                 additions: 50,
                 deletions: 10,
+                head_ref_name: "fix/test-branch".to_string(),
                 created_at: "2026-03-24T10:00:00Z".to_string(),
                 updated_at: "2026-03-24T12:00:00Z".to_string(),
             },

--- a/src-tauri/src/workspace/lifecycle.rs
+++ b/src-tauri/src/workspace/lifecycle.rs
@@ -278,6 +278,7 @@ mod tests {
             labels: vec![],
             additions: 10,
             deletions: 5,
+            head_ref_name: "fix/test-branch".to_string(),
             created_at: "2026-03-01T00:00:00Z".to_string(),
             updated_at: updated_at.to_string(),
         };

--- a/src-tauri/src/workspace/worktree.rs
+++ b/src-tauri/src/workspace/worktree.rs
@@ -118,6 +118,51 @@ fn classify_git_error(stderr: &str, args_display: &str) -> AppError {
     ))
 }
 
+/// Clones a GitHub repository into `{base_dir}/{repo_name}`.
+///
+/// Returns the path to the cloned repository.
+/// Times out after [`GIT_TIMEOUT`] (120s — enough for most repos).
+pub async fn clone_repo(
+    repo_url: &str,
+    repo_name: &str,
+    base_dir: &Path,
+) -> Result<PathBuf, AppError> {
+    let clone_path = base_dir.join(repo_name);
+
+    if clone_path.exists() {
+        // Already cloned — just fetch latest
+        tracing::info!("repo already cloned at {}, fetching", clone_path.display());
+        let _ = run_git(&["fetch".into(), "--all".into()], &clone_path).await;
+        return Ok(clone_path);
+    }
+
+    if let Some(parent) = clone_path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|e| AppError::Workspace(format!("failed to create clone dir: {e}")))?;
+    }
+
+    tracing::info!("cloning {} into {}", repo_url, clone_path.display());
+
+    let clone_url = if repo_url.starts_with("http") {
+        repo_url.to_string()
+    } else {
+        format!("https://github.com/{repo_url}.git")
+    };
+
+    run_git(
+        &[
+            "clone".into(),
+            clone_url.into(),
+            clone_path.as_os_str().to_os_string(),
+        ],
+        base_dir,
+    )
+    .await?;
+
+    Ok(clone_path)
+}
+
 /// Runs a git command in the given directory and returns stdout on success.
 ///
 /// Times out after [`GIT_TIMEOUT`] to prevent indefinite hangs on network operations.

--- a/src-tauri/src/workspace/worktree.rs
+++ b/src-tauri/src/workspace/worktree.rs
@@ -129,11 +129,17 @@ pub async fn clone_repo(
 ) -> Result<PathBuf, AppError> {
     let clone_path = base_dir.join(repo_name);
 
-    if clone_path.exists() {
-        // Already cloned — just fetch latest
+    if clone_path.join(".git").exists() {
+        // Valid clone — just fetch latest
         tracing::info!("repo already cloned at {}, fetching", clone_path.display());
         run_git(&["fetch".into(), "--all".into()], &clone_path).await?;
         return Ok(clone_path);
+    } else if clone_path.exists() {
+        // Directory exists but isn't a git repo — likely a failed previous clone
+        return Err(AppError::Workspace(format!(
+            "clone path '{}' exists but is not a git repository; please remove it and try again",
+            clone_path.display()
+        )));
     }
 
     if let Some(parent) = clone_path.parent() {

--- a/src-tauri/src/workspace/worktree.rs
+++ b/src-tauri/src/workspace/worktree.rs
@@ -132,7 +132,7 @@ pub async fn clone_repo(
     if clone_path.exists() {
         // Already cloned — just fetch latest
         tracing::info!("repo already cloned at {}, fetching", clone_path.display());
-        let _ = run_git(&["fetch".into(), "--all".into()], &clone_path).await;
+        run_git(&["fetch".into(), "--all".into()], &clone_path).await?;
         return Ok(clone_path);
     }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -128,6 +128,8 @@ function MainContent({ view, onBackToDashboard }: MainContentProps): ReactElemen
         if (params.workspaceId && params.workspaceState !== "archived") {
           if (params.workspaceState === "suspended") {
             await resumeWorkspace(params.workspaceId);
+            await queryClient.invalidateQueries({ queryKey: ["workspaces"] });
+            await queryClient.invalidateQueries({ queryKey: ["github", "dashboard"] });
           }
           setActiveWorkspace(params.workspaceId);
           setView("workspaces");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,13 +3,14 @@ import {
   lazy,
   Suspense,
   useCallback,
+  useMemo,
   useState,
   type ErrorInfo,
   type ReactElement,
   type ReactNode,
 } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { authGetStatus, markAllActivityRead, openWorkspace, resumeWorkspace } from "./lib/tauri";
+import { authGetStatus, listRepos, markAllActivityRead, openWorkspace, resumeWorkspace } from "./lib/tauri";
 import { useGitHubData } from "./hooks/useGitHubData";
 import { AuthSetup } from "./components/AuthSetup/AuthSetup";
 import { StatsBar } from "./components/StatsBar";
@@ -104,6 +105,12 @@ function MainContent({ view, onBackToDashboard }: MainContentProps): ReactElemen
   const { dashboard } = useGitHubData();
   const { statusInfo } = useWorkspaceEnriched(view === "workspaces");
   const queryClient = useQueryClient();
+  const { data: repos } = useQuery({ queryKey: ["repos"], queryFn: listRepos, staleTime: 60_000 });
+
+  const workspaceRepoIds = useMemo(
+    () => new Set(repos?.filter((r) => r.localPath).map((r) => r.id) ?? []),
+    [repos],
+  );
 
   const markAllRead = useMutation({
     mutationFn: markAllActivityRead,
@@ -156,9 +163,9 @@ function MainContent({ view, onBackToDashboard }: MainContentProps): ReactElemen
     case "overview":
       return <Overview />;
     case "reviews":
-      return <ReviewQueue reviews={dashboard?.reviewRequests ?? []} onOpen={openUrl} onWorkspaceAction={handleWorkspaceAction} />;
+      return <ReviewQueue reviews={dashboard?.reviewRequests ?? []} onOpen={openUrl} onWorkspaceAction={handleWorkspaceAction} workspaceRepoIds={workspaceRepoIds} />;
     case "mine":
-      return <MyPRs prs={dashboard?.myPullRequests ?? []} onOpen={openUrl} onWorkspaceAction={handleWorkspaceAction} />;
+      return <MyPRs prs={dashboard?.myPullRequests ?? []} onOpen={openUrl} onWorkspaceAction={handleWorkspaceAction} workspaceRepoIds={workspaceRepoIds} />;
     case "issues":
       return <Issues issues={dashboard?.assignedIssues ?? []} onOpen={openUrl} />;
     case "feed":

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ import {
   type ReactNode,
 } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { authGetStatus, markAllActivityRead } from "./lib/tauri";
+import { authGetStatus, markAllActivityRead, openWorkspace, resumeWorkspace } from "./lib/tauri";
 import { useGitHubData } from "./hooks/useGitHubData";
 import { AuthSetup } from "./components/AuthSetup/AuthSetup";
 import { StatsBar } from "./components/StatsBar";
@@ -113,13 +113,52 @@ function MainContent({ view, onBackToDashboard }: MainContentProps): ReactElemen
     },
   });
 
+  const handleWorkspaceAction = useCallback(
+    async (params: {
+      readonly repoId: string;
+      readonly pullRequestNumber: number;
+      readonly headRefName: string;
+      readonly workspaceId?: string;
+      readonly workspaceState?: string;
+    }) => {
+      try {
+        const { setActiveWorkspace } = useWorkspacesStore.getState();
+        const { setView } = useDashboardStore.getState();
+
+        if (params.workspaceId && params.workspaceState !== "archived") {
+          if (params.workspaceState === "suspended") {
+            await resumeWorkspace(params.workspaceId);
+          }
+          setActiveWorkspace(params.workspaceId);
+          setView("workspaces");
+          return;
+        }
+
+        if (!params.headRefName) return;
+
+        const response = await openWorkspace({
+          repoId: params.repoId,
+          pullRequestNumber: params.pullRequestNumber,
+          branch: params.headRefName,
+        });
+        await queryClient.invalidateQueries({ queryKey: ["workspaces"] });
+        await queryClient.invalidateQueries({ queryKey: ["github", "dashboard"] });
+        setActiveWorkspace(response.workspaceId);
+        setView("workspaces");
+      } catch (err: unknown) {
+        console.error("[MainContent] workspace action failed:", err);
+      }
+    },
+    [queryClient],
+  );
+
   switch (view) {
     case "overview":
       return <Overview />;
     case "reviews":
-      return <ReviewQueue reviews={dashboard?.reviewRequests ?? []} onOpen={openUrl} />;
+      return <ReviewQueue reviews={dashboard?.reviewRequests ?? []} onOpen={openUrl} onWorkspaceAction={handleWorkspaceAction} />;
     case "mine":
-      return <MyPRs prs={dashboard?.myPullRequests ?? []} onOpen={openUrl} />;
+      return <MyPRs prs={dashboard?.myPullRequests ?? []} onOpen={openUrl} onWorkspaceAction={handleWorkspaceAction} />;
     case "issues":
       return <Issues issues={dashboard?.assignedIssues ?? []} onOpen={openUrl} />;
     case "feed":

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,14 +3,13 @@ import {
   lazy,
   Suspense,
   useCallback,
-  useMemo,
   useState,
   type ErrorInfo,
   type ReactElement,
   type ReactNode,
 } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { authGetStatus, listRepos, markAllActivityRead, openWorkspace, resumeWorkspace } from "./lib/tauri";
+import { authGetStatus, markAllActivityRead, openWorkspace, resumeWorkspace } from "./lib/tauri";
 import { useGitHubData } from "./hooks/useGitHubData";
 import { AuthSetup } from "./components/AuthSetup/AuthSetup";
 import { StatsBar } from "./components/StatsBar";
@@ -105,12 +104,6 @@ function MainContent({ view, onBackToDashboard }: MainContentProps): ReactElemen
   const { dashboard } = useGitHubData();
   const { statusInfo } = useWorkspaceEnriched(view === "workspaces");
   const queryClient = useQueryClient();
-  const { data: repos } = useQuery({ queryKey: ["repos"], queryFn: listRepos, staleTime: 60_000 });
-
-  const workspaceRepoIds = useMemo(
-    () => new Set(repos?.filter((r) => r.localPath).map((r) => r.id) ?? []),
-    [repos],
-  );
 
   const markAllRead = useMutation({
     mutationFn: markAllActivityRead,
@@ -163,9 +156,9 @@ function MainContent({ view, onBackToDashboard }: MainContentProps): ReactElemen
     case "overview":
       return <Overview />;
     case "reviews":
-      return <ReviewQueue reviews={dashboard?.reviewRequests ?? []} onOpen={openUrl} onWorkspaceAction={handleWorkspaceAction} workspaceRepoIds={workspaceRepoIds} />;
+      return <ReviewQueue reviews={dashboard?.reviewRequests ?? []} onOpen={openUrl} onWorkspaceAction={handleWorkspaceAction} />;
     case "mine":
-      return <MyPRs prs={dashboard?.myPullRequests ?? []} onOpen={openUrl} onWorkspaceAction={handleWorkspaceAction} workspaceRepoIds={workspaceRepoIds} />;
+      return <MyPRs prs={dashboard?.myPullRequests ?? []} onOpen={openUrl} onWorkspaceAction={handleWorkspaceAction} />;
     case "issues":
       return <Issues issues={dashboard?.assignedIssues ?? []} onOpen={openUrl} />;
     case "feed":

--- a/src/components/CommandPalette/CommandPalette.test.tsx
+++ b/src/components/CommandPalette/CommandPalette.test.tsx
@@ -46,6 +46,7 @@ function makePr(overrides: Partial<PullRequestWithReview> = {}): PullRequestWith
       priority: "high",
       repoId: "repo-1",
       url: "https://github.com/org/repo/pull/42",
+      headRefName: "fix/login-bug",
       labels: [],
       createdAt: "2026-01-01T00:00:00Z",
       updatedAt: "2026-01-01T00:00:00Z",

--- a/src/components/MyPRs/MyPRs.test.tsx
+++ b/src/components/MyPRs/MyPRs.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { PullRequestWithReview } from "../../lib/types";
@@ -18,6 +18,7 @@ function makePr(
       priority: "medium",
       repoId: "repo-1",
       url: "https://github.com/org/repo/pull/1",
+      headRefName: "fix/test",
       labels: [],
       additions: 10,
       deletions: 2,
@@ -76,11 +77,13 @@ describe("MyPRs", () => {
   it("should show correct counts", () => {
     render(<MyPRs prs={allPrs} onOpen={onOpen} />);
 
-    const openTab = screen.getByRole("button", { name: /open/i });
-    const mergedTab = screen.getByRole("button", { name: /merged/i });
+    const group = screen.getByRole("group", { name: /filter by state/i });
+    const buttons = within(group).getAllByRole("button");
+    const openTab = buttons[0];
+    const mergedTab = buttons[1];
 
-    expect(openTab).toHaveTextContent("3");
-    expect(mergedTab).toHaveTextContent("2");
+    expect(openTab).toHaveTextContent("3"); // openPr1, openPr2, draftPr
+    expect(mergedTab).toHaveTextContent("2"); // mergedPr1, mergedPr2
   });
 
   it("should show empty state when no PRs match current tab", () => {

--- a/src/components/MyPRs/MyPRs.tsx
+++ b/src/components/MyPRs/MyPRs.tsx
@@ -17,6 +17,7 @@ interface MyPRsProps {
   readonly prs: readonly PullRequestWithReview[];
   readonly onOpen: (url: string) => void;
   readonly onWorkspaceAction?: (params: WorkspaceActionParams) => void;
+  readonly workspaceRepoIds?: ReadonlySet<string>;
 }
 
 type Tab = "open" | "merged";
@@ -34,6 +35,7 @@ export function MyPRs({
   prs,
   onOpen,
   onWorkspaceAction,
+  workspaceRepoIds,
 }: MyPRsProps): ReactElement {
   const [tab, setTab] = useState<Tab>("open");
 
@@ -91,6 +93,7 @@ export function MyPRs({
               data={pr}
               onOpen={onOpen}
               onWorkspaceAction={onWorkspaceAction}
+              workspaceRepoIds={workspaceRepoIds}
             />
           ))}
         </div>

--- a/src/components/MyPRs/MyPRs.tsx
+++ b/src/components/MyPRs/MyPRs.tsx
@@ -17,7 +17,6 @@ interface MyPRsProps {
   readonly prs: readonly PullRequestWithReview[];
   readonly onOpen: (url: string) => void;
   readonly onWorkspaceAction?: (params: WorkspaceActionParams) => void;
-  readonly workspaceRepoIds?: ReadonlySet<string>;
 }
 
 type Tab = "open" | "merged";
@@ -35,7 +34,6 @@ export function MyPRs({
   prs,
   onOpen,
   onWorkspaceAction,
-  workspaceRepoIds,
 }: MyPRsProps): ReactElement {
   const [tab, setTab] = useState<Tab>("open");
 
@@ -93,7 +91,6 @@ export function MyPRs({
               data={pr}
               onOpen={onOpen}
               onWorkspaceAction={onWorkspaceAction}
-              workspaceRepoIds={workspaceRepoIds}
             />
           ))}
         </div>

--- a/src/components/MyPRs/MyPRs.tsx
+++ b/src/components/MyPRs/MyPRs.tsx
@@ -5,10 +5,18 @@ import { EmptyState } from "../atoms/EmptyState";
 import { SectionHead } from "../atoms/SectionHead";
 import { MyPrCard } from "./MyPrCard";
 
+interface WorkspaceActionParams {
+  readonly repoId: string;
+  readonly pullRequestNumber: number;
+  readonly headRefName: string;
+  readonly workspaceId?: string;
+  readonly workspaceState?: string;
+}
+
 interface MyPRsProps {
   readonly prs: readonly PullRequestWithReview[];
   readonly onOpen: (url: string) => void;
-  readonly onWorkspaceAction?: (workspaceId: string) => void;
+  readonly onWorkspaceAction?: (params: WorkspaceActionParams) => void;
 }
 
 type Tab = "open" | "merged";

--- a/src/components/MyPRs/MyPrCard.test.tsx
+++ b/src/components/MyPRs/MyPrCard.test.tsx
@@ -149,7 +149,9 @@ describe("MyPrCard", () => {
   });
 
   it("should show workspace badge", () => {
-    render(<MyPrCard data={basePr} onOpen={vi.fn()} />);
+    render(
+      <MyPrCard data={basePr} onOpen={vi.fn()} onWorkspaceAction={vi.fn()} />,
+    );
     expect(screen.getByText("resume")).toBeInTheDocument();
   });
 
@@ -170,7 +172,9 @@ describe("MyPrCard", () => {
       ...basePr,
       workspace: null,
     };
-    render(<MyPrCard data={data} onOpen={vi.fn()} />);
+    render(
+      <MyPrCard data={data} onOpen={vi.fn()} onWorkspaceAction={vi.fn()} />,
+    );
     expect(screen.getByText("open")).toBeInTheDocument();
   });
 

--- a/src/components/MyPRs/MyPrCard.test.tsx
+++ b/src/components/MyPRs/MyPrCard.test.tsx
@@ -15,6 +15,7 @@ const basePr: PullRequestWithReview = {
     priority: "medium",
     repoId: "repo-1",
     url: "https://github.com/org/repo/pull/99",
+    headRefName: "fix/test",
     labels: [],
     additions: 42,
     deletions: 7,
@@ -156,11 +157,21 @@ describe("MyPrCard", () => {
     const data: PullRequestWithReview = {
       ...basePr,
       workspace: null,
+      pullRequest: { ...basePr.pullRequest, state: "merged" },
     };
     render(<MyPrCard data={data} onOpen={vi.fn()} />);
     expect(screen.queryByText("resume")).not.toBeInTheDocument();
     expect(screen.queryByText("wake")).not.toBeInTheDocument();
     expect(screen.queryByText("open")).not.toBeInTheDocument();
+  });
+
+  it("should show open badge when PR is open and no workspace", () => {
+    const data: PullRequestWithReview = {
+      ...basePr,
+      workspace: null,
+    };
+    render(<MyPrCard data={data} onOpen={vi.fn()} />);
+    expect(screen.getByText("open")).toBeInTheDocument();
   });
 
   it("should call onOpen on click", async () => {
@@ -178,7 +189,13 @@ describe("MyPrCard", () => {
       <MyPrCard data={basePr} onOpen={vi.fn()} onWorkspaceAction={handleWs} />,
     );
     await userEvent.click(screen.getByRole("button"));
-    expect(handleWs).toHaveBeenCalledWith("ws-1");
+    expect(handleWs).toHaveBeenCalledWith({
+      repoId: "repo-1",
+      pullRequestNumber: 99,
+      headRefName: "fix/test",
+      workspaceId: "ws-1",
+      workspaceState: "active",
+    });
   });
 
   it("should not show MERGEABLE when PR is closed", () => {

--- a/src/components/MyPRs/MyPrCard.tsx
+++ b/src/components/MyPRs/MyPrCard.tsx
@@ -131,11 +131,11 @@ export function MyPrCard({
         </div>
       </a>
 
-      {((workspace && workspace.state !== "archived") || ((pr.state === "open" || pr.state === "draft") && pr.headRefName)) && (
+      {onWorkspaceAction && ((workspace && workspace.state !== "archived") || ((pr.state === "open" || pr.state === "draft") && pr.headRefName)) && (
         <WsBadge
           state={workspace?.state === "archived" ? undefined : workspace?.state}
           loading={loading}
-          onClick={onWorkspaceAction ? handleWorkspace : undefined}
+          onClick={handleWorkspace}
           ariaLabel={`${workspace?.state === "active" ? "Resume" : workspace?.state === "suspended" ? "Wake" : "Open"} workspace for PR #${pr.number}`}
         />
       )}

--- a/src/components/MyPRs/MyPrCard.tsx
+++ b/src/components/MyPRs/MyPrCard.tsx
@@ -116,9 +116,9 @@ export function MyPrCard({
         </div>
       </a>
 
-      {(workspace || (pr.state === "open" || pr.state === "draft")) && (
+      {((workspace && workspace.state !== "archived") || ((pr.state === "open" || pr.state === "draft") && pr.headRefName)) && (
         <WsBadge
-          state={workspace?.state}
+          state={workspace?.state === "archived" ? undefined : workspace?.state}
           onClick={
             onWorkspaceAction
               ? () =>

--- a/src/components/MyPRs/MyPrCard.tsx
+++ b/src/components/MyPRs/MyPrCard.tsx
@@ -15,6 +15,7 @@ interface MyPrCardProps {
     readonly workspaceId?: string;
     readonly workspaceState?: string;
   }) => void;
+  readonly workspaceRepoIds?: ReadonlySet<string>;
 }
 
 function isMergeable(data: PullRequestWithReview): boolean {
@@ -52,6 +53,7 @@ export function MyPrCard({
   data,
   onOpen,
   onWorkspaceAction,
+  workspaceRepoIds,
 }: MyPrCardProps): ReactElement {
   const { pullRequest: pr, workspace } = data;
   const merged = pr.state === "merged";
@@ -116,7 +118,7 @@ export function MyPrCard({
         </div>
       </a>
 
-      {((workspace && workspace.state !== "archived") || ((pr.state === "open" || pr.state === "draft") && pr.headRefName)) && (
+      {((workspace && workspace.state !== "archived") || ((pr.state === "open" || pr.state === "draft") && pr.headRefName && (!workspaceRepoIds || workspaceRepoIds.has(pr.repoId)))) && (
         <WsBadge
           state={workspace?.state === "archived" ? undefined : workspace?.state}
           onClick={

--- a/src/components/MyPRs/MyPrCard.tsx
+++ b/src/components/MyPRs/MyPrCard.tsx
@@ -8,7 +8,13 @@ import { WsBadge } from "../atoms/WsBadge";
 interface MyPrCardProps {
   readonly data: PullRequestWithReview;
   readonly onOpen: (url: string) => void;
-  readonly onWorkspaceAction?: (workspaceId: string) => void;
+  readonly onWorkspaceAction?: (params: {
+    readonly repoId: string;
+    readonly pullRequestNumber: number;
+    readonly headRefName: string;
+    readonly workspaceId?: string;
+    readonly workspaceState?: string;
+  }) => void;
 }
 
 function isMergeable(data: PullRequestWithReview): boolean {
@@ -110,15 +116,22 @@ export function MyPrCard({
         </div>
       </a>
 
-      {workspace && (
+      {(workspace || (pr.state === "open" || pr.state === "draft")) && (
         <WsBadge
-          state={workspace.state}
+          state={workspace?.state}
           onClick={
             onWorkspaceAction
-              ? () => onWorkspaceAction(workspace.id)
+              ? () =>
+                  onWorkspaceAction({
+                    repoId: pr.repoId,
+                    pullRequestNumber: pr.number,
+                    headRefName: pr.headRefName,
+                    workspaceId: workspace?.id,
+                    workspaceState: workspace?.state,
+                  })
               : undefined
           }
-          ariaLabel={`${workspace.state === "active" ? "Resume" : workspace.state === "suspended" ? "Wake" : "Open"} workspace for PR #${pr.number}`}
+          ariaLabel={`${workspace?.state === "active" ? "Resume" : workspace?.state === "suspended" ? "Wake" : "Open"} workspace for PR #${pr.number}`}
         />
       )}
     </div>

--- a/src/components/MyPRs/MyPrCard.tsx
+++ b/src/components/MyPRs/MyPrCard.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement } from "react";
+import { type ReactElement, useState } from "react";
 import { timeAgo } from "../../lib/timeAgo";
 import type { CiStatus, PullRequestWithReview } from "../../lib/types";
 import { CI } from "../atoms/CI";
@@ -15,7 +15,6 @@ interface MyPrCardProps {
     readonly workspaceId?: string;
     readonly workspaceState?: string;
   }) => void;
-  readonly workspaceRepoIds?: ReadonlySet<string>;
 }
 
 function isMergeable(data: PullRequestWithReview): boolean {
@@ -53,10 +52,24 @@ export function MyPrCard({
   data,
   onOpen,
   onWorkspaceAction,
-  workspaceRepoIds,
 }: MyPrCardProps): ReactElement {
   const { pullRequest: pr, workspace } = data;
   const merged = pr.state === "merged";
+  const [loading, setLoading] = useState(false);
+
+  function handleWorkspace() {
+    if (!onWorkspaceAction || loading) return;
+    setLoading(true);
+    Promise.resolve(
+      onWorkspaceAction({
+        repoId: pr.repoId,
+        pullRequestNumber: pr.number,
+        headRefName: pr.headRefName,
+        workspaceId: workspace?.id,
+        workspaceState: workspace?.state,
+      }),
+    ).finally(() => setLoading(false));
+  }
   const reviewDots = buildReviewDots(data.reviewSummary);
 
   function handleClick(e: React.MouseEvent) {
@@ -118,21 +131,11 @@ export function MyPrCard({
         </div>
       </a>
 
-      {((workspace && workspace.state !== "archived") || ((pr.state === "open" || pr.state === "draft") && pr.headRefName && (!workspaceRepoIds || workspaceRepoIds.has(pr.repoId)))) && (
+      {((workspace && workspace.state !== "archived") || ((pr.state === "open" || pr.state === "draft") && pr.headRefName)) && (
         <WsBadge
           state={workspace?.state === "archived" ? undefined : workspace?.state}
-          onClick={
-            onWorkspaceAction
-              ? () =>
-                  onWorkspaceAction({
-                    repoId: pr.repoId,
-                    pullRequestNumber: pr.number,
-                    headRefName: pr.headRefName,
-                    workspaceId: workspace?.id,
-                    workspaceState: workspace?.state,
-                  })
-              : undefined
-          }
+          loading={loading}
+          onClick={onWorkspaceAction ? handleWorkspace : undefined}
           ariaLabel={`${workspace?.state === "active" ? "Resume" : workspace?.state === "suspended" ? "Wake" : "Open"} workspace for PR #${pr.number}`}
         />
       )}

--- a/src/components/Overview/Overview.test.tsx
+++ b/src/components/Overview/Overview.test.tsx
@@ -46,6 +46,7 @@ function makePr(n: number): PullRequestWithReview {
       priority: "medium",
       repoId: "repo-1",
       url: `https://github.com/org/repo/pull/${n}`,
+      headRefName: "fix/test",
       labels: [],
       additions: 10,
       deletions: 5,

--- a/src/components/Overview/Overview.tsx
+++ b/src/components/Overview/Overview.tsx
@@ -49,6 +49,8 @@ export function Overview(): ReactElement {
           // Existing workspace — resume if suspended, then navigate
           if (params.workspaceState === "suspended") {
             await resumeWorkspace(params.workspaceId);
+            await queryClient.invalidateQueries({ queryKey: ["workspaces"] });
+            await queryClient.invalidateQueries({ queryKey: ["github", "dashboard"] });
           }
           setActiveWorkspace(params.workspaceId);
           setView("workspaces");

--- a/src/components/Overview/Overview.tsx
+++ b/src/components/Overview/Overview.tsx
@@ -1,7 +1,7 @@
-import { type ReactElement, useCallback, useMemo } from "react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { type ReactElement, useCallback } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useGitHubData } from "../../hooks/useGitHubData";
-import { listRepos, markAllActivityRead, openWorkspace, resumeWorkspace } from "../../lib/tauri";
+import { markAllActivityRead, openWorkspace, resumeWorkspace } from "../../lib/tauri";
 import { useWorkspacesStore } from "../../stores/workspaces";
 import { useDashboardStore } from "../../stores/dashboard";
 import { ReviewQueue } from "../ReviewQueue";
@@ -21,11 +21,6 @@ function openUrl(url: string): void {
 export function Overview(): ReactElement {
   const { dashboard, error } = useGitHubData();
   const queryClient = useQueryClient();
-  const { data: repos } = useQuery({ queryKey: ["repos"], queryFn: listRepos, staleTime: 60_000 });
-  const workspaceRepoIds = useMemo(
-    () => new Set(repos?.filter((r) => r.localPath).map((r) => r.id) ?? []),
-    [repos],
-  );
 
   const markAllRead = useMutation({
     mutationFn: markAllActivityRead,
@@ -107,8 +102,8 @@ export function Overview(): ReactElement {
   return (
     <div data-testid="overview" className="flex h-full gap-6 overflow-y-auto p-4">
       <div className="flex min-w-0 flex-1 flex-col gap-6">
-        <ReviewQueue reviews={reviews} onOpen={openUrl} onWorkspaceAction={handleWorkspaceAction} workspaceRepoIds={workspaceRepoIds} />
-        <MyPRs prs={prs} onOpen={openUrl} onWorkspaceAction={handleWorkspaceAction} workspaceRepoIds={workspaceRepoIds} />
+        <ReviewQueue reviews={reviews} onOpen={openUrl} onWorkspaceAction={handleWorkspaceAction} />
+        <MyPRs prs={prs} onOpen={openUrl} onWorkspaceAction={handleWorkspaceAction} />
       </div>
 
       <div className="flex w-[300px] min-w-0 flex-col gap-6">

--- a/src/components/Overview/Overview.tsx
+++ b/src/components/Overview/Overview.tsx
@@ -1,7 +1,7 @@
-import { type ReactElement, useCallback } from "react";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { type ReactElement, useCallback, useMemo } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useGitHubData } from "../../hooks/useGitHubData";
-import { markAllActivityRead, openWorkspace, resumeWorkspace } from "../../lib/tauri";
+import { listRepos, markAllActivityRead, openWorkspace, resumeWorkspace } from "../../lib/tauri";
 import { useWorkspacesStore } from "../../stores/workspaces";
 import { useDashboardStore } from "../../stores/dashboard";
 import { ReviewQueue } from "../ReviewQueue";
@@ -21,6 +21,11 @@ function openUrl(url: string): void {
 export function Overview(): ReactElement {
   const { dashboard, error } = useGitHubData();
   const queryClient = useQueryClient();
+  const { data: repos } = useQuery({ queryKey: ["repos"], queryFn: listRepos, staleTime: 60_000 });
+  const workspaceRepoIds = useMemo(
+    () => new Set(repos?.filter((r) => r.localPath).map((r) => r.id) ?? []),
+    [repos],
+  );
 
   const markAllRead = useMutation({
     mutationFn: markAllActivityRead,
@@ -102,8 +107,8 @@ export function Overview(): ReactElement {
   return (
     <div data-testid="overview" className="flex h-full gap-6 overflow-y-auto p-4">
       <div className="flex min-w-0 flex-1 flex-col gap-6">
-        <ReviewQueue reviews={reviews} onOpen={openUrl} onWorkspaceAction={handleWorkspaceAction} />
-        <MyPRs prs={prs} onOpen={openUrl} onWorkspaceAction={handleWorkspaceAction} />
+        <ReviewQueue reviews={reviews} onOpen={openUrl} onWorkspaceAction={handleWorkspaceAction} workspaceRepoIds={workspaceRepoIds} />
+        <MyPRs prs={prs} onOpen={openUrl} onWorkspaceAction={handleWorkspaceAction} workspaceRepoIds={workspaceRepoIds} />
       </div>
 
       <div className="flex w-[300px] min-w-0 flex-col gap-6">

--- a/src/components/Overview/Overview.tsx
+++ b/src/components/Overview/Overview.tsx
@@ -41,29 +41,35 @@ export function Overview(): ReactElement {
       readonly workspaceId?: string;
       readonly workspaceState?: string;
     }) => {
-      const { setActiveWorkspace } = useWorkspacesStore.getState();
-      const { setView } = useDashboardStore.getState();
+      try {
+        const { setActiveWorkspace } = useWorkspacesStore.getState();
+        const { setView } = useDashboardStore.getState();
 
-      if (params.workspaceId) {
-        // Existing workspace — resume if suspended, then navigate
-        if (params.workspaceState === "suspended") {
-          await resumeWorkspace(params.workspaceId);
+        if (params.workspaceId && params.workspaceState !== "archived") {
+          // Existing workspace — resume if suspended, then navigate
+          if (params.workspaceState === "suspended") {
+            await resumeWorkspace(params.workspaceId);
+          }
+          setActiveWorkspace(params.workspaceId);
+          setView("workspaces");
+          return;
         }
-        setActiveWorkspace(params.workspaceId);
-        setView("workspaces");
-        return;
-      }
 
-      // No workspace yet — create one
-      const response = await openWorkspace({
-        repoId: params.repoId,
-        pullRequestNumber: params.pullRequestNumber,
-        branch: params.headRefName,
-      });
-      await queryClient.invalidateQueries({ queryKey: ["workspaces"] });
-      await queryClient.invalidateQueries({ queryKey: ["github", "dashboard"] });
-      setActiveWorkspace(response.workspaceId);
-      setView("workspaces");
+        // No workspace or archived — create a new one
+        const response = await openWorkspace({
+          repoId: params.repoId,
+          pullRequestNumber: params.pullRequestNumber,
+          branch: params.headRefName,
+        });
+        await queryClient.invalidateQueries({ queryKey: ["workspaces"] });
+        await queryClient.invalidateQueries({
+          queryKey: ["github", "dashboard"],
+        });
+        setActiveWorkspace(response.workspaceId);
+        setView("workspaces");
+      } catch (err: unknown) {
+        console.error("[Overview] workspace action failed:", err);
+      }
     },
     [queryClient],
   );

--- a/src/components/Overview/Overview.tsx
+++ b/src/components/Overview/Overview.tsx
@@ -1,7 +1,9 @@
-import type { ReactElement } from "react";
+import { type ReactElement, useCallback } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useGitHubData } from "../../hooks/useGitHubData";
-import { markAllActivityRead } from "../../lib/tauri";
+import { markAllActivityRead, openWorkspace, resumeWorkspace } from "../../lib/tauri";
+import { useWorkspacesStore } from "../../stores/workspaces";
+import { useDashboardStore } from "../../stores/dashboard";
 import { ReviewQueue } from "../ReviewQueue";
 import { MyPRs } from "../MyPRs";
 import { Issues } from "../Issues";
@@ -31,6 +33,41 @@ export function Overview(): ReactElement {
     },
   });
 
+  const handleWorkspaceAction = useCallback(
+    async (params: {
+      readonly repoId: string;
+      readonly pullRequestNumber: number;
+      readonly headRefName: string;
+      readonly workspaceId?: string;
+      readonly workspaceState?: string;
+    }) => {
+      const { setActiveWorkspace } = useWorkspacesStore.getState();
+      const { setView } = useDashboardStore.getState();
+
+      if (params.workspaceId) {
+        // Existing workspace — resume if suspended, then navigate
+        if (params.workspaceState === "suspended") {
+          await resumeWorkspace(params.workspaceId);
+        }
+        setActiveWorkspace(params.workspaceId);
+        setView("workspaces");
+        return;
+      }
+
+      // No workspace yet — create one
+      const response = await openWorkspace({
+        repoId: params.repoId,
+        pullRequestNumber: params.pullRequestNumber,
+        branch: params.headRefName,
+      });
+      await queryClient.invalidateQueries({ queryKey: ["workspaces"] });
+      await queryClient.invalidateQueries({ queryKey: ["github", "dashboard"] });
+      setActiveWorkspace(response.workspaceId);
+      setView("workspaces");
+    },
+    [queryClient],
+  );
+
   if (!dashboard && error) {
     return (
       <div className="flex h-full items-center justify-center text-dim">
@@ -55,8 +92,8 @@ export function Overview(): ReactElement {
   return (
     <div data-testid="overview" className="flex h-full gap-6 overflow-y-auto p-4">
       <div className="flex min-w-0 flex-1 flex-col gap-6">
-        <ReviewQueue reviews={reviews} onOpen={openUrl} />
-        <MyPRs prs={prs} onOpen={openUrl} />
+        <ReviewQueue reviews={reviews} onOpen={openUrl} onWorkspaceAction={handleWorkspaceAction} />
+        <MyPRs prs={prs} onOpen={openUrl} onWorkspaceAction={handleWorkspaceAction} />
       </div>
 
       <div className="flex w-[300px] min-w-0 flex-col gap-6">

--- a/src/components/Overview/Overview.tsx
+++ b/src/components/Overview/Overview.tsx
@@ -56,6 +56,10 @@ export function Overview(): ReactElement {
         }
 
         // No workspace or archived — create a new one
+        if (!params.headRefName) {
+          console.warn("[Overview] cannot open workspace: branch name unknown (force sync first)");
+          return;
+        }
         const response = await openWorkspace({
           repoId: params.repoId,
           pullRequestNumber: params.pullRequestNumber,

--- a/src/components/ReviewQueue/ReviewCard.test.tsx
+++ b/src/components/ReviewQueue/ReviewCard.test.tsx
@@ -15,6 +15,7 @@ const mockData: PullRequestWithReview = {
     priority: "high",
     repoId: "repo-1",
     url: "https://github.com/org/repo/pull/42",
+    headRefName: "fix/test",
     labels: ["bug"],
     additions: 10,
     deletions: 5,
@@ -100,7 +101,13 @@ describe("ReviewCard", () => {
       />,
     );
     await userEvent.click(screen.getByRole("button"));
-    expect(handleWs).toHaveBeenCalledWith("ws-1");
+    expect(handleWs).toHaveBeenCalledWith({
+      repoId: "repo-1",
+      pullRequestNumber: 42,
+      headRefName: "fix/test",
+      workspaceId: "ws-1",
+      workspaceState: "active",
+    });
   });
 
   it("should have aria-label on link describing the PR", () => {

--- a/src/components/ReviewQueue/ReviewCard.test.tsx
+++ b/src/components/ReviewQueue/ReviewCard.test.tsx
@@ -60,7 +60,13 @@ describe("ReviewCard", () => {
   });
 
   it("should show workspace badge", () => {
-    render(<ReviewCard data={mockData} onOpen={vi.fn()} />);
+    render(
+      <ReviewCard
+        data={mockData}
+        onOpen={vi.fn()}
+        onWorkspaceAction={vi.fn()}
+      />,
+    );
     expect(screen.getByText("resume")).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Resume workspace for PR #42" }),

--- a/src/components/ReviewQueue/ReviewCard.tsx
+++ b/src/components/ReviewQueue/ReviewCard.tsx
@@ -9,7 +9,13 @@ import { WsBadge } from "../atoms/WsBadge";
 interface ReviewCardProps {
   readonly data: PullRequestWithReview;
   readonly onOpen: (url: string) => void;
-  readonly onWorkspaceAction?: (workspaceId: string) => void;
+  readonly onWorkspaceAction?: (params: {
+    readonly repoId: string;
+    readonly pullRequestNumber: number;
+    readonly headRefName: string;
+    readonly workspaceId?: string;
+    readonly workspaceState?: string;
+  }) => void;
 }
 
 export function ReviewCard({
@@ -53,15 +59,22 @@ export function ReviewCard({
         </div>
       </a>
 
-      {workspace && (
+      {(workspace || pr.state === "open") && (
         <WsBadge
-          state={workspace.state}
+          state={workspace?.state}
           onClick={
             onWorkspaceAction
-              ? () => onWorkspaceAction(workspace.id)
+              ? () =>
+                  onWorkspaceAction({
+                    repoId: pr.repoId,
+                    pullRequestNumber: pr.number,
+                    headRefName: pr.headRefName,
+                    workspaceId: workspace?.id,
+                    workspaceState: workspace?.state,
+                  })
               : undefined
           }
-          ariaLabel={`${workspace.state === "active" ? "Resume" : workspace.state === "suspended" ? "Wake" : "Open"} workspace for PR #${pr.number}`}
+          ariaLabel={`${workspace?.state === "active" ? "Resume" : workspace?.state === "suspended" ? "Wake" : "Open"} workspace for PR #${pr.number}`}
         />
       )}
     </div>

--- a/src/components/ReviewQueue/ReviewCard.tsx
+++ b/src/components/ReviewQueue/ReviewCard.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement } from "react";
+import { type ReactElement, useState } from "react";
 import { timeAgo } from "../../lib/timeAgo";
 import type { PullRequestWithReview } from "../../lib/types";
 import { CI } from "../atoms/CI";
@@ -16,20 +16,33 @@ interface ReviewCardProps {
     readonly workspaceId?: string;
     readonly workspaceState?: string;
   }) => void;
-  readonly workspaceRepoIds?: ReadonlySet<string>;
 }
 
 export function ReviewCard({
   data,
   onOpen,
   onWorkspaceAction,
-  workspaceRepoIds,
 }: ReviewCardProps): ReactElement {
   const { pullRequest: pr, workspace } = data;
+  const [loading, setLoading] = useState(false);
 
   function handleClick(e: React.MouseEvent) {
     e.preventDefault();
     onOpen(pr.url);
+  }
+
+  function handleWorkspace() {
+    if (!onWorkspaceAction || loading) return;
+    setLoading(true);
+    Promise.resolve(
+      onWorkspaceAction({
+        repoId: pr.repoId,
+        pullRequestNumber: pr.number,
+        headRefName: pr.headRefName,
+        workspaceId: workspace?.id,
+        workspaceState: workspace?.state,
+      }),
+    ).finally(() => setLoading(false));
   }
 
   return (
@@ -61,21 +74,11 @@ export function ReviewCard({
         </div>
       </a>
 
-      {((workspace && workspace.state !== "archived") || (pr.state === "open" && pr.headRefName && (!workspaceRepoIds || workspaceRepoIds.has(pr.repoId)))) && (
+      {((workspace && workspace.state !== "archived") || (pr.state === "open" && pr.headRefName)) && (
         <WsBadge
           state={workspace?.state === "archived" ? undefined : workspace?.state}
-          onClick={
-            onWorkspaceAction
-              ? () =>
-                  onWorkspaceAction({
-                    repoId: pr.repoId,
-                    pullRequestNumber: pr.number,
-                    headRefName: pr.headRefName,
-                    workspaceId: workspace?.id,
-                    workspaceState: workspace?.state,
-                  })
-              : undefined
-          }
+          loading={loading}
+          onClick={onWorkspaceAction ? handleWorkspace : undefined}
           ariaLabel={`${workspace?.state === "active" ? "Resume" : workspace?.state === "suspended" ? "Wake" : "Open"} workspace for PR #${pr.number}`}
         />
       )}

--- a/src/components/ReviewQueue/ReviewCard.tsx
+++ b/src/components/ReviewQueue/ReviewCard.tsx
@@ -74,11 +74,11 @@ export function ReviewCard({
         </div>
       </a>
 
-      {((workspace && workspace.state !== "archived") || (pr.state === "open" && pr.headRefName)) && (
+      {onWorkspaceAction && ((workspace && workspace.state !== "archived") || (pr.state === "open" && pr.headRefName)) && (
         <WsBadge
           state={workspace?.state === "archived" ? undefined : workspace?.state}
           loading={loading}
-          onClick={onWorkspaceAction ? handleWorkspace : undefined}
+          onClick={handleWorkspace}
           ariaLabel={`${workspace?.state === "active" ? "Resume" : workspace?.state === "suspended" ? "Wake" : "Open"} workspace for PR #${pr.number}`}
         />
       )}

--- a/src/components/ReviewQueue/ReviewCard.tsx
+++ b/src/components/ReviewQueue/ReviewCard.tsx
@@ -59,9 +59,9 @@ export function ReviewCard({
         </div>
       </a>
 
-      {(workspace || pr.state === "open") && (
+      {((workspace && workspace.state !== "archived") || (pr.state === "open" && pr.headRefName)) && (
         <WsBadge
-          state={workspace?.state}
+          state={workspace?.state === "archived" ? undefined : workspace?.state}
           onClick={
             onWorkspaceAction
               ? () =>

--- a/src/components/ReviewQueue/ReviewCard.tsx
+++ b/src/components/ReviewQueue/ReviewCard.tsx
@@ -16,12 +16,14 @@ interface ReviewCardProps {
     readonly workspaceId?: string;
     readonly workspaceState?: string;
   }) => void;
+  readonly workspaceRepoIds?: ReadonlySet<string>;
 }
 
 export function ReviewCard({
   data,
   onOpen,
   onWorkspaceAction,
+  workspaceRepoIds,
 }: ReviewCardProps): ReactElement {
   const { pullRequest: pr, workspace } = data;
 
@@ -59,7 +61,7 @@ export function ReviewCard({
         </div>
       </a>
 
-      {((workspace && workspace.state !== "archived") || (pr.state === "open" && pr.headRefName)) && (
+      {((workspace && workspace.state !== "archived") || (pr.state === "open" && pr.headRefName && (!workspaceRepoIds || workspaceRepoIds.has(pr.repoId)))) && (
         <WsBadge
           state={workspace?.state === "archived" ? undefined : workspace?.state}
           onClick={

--- a/src/components/ReviewQueue/ReviewQueue.test.tsx
+++ b/src/components/ReviewQueue/ReviewQueue.test.tsx
@@ -19,6 +19,7 @@ function makePr(
       priority: "medium",
       repoId: "repo-1",
       url: "https://github.com/org/repo/pull/1",
+      headRefName: "fix/test",
       labels: [],
       additions: 10,
       deletions: 5,
@@ -285,6 +286,12 @@ describe("ReviewQueue", () => {
     );
 
     await userEvent.click(screen.getByRole("button", { name: /workspace/i }));
-    expect(handleWs).toHaveBeenCalledWith("ws-42");
+    expect(handleWs).toHaveBeenCalledWith({
+      repoId: "repo-1",
+      pullRequestNumber: 99,
+      headRefName: "fix/test",
+      workspaceId: "ws-42",
+      workspaceState: "active",
+    });
   });
 });

--- a/src/components/ReviewQueue/ReviewQueue.tsx
+++ b/src/components/ReviewQueue/ReviewQueue.tsx
@@ -18,7 +18,6 @@ interface ReviewQueueProps {
   readonly reviews: readonly PullRequestWithReview[];
   readonly onOpen: (url: string) => void;
   readonly onWorkspaceAction?: (params: WorkspaceActionParams) => void;
-  readonly workspaceRepoIds?: ReadonlySet<string>;
 }
 
 const PRIORITY_ORDER: Record<Priority, number> = {
@@ -61,7 +60,6 @@ export function ReviewQueue({
   reviews,
   onOpen,
   onWorkspaceAction,
-  workspaceRepoIds,
 }: ReviewQueueProps): ReactElement {
   const storePriority = useDashboardStore((s) => s.activeFilters.priority);
   const storeRepo = useDashboardStore((s) => s.activeFilters.repo);
@@ -157,7 +155,6 @@ export function ReviewQueue({
               data={review}
               onOpen={onOpen}
               onWorkspaceAction={onWorkspaceAction}
-              workspaceRepoIds={workspaceRepoIds}
             />
           ))}
         </div>

--- a/src/components/ReviewQueue/ReviewQueue.tsx
+++ b/src/components/ReviewQueue/ReviewQueue.tsx
@@ -18,6 +18,7 @@ interface ReviewQueueProps {
   readonly reviews: readonly PullRequestWithReview[];
   readonly onOpen: (url: string) => void;
   readonly onWorkspaceAction?: (params: WorkspaceActionParams) => void;
+  readonly workspaceRepoIds?: ReadonlySet<string>;
 }
 
 const PRIORITY_ORDER: Record<Priority, number> = {
@@ -60,6 +61,7 @@ export function ReviewQueue({
   reviews,
   onOpen,
   onWorkspaceAction,
+  workspaceRepoIds,
 }: ReviewQueueProps): ReactElement {
   const storePriority = useDashboardStore((s) => s.activeFilters.priority);
   const storeRepo = useDashboardStore((s) => s.activeFilters.repo);
@@ -155,6 +157,7 @@ export function ReviewQueue({
               data={review}
               onOpen={onOpen}
               onWorkspaceAction={onWorkspaceAction}
+              workspaceRepoIds={workspaceRepoIds}
             />
           ))}
         </div>

--- a/src/components/ReviewQueue/ReviewQueue.tsx
+++ b/src/components/ReviewQueue/ReviewQueue.tsx
@@ -6,10 +6,18 @@ import { EmptyState } from "../atoms/EmptyState";
 import { SectionHead } from "../atoms/SectionHead";
 import { ReviewCard } from "./ReviewCard";
 
+interface WorkspaceActionParams {
+  readonly repoId: string;
+  readonly pullRequestNumber: number;
+  readonly headRefName: string;
+  readonly workspaceId?: string;
+  readonly workspaceState?: string;
+}
+
 interface ReviewQueueProps {
   readonly reviews: readonly PullRequestWithReview[];
   readonly onOpen: (url: string) => void;
-  readonly onWorkspaceAction?: (workspaceId: string) => void;
+  readonly onWorkspaceAction?: (params: WorkspaceActionParams) => void;
 }
 
 const PRIORITY_ORDER: Record<Priority, number> = {

--- a/src/components/Workspace/WorkspaceSwitcher.test.tsx
+++ b/src/components/Workspace/WorkspaceSwitcher.test.tsx
@@ -57,6 +57,7 @@ function resetStores() {
     config: {
       pollIntervalSecs: 300,
       maxActiveWorkspaces: 3,
+      autoSuspendMinutes: 30,
       githubToken: null,
       dataDir: null,
       workspacesDir: null,
@@ -147,6 +148,7 @@ describe("WorkspaceSwitcher", () => {
       config: {
         pollIntervalSecs: 300,
         maxActiveWorkspaces: 5,
+        autoSuspendMinutes: 30,
         githubToken: null,
         dataDir: null,
         workspacesDir: null,
@@ -200,6 +202,7 @@ describe("WorkspaceSwitcher", () => {
       config: {
         pollIntervalSecs: 300,
         maxActiveWorkspaces: 0,
+        autoSuspendMinutes: 30,
         githubToken: null,
         dataDir: null,
         workspacesDir: null,

--- a/src/components/atoms/WsBadge.tsx
+++ b/src/components/atoms/WsBadge.tsx
@@ -3,6 +3,7 @@ import type { WorkspaceState } from "../../lib/types";
 
 interface WsBadgeProps {
   readonly state?: WorkspaceState;
+  readonly loading?: boolean;
   readonly onClick?: () => void;
   readonly ariaLabel?: string;
 }
@@ -12,19 +13,20 @@ const LABEL_MAP: Record<Exclude<WorkspaceState, "archived">, string> = {
   suspended: "wake",
 };
 
-export function WsBadge({ state, onClick, ariaLabel }: WsBadgeProps): ReactElement | null {
+export function WsBadge({ state, loading, onClick, ariaLabel }: WsBadgeProps): ReactElement | null {
   if (state === "archived") {
     return null;
   }
 
-  const label = state ? LABEL_MAP[state as Exclude<WorkspaceState, "archived">] : "open";
+  const label = loading ? "cloning…" : state ? LABEL_MAP[state as Exclude<WorkspaceState, "archived">] : "open";
 
   return (
     <button
       type="button"
-      onClick={onClick}
+      onClick={loading ? undefined : onClick}
+      disabled={loading}
       aria-label={ariaLabel}
-      className="rounded border border-accent/30 px-2 py-0.5 text-xs text-accent hover:bg-accent/10"
+      className={`rounded border border-accent/30 px-2 py-0.5 text-xs text-accent ${loading ? "animate-pulse opacity-60" : "hover:bg-accent/10"}`}
     >
       {label}
     </button>

--- a/src/hooks/useWorkspace.ts
+++ b/src/hooks/useWorkspace.ts
@@ -75,7 +75,7 @@ export function useWorkspace(): UseWorkspaceResult {
         if (!cancelled && payload.workspaceId === activeIdRef.current) {
           if (payload.newState === "suspended") {
             setSuspendedActiveWorkspace(payload.workspaceId);
-          } else if (payload.newState !== "suspended") {
+          } else {
             setSuspendedActiveWorkspace(null);
           }
         }

--- a/src/lib/tauri.test.ts
+++ b/src/lib/tauri.test.ts
@@ -100,9 +100,9 @@ describe("Workspace wrappers", () => {
   it("should invoke workspace_open with request payload", async () => {
     const { openWorkspace } = await import("./tauri");
     mockInvoke.mockResolvedValue({});
-    await openWorkspace({ repoId: "r-1", pullRequestNumber: 42 });
+    await openWorkspace({ repoId: "r-1", pullRequestNumber: 42, branch: "fix/test" });
     expect(mockInvoke).toHaveBeenCalledWith(TAURI_COMMANDS.workspace_open, {
-      request: { repoId: "r-1", pullRequestNumber: 42 },
+      req: { repoId: "r-1", pullRequestNumber: 42, branch: "fix/test" },
     });
   });
 

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -68,8 +68,8 @@ export async function setRepoLocalPath(repoId: string, path: string | null): Pro
 
 // ── Workspaces ───────────────────────────────────────────────────
 
-export async function openWorkspace(request: OpenWorkspaceRequest): Promise<OpenWorkspaceResponse> {
-  return invoke<OpenWorkspaceResponse>(TAURI_COMMANDS.workspace_open, { request });
+export async function openWorkspace(req: OpenWorkspaceRequest): Promise<OpenWorkspaceResponse> {
+  return invoke<OpenWorkspaceResponse>(TAURI_COMMANDS.workspace_open, { req });
 }
 
 export async function suspendWorkspace(workspaceId: string): Promise<void> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -52,6 +52,7 @@ export interface PullRequest {
   readonly deletions?: number;
   readonly changedFiles?: number;
   readonly commentsCount?: number;
+  readonly headRefName: string;
   readonly createdAt: string;
   readonly updatedAt: string;
 }
@@ -192,6 +193,7 @@ export interface PersonalStats {
 export interface OpenWorkspaceRequest {
   readonly repoId: string;
   readonly pullRequestNumber: number;
+  readonly branch: string;
 }
 
 export interface OpenWorkspaceResponse {


### PR DESCRIPTION
## Summary

Full workspace creation flow from PR cards — click "open" on any PR to get a terminal workspace.

**Backend:**
- Add `head_ref_name` column to `pull_requests` (migration 003)
- Auto-clone repos via `git clone` when no `local_path` exists
- Delete archived workspaces before re-creating (UNIQUE constraint fix)
- Fix `openWorkspace` IPC parameter name mismatch (`request` → `req`)

**Frontend:**
- Show "open" badge on all open PRs with known branch names
- Wire `onWorkspaceAction` in Overview, MyPRs, and ReviewQueue views
- Loading state ("cloning…" with pulse animation) during workspace creation
- Handle archived workspaces: show "open" badge to re-create
- Error handling with try/catch on async workspace actions

Closes #103

## Test plan

- [x] `cargo check` compiles
- [x] `cargo test` — 334/335 pass (1 pre-existing unrelated failure)
- [x] `tsc --noEmit` — 0 errors
- [x] tauri-pilot: click "open" on PR from repo WITH local_path → workspace created, terminal opens
- [x] tauri-pilot: click "open" on PR from repo WITHOUT local_path → auto-clones repo, then workspace created
- [x] tauri-pilot: click "resume" on existing workspace → navigates to terminal
- [x] tauri-pilot: "cloning…" loading state shown during clone
- [x] tauri-pilot: archived workspace shows "open" badge for re-creation