### PR TITLE
feat(workspace): assemble workspace page (T-075, T-076)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -102,7 +102,7 @@ interface MainContentProps {
 
 function MainContent({ view, onBackToDashboard }: MainContentProps): ReactElement {
   const { dashboard } = useGitHubData();
-  const { statusInfo } = useWorkspaceEnriched(view === "workspaces");
+  const { statusInfo, entries } = useWorkspaceEnriched(view === "workspaces");
   const queryClient = useQueryClient();
 
   const markAllRead = useMutation({
@@ -175,6 +175,7 @@ function MainContent({ view, onBackToDashboard }: MainContentProps): ReactElemen
         <WorkspaceView
           workspaces={dashboard?.workspaces ?? []}
           statusInfo={statusInfo}
+          entries={entries}
           onBackToDashboard={onBackToDashboard}
         />
       );

--- a/src/components/Workspace/WorkspaceView.test.tsx
+++ b/src/components/Workspace/WorkspaceView.test.tsx
@@ -294,6 +294,7 @@ describe("WorkspaceView", () => {
     useWorkspacesStore.setState({ setActiveWorkspace } as Partial<ReturnType<typeof useWorkspacesStore.getState>>);
 
     vi.mocked(resumeWorkspace).mockImplementation(async () => {
+      await Promise.resolve();
       callOrder.push("resume");
     });
 

--- a/src/components/Workspace/WorkspaceView.test.tsx
+++ b/src/components/Workspace/WorkspaceView.test.tsx
@@ -265,7 +265,7 @@ describe("WorkspaceView", () => {
     useWorkspacesStore.setState({ activeWorkspaceId: null });
 
     const setActiveWorkspace = vi.fn();
-    useWorkspacesStore.setState({ setActiveWorkspace } as Partial<typeof useWorkspacesStore.getState>);
+    useWorkspacesStore.setState({ setActiveWorkspace } as Partial<ReturnType<typeof useWorkspacesStore.getState>>);
 
     const activeEntry = makeEntry({ workspaceOverrides: { id: "ws-click", state: "active", pullRequestNumber: 5 } });
 
@@ -289,10 +289,13 @@ describe("WorkspaceView", () => {
   it("should call resumeWorkspace then set active when clicking a suspended workspace", async () => {
     useWorkspacesStore.setState({ activeWorkspaceId: null });
 
-    const setActiveWorkspace = vi.fn();
-    useWorkspacesStore.setState({ setActiveWorkspace } as Partial<typeof useWorkspacesStore.getState>);
+    const callOrder: string[] = [];
+    const setActiveWorkspace = vi.fn(() => callOrder.push("setActive"));
+    useWorkspacesStore.setState({ setActiveWorkspace } as Partial<ReturnType<typeof useWorkspacesStore.getState>>);
 
-    vi.mocked(resumeWorkspace).mockResolvedValue(undefined);
+    vi.mocked(resumeWorkspace).mockImplementation(async () => {
+      callOrder.push("resume");
+    });
 
     const suspendedEntry = makeEntry({ workspaceOverrides: { id: "ws-suspended", state: "suspended", pullRequestNumber: 7 } });
 
@@ -310,6 +313,7 @@ describe("WorkspaceView", () => {
     await waitFor(() => {
       expect(resumeWorkspace).toHaveBeenCalledWith("ws-suspended");
       expect(setActiveWorkspace).toHaveBeenCalledWith("ws-suspended");
+      expect(callOrder).toEqual(["resume", "setActive"]);
     });
   });
 });

--- a/src/components/Workspace/WorkspaceView.test.tsx
+++ b/src/components/Workspace/WorkspaceView.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, act } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useWorkspacesStore } from "../../stores/workspaces";
-import type { Workspace, WorkspaceStatusInfo } from "../../lib/types";
+import type { Workspace, WorkspaceListEntry, WorkspaceState, WorkspaceStatusInfo } from "../../lib/types";
 
 // ── Mock child components ────────────────────────────────────────
 
@@ -30,7 +31,78 @@ vi.mock("./WorkspaceStatusBar", () => ({
   ),
 }));
 
+vi.mock("./WorkspaceListPage", () => ({
+  WorkspaceListPage: ({
+    entries,
+    onWorkspaceClick,
+  }: {
+    entries: readonly WorkspaceListEntry[];
+    onWorkspaceClick: (id: string) => void;
+  }) => (
+    <div data-testid="workspace-list">
+      {entries.map((e) => (
+        <button
+          key={e.workspace.id}
+          data-testid={`workspace-item-${e.workspace.id}`}
+          onClick={() => onWorkspaceClick(e.workspace.id)}
+        >
+          PR #{e.workspace.pullRequestNumber}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock("../../lib/tauri", () => ({
+  resumeWorkspace: vi.fn(),
+}));
+
 import { WorkspaceView } from "./WorkspaceView";
+import { resumeWorkspace } from "../../lib/tauri";
+
+// ── Test helpers ─────────────────────────────────────────────────
+
+function makeQueryClient(): QueryClient {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+function renderWithQuery(ui: React.ReactElement): ReturnType<typeof render> {
+  const queryClient = makeQueryClient();
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  );
+}
+
+function makeEntry(
+  overrides: Partial<Omit<WorkspaceListEntry, "workspace">> & {
+    workspaceOverrides?: Partial<Workspace> & { state?: WorkspaceState };
+  } = {},
+): WorkspaceListEntry {
+  const { workspaceOverrides, ...rest } = overrides;
+  const { state = "active", ...wsRest } = workspaceOverrides ?? {};
+  return {
+    workspace: {
+      id: `ws-${Math.random().toString(36).slice(2, 8)}`,
+      repoId: "repo-1",
+      pullRequestNumber: 42,
+      state,
+      worktreePath: "/tmp/ws",
+      sessionId: null,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      ...wsRest,
+    },
+    branch: "feat/test",
+    ahead: 0,
+    behind: 0,
+    ciStatus: null,
+    githubUrl: "https://github.com/test/repo/pull/42",
+    sessionCount: 1,
+    diskUsageMb: 50,
+    lastNote: null,
+    ...rest,
+  };
+}
 
 // ── Mock data ────────────────────────────────────────────────────
 
@@ -85,10 +157,11 @@ describe("WorkspaceView", () => {
   });
 
   it("should render switcher, terminal, and status bar", () => {
-    render(
+    renderWithQuery(
       <WorkspaceView
         workspaces={WORKSPACES}
         statusInfo={STATUS_INFO}
+        entries={[]}
         onBackToDashboard={vi.fn()}
       />,
     );
@@ -99,10 +172,11 @@ describe("WorkspaceView", () => {
   });
 
   it("should switch terminal on workspace change", () => {
-    render(
+    renderWithQuery(
       <WorkspaceView
         workspaces={WORKSPACES}
         statusInfo={STATUS_INFO}
+        entries={[]}
         onBackToDashboard={vi.fn()}
       />,
     );
@@ -117,27 +191,12 @@ describe("WorkspaceView", () => {
     expect(screen.queryByTestId("terminal-ws-1")).not.toBeInTheDocument();
   });
 
-  it("should show empty state when no active workspace", () => {
-    useWorkspacesStore.setState({ activeWorkspaceId: null });
-
-    render(
-      <WorkspaceView
-        workspaces={WORKSPACES}
-        statusInfo={STATUS_INFO}
-        onBackToDashboard={vi.fn()}
-      />,
-    );
-
-    expect(screen.getByTestId("workspace-switcher")).toBeInTheDocument();
-    expect(screen.queryByTestId("terminal-ws-1")).not.toBeInTheDocument();
-    expect(screen.getByText(/select a workspace/i)).toBeInTheDocument();
-  });
-
   it("should render terminal without status bar when status info is missing", () => {
-    render(
+    renderWithQuery(
       <WorkspaceView
         workspaces={WORKSPACES}
         statusInfo={{}}
+        entries={[]}
         onBackToDashboard={vi.fn()}
       />,
     );
@@ -150,16 +209,107 @@ describe("WorkspaceView", () => {
   it("should show empty state when active workspace not in list", () => {
     useWorkspacesStore.setState({ activeWorkspaceId: "ws-unknown" });
 
-    render(
+    renderWithQuery(
       <WorkspaceView
         workspaces={WORKSPACES}
         statusInfo={STATUS_INFO}
+        entries={[]}
         onBackToDashboard={vi.fn()}
       />,
     );
 
     expect(screen.getByTestId("workspace-switcher")).toBeInTheDocument();
     expect(screen.queryByTestId("workspace-statusbar")).not.toBeInTheDocument();
-    expect(screen.getByText(/select a workspace/i)).toBeInTheDocument();
+    expect(screen.getByTestId("workspace-list")).toBeInTheDocument();
+  });
+
+  it("should render WorkspaceListPage when no active workspace", () => {
+    useWorkspacesStore.setState({ activeWorkspaceId: null });
+
+    const activeEntry = makeEntry({ workspaceOverrides: { id: "ws-a", state: "active", pullRequestNumber: 10 } });
+    const suspendedEntry = makeEntry({ workspaceOverrides: { id: "ws-b", state: "suspended", pullRequestNumber: 20 } });
+
+    renderWithQuery(
+      <WorkspaceView
+        workspaces={WORKSPACES}
+        statusInfo={{}}
+        entries={[activeEntry, suspendedEntry]}
+        onBackToDashboard={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("workspace-list")).toBeInTheDocument();
+    expect(screen.queryByTestId("terminal-ws-1")).not.toBeInTheDocument();
+  });
+
+  it("should filter out archived workspaces from list", () => {
+    useWorkspacesStore.setState({ activeWorkspaceId: null });
+
+    const activeEntry = makeEntry({ workspaceOverrides: { id: "ws-active", state: "active", pullRequestNumber: 1 } });
+    const archivedEntry = makeEntry({ workspaceOverrides: { id: "ws-archived", state: "archived", pullRequestNumber: 2 } });
+
+    renderWithQuery(
+      <WorkspaceView
+        workspaces={WORKSPACES}
+        statusInfo={{}}
+        entries={[activeEntry, archivedEntry]}
+        onBackToDashboard={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("workspace-item-ws-active")).toBeInTheDocument();
+    expect(screen.queryByTestId("workspace-item-ws-archived")).not.toBeInTheDocument();
+  });
+
+  it("should set active workspace when clicking an active workspace", async () => {
+    useWorkspacesStore.setState({ activeWorkspaceId: null });
+
+    const setActiveWorkspace = vi.fn();
+    useWorkspacesStore.setState({ setActiveWorkspace } as Partial<typeof useWorkspacesStore.getState>);
+
+    const activeEntry = makeEntry({ workspaceOverrides: { id: "ws-click", state: "active", pullRequestNumber: 5 } });
+
+    renderWithQuery(
+      <WorkspaceView
+        workspaces={WORKSPACES}
+        statusInfo={{}}
+        entries={[activeEntry]}
+        onBackToDashboard={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("workspace-item-ws-click"));
+
+    await waitFor(() => {
+      expect(resumeWorkspace).not.toHaveBeenCalled();
+      expect(setActiveWorkspace).toHaveBeenCalledWith("ws-click");
+    });
+  });
+
+  it("should call resumeWorkspace then set active when clicking a suspended workspace", async () => {
+    useWorkspacesStore.setState({ activeWorkspaceId: null });
+
+    const setActiveWorkspace = vi.fn();
+    useWorkspacesStore.setState({ setActiveWorkspace } as Partial<typeof useWorkspacesStore.getState>);
+
+    vi.mocked(resumeWorkspace).mockResolvedValue(undefined);
+
+    const suspendedEntry = makeEntry({ workspaceOverrides: { id: "ws-suspended", state: "suspended", pullRequestNumber: 7 } });
+
+    renderWithQuery(
+      <WorkspaceView
+        workspaces={WORKSPACES}
+        statusInfo={{}}
+        entries={[suspendedEntry]}
+        onBackToDashboard={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("workspace-item-ws-suspended"));
+
+    await waitFor(() => {
+      expect(resumeWorkspace).toHaveBeenCalledWith("ws-suspended");
+      expect(setActiveWorkspace).toHaveBeenCalledWith("ws-suspended");
+    });
   });
 });

--- a/src/components/Workspace/WorkspaceView.tsx
+++ b/src/components/Workspace/WorkspaceView.tsx
@@ -1,24 +1,55 @@
-import type { ReactElement } from "react";
-import type { Workspace, WorkspaceStatusInfo } from "../../lib/types";
+import { useCallback, useMemo, type ReactElement } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import type { Workspace, WorkspaceListEntry, WorkspaceStatusInfo } from "../../lib/types";
+import { resumeWorkspace } from "../../lib/tauri";
 import { useWorkspacesStore } from "../../stores/workspaces";
 import { WorkspaceSwitcher } from "./WorkspaceSwitcher";
 import { Terminal } from "./Terminal";
 import { WorkspaceStatusBar } from "./WorkspaceStatusBar";
+import { WorkspaceListPage } from "./WorkspaceListPage";
 
 interface WorkspaceViewProps {
   readonly workspaces: readonly Workspace[];
   readonly statusInfo: Readonly<Record<string, WorkspaceStatusInfo>>;
+  readonly entries: readonly WorkspaceListEntry[];
   readonly onBackToDashboard: () => void;
 }
 
 export function WorkspaceView({
   workspaces,
   statusInfo,
+  entries,
   onBackToDashboard,
 }: WorkspaceViewProps): ReactElement {
+  const queryClient = useQueryClient();
   const activeWorkspaceId = useWorkspacesStore((s) => s.activeWorkspaceId);
+  const setActiveWorkspace = useWorkspacesStore((s) => s.setActiveWorkspace);
   const active = workspaces.find((w) => w.id === activeWorkspaceId);
   const info = active ? statusInfo[active.id] : undefined;
+
+  const visibleEntries = useMemo(
+    () => entries.filter((e) => e.workspace.state !== "archived"),
+    [entries],
+  );
+
+  const handleWorkspaceClick = useCallback(
+    async (id: string) => {
+      const entry = visibleEntries.find((e) => e.workspace.id === id);
+      if (!entry) return;
+
+      try {
+        if (entry.workspace.state === "suspended") {
+          await resumeWorkspace(id);
+        }
+        setActiveWorkspace(id);
+        queryClient.invalidateQueries({ queryKey: ["workspaces"] });
+        queryClient.invalidateQueries({ queryKey: ["github", "dashboard"] });
+      } catch (err: unknown) {
+        console.error("[WorkspaceView] failed to resume workspace:", err);
+      }
+    },
+    [visibleEntries, queryClient, setActiveWorkspace],
+  );
 
   return (
     <section
@@ -49,9 +80,7 @@ export function WorkspaceView({
           )}
         </>
       ) : (
-        <div className="flex flex-1 items-center justify-center text-dim">
-          Select a workspace to begin
-        </div>
+        <WorkspaceListPage entries={visibleEntries} onWorkspaceClick={handleWorkspaceClick} />
       )}
     </section>
   );

--- a/src/hooks/useWorkspaceEnriched.ts
+++ b/src/hooks/useWorkspaceEnriched.ts
@@ -61,7 +61,10 @@ export function useWorkspaceEnriched(enabled = true) {
     return map;
   }, [query.data]);
 
-  const entries: readonly WorkspaceListEntry[] = query.data ?? [];
+  const entries: readonly WorkspaceListEntry[] = useMemo(
+    () => query.data ?? [],
+    [query.data],
+  );
 
   return { statusInfo, entries, isLoading: query.isLoading };
 }

--- a/src/hooks/useWorkspaceEnriched.ts
+++ b/src/hooks/useWorkspaceEnriched.ts
@@ -2,7 +2,7 @@ import { useEffect, useMemo } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { listWorkspacesEnriched, onEvent } from "../lib/tauri";
 import { TAURI_EVENTS } from "../lib/types";
-import type { WorkspaceStatusInfo } from "../lib/types";
+import type { WorkspaceListEntry, WorkspaceStatusInfo } from "../lib/types";
 
 const STALE_TIME = 30_000;
 
@@ -61,5 +61,7 @@ export function useWorkspaceEnriched(enabled = true) {
     return map;
   }, [query.data]);
 
-  return { statusInfo, isLoading: query.isLoading };
+  const entries: readonly WorkspaceListEntry[] = query.data ?? [];
+
+  return { statusInfo, entries, isLoading: query.isLoading };
 }


### PR DESCRIPTION
## Summary

- Integrate `WorkspaceListPage` as the empty state in `WorkspaceView` — when no workspace is active, users see the full workspace list (active + suspended) instead of a "Select a workspace" message
- Click a workspace to activate it; suspended workspaces are automatically resumed via `resumeWorkspace` IPC
- Archived workspaces are filtered out from the list
- Expose `entries: readonly WorkspaceListEntry[]` from `useWorkspaceEnriched` hook

## Files changed

| File | Change |
|------|--------|
| `src/hooks/useWorkspaceEnriched.ts` | Return `entries` alongside `statusInfo` |
| `src/components/Workspace/WorkspaceView.tsx` | Integrate WorkspaceListPage, add click handler with resume support |
| `src/App.tsx` | Pass `entries` prop to WorkspaceView |
| `src/components/Workspace/WorkspaceView.test.tsx` | Fix existing tests + 4 new tests (8 total) |

## Test plan

- [x] Typecheck passes (0 errors)
- [x] All 466 tests pass (43 test files)
- [x] Lint passes (0 warnings)
- [x] Adversarial review: race condition fixed (fire-and-forget invalidation), readonly types enforced
- [ ] Manual: navigate to Workspaces view, verify list is shown when no workspace active
- [ ] Manual: click an active workspace, verify terminal opens
- [ ] Manual: click a suspended workspace, verify it resumes and opens

Closes #105

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Assembled the workspace page in `WorkspaceView`. When no workspace is active, we show `WorkspaceListPage`; clicking a workspace opens it, and suspended workspaces are resumed first. Archived workspaces are hidden.

- **New Features**
  - Integrated `WorkspaceListPage` as the empty state.
  - Click handling: open active; resume suspended via `resumeWorkspace`; invalidate `@tanstack/react-query` queries to refresh data.
  - Exposed and memoized `entries: readonly WorkspaceListEntry[]` from `useWorkspaceEnriched`; wired via `App.tsx`. Aligns with Linear T-075 and T-076.

- **Bug Fixes**
  - Tests now use an async `resumeWorkspace` mock to reliably assert resume-before-activate ordering.

<sup>Written for commit bcb31620fb608344cfaba15a172a5e0fcab650e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive workspace selection list with clickable items.
  * Suspended workspaces now automatically resume when selected, then become active.
  * Archived workspaces are excluded from the selection list.

* **Bug Fixes**
  * Selection reliably activates the chosen workspace and refreshes related views.

* **Tests**
  * Added coverage for list-driven behavior, resume flows, activation order, and archived-item exclusion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->