### PR TITLE
fix(cache): wire sync_activity into dashboard sync pipeline

### DIFF
--- a/src-tauri/src/cache/activity.rs
+++ b/src-tauri/src/cache/activity.rs
@@ -95,7 +95,6 @@ pub async fn insert_activity(pool: &SqlitePool, activity: &Activity) -> Result<A
 }
 
 /// Return recent activity events, paginated and ordered by `created_at DESC`.
-#[allow(dead_code)]
 pub async fn get_recent_activity(
     pool: &SqlitePool,
     limit: i64,
@@ -135,7 +134,6 @@ pub async fn mark_all_read(pool: &SqlitePool) -> Result<u64, AppError> {
 ///
 /// Returns `true` if a new row was inserted, `false` if the ID already existed.
 /// Accepts any sqlx executor (pool, connection, or transaction) for flexibility.
-#[allow(dead_code)]
 pub async fn upsert_activity<'e, E>(executor: E, activity: &Activity) -> Result<bool, AppError>
 where
     E: sqlx::Executor<'e, Database = sqlx::Sqlite>,

--- a/src-tauri/src/cache/dashboard.rs
+++ b/src-tauri/src/cache/dashboard.rs
@@ -253,7 +253,7 @@ pub async fn compute_dashboard_stats(
 }
 
 /// Get the most recent `last_sync_at` across all repos.
-async fn get_latest_sync_at(pool: &SqlitePool) -> Result<Option<String>, AppError> {
+pub(crate) async fn get_latest_sync_at(pool: &SqlitePool) -> Result<Option<String>, AppError> {
     let row: Option<(Option<String>,)> =
         sqlx::query_as("SELECT MAX(last_sync_at) FROM repos WHERE last_sync_at IS NOT NULL")
             .fetch_optional(pool)

--- a/src-tauri/src/cache/sync.rs
+++ b/src-tauri/src/cache/sync.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)] // TODO(T-034): remove after wiring up polling
 //! GitHub data synchronization (T-032).
 //!
 //! Fetches dashboard data from GitHub GraphQL API and persists it
@@ -9,7 +8,7 @@ use std::collections::HashSet;
 use sqlx::SqlitePool;
 
 use crate::cache::activity::upsert_activity;
-use crate::cache::dashboard::compute_dashboard_stats;
+use crate::cache::dashboard::{compute_dashboard_stats, get_latest_sync_at};
 use crate::cache::issues::upsert_issue;
 use crate::cache::pull_requests::upsert_pull_request;
 use crate::cache::repos::{list_repos, upsert_repo};
@@ -171,6 +170,17 @@ pub async fn sync_dashboard(
     }
 
     tx.commit().await?;
+
+    // Activity sync is best-effort — don't fail dashboard sync if it errors.
+    let since = get_latest_sync_at(pool)
+        .await
+        .ok()
+        .flatten()
+        .unwrap_or_else(|| (chrono::Utc::now() - chrono::Duration::days(7)).to_rfc3339());
+    match sync_activity(client, pool, username, &since).await {
+        Ok(n) => tracing::info!("activity sync: {n} new events"),
+        Err(e) => tracing::warn!("activity sync failed: {e}"),
+    }
 
     compute_dashboard_stats(pool, username).await
 }

--- a/src-tauri/src/cache/sync.rs
+++ b/src-tauri/src/cache/sync.rs
@@ -153,6 +153,13 @@ pub async fn sync_dashboard(
     let variables = build_query_variables(username, &enabled)?;
     let data = client.execute_graphql::<DashboardData>(variables).await?;
 
+    // Capture the previous sync cursor BEFORE the transaction advances it.
+    let activity_since = get_latest_sync_at(pool)
+        .await
+        .ok()
+        .flatten()
+        .unwrap_or_else(|| (chrono::Utc::now() - chrono::Duration::days(7)).to_rfc3339());
+
     // All DB writes in a single transaction for atomicity.
     let mut tx = pool.begin().await?;
 
@@ -172,12 +179,7 @@ pub async fn sync_dashboard(
     tx.commit().await?;
 
     // Activity sync is best-effort — don't fail dashboard sync if it errors.
-    let since = get_latest_sync_at(pool)
-        .await
-        .ok()
-        .flatten()
-        .unwrap_or_else(|| (chrono::Utc::now() - chrono::Duration::days(7)).to_rfc3339());
-    match sync_activity(client, pool, username, &since).await {
+    match sync_activity(client, pool, username, &activity_since).await {
         Ok(n) => tracing::info!("activity sync: {n} new events"),
         Err(e) => tracing::warn!("activity sync failed: {e}"),
     }


### PR DESCRIPTION
## Summary
- Wire the existing `sync_activity()` function into `sync_dashboard()` so the activity feed is populated during each sync cycle
- Activity sync is best-effort: failures are logged but don't break the dashboard sync
- Remove stale `#[allow(dead_code)]` annotations on functions now called from the sync pipeline

## Root cause
`sync_activity()` (T-032) was fully implemented with GraphQL query, persistence layer, and deduplication — but never called from `sync_dashboard()`. The activity table stayed permanently empty, causing "No activity to display" on both the Overview and Activity pages.

## Changes
- `sync.rs`: Remove `#![allow(dead_code)]`, call `sync_activity()` after dashboard data commit using `get_latest_sync_at` as the `since` parameter (7-day fallback on first run)
- `dashboard.rs`: Make `get_latest_sync_at` `pub(crate)` for cross-module access
- `activity.rs`: Remove `#[allow(dead_code)]` from `get_recent_activity` and `upsert_activity`

## Test plan
- [x] `cargo clippy` — zero warnings
- [x] `cargo test` — 340/341 pass (1 pre-existing failure unrelated to this change)
- [ ] Manual: force sync via UI → verify activity feed populates
- [ ] Manual: verify activity filters (all/comment/review/ci/mention/other) work with real data

Closes #109

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wired `sync_activity()` into the dashboard sync so the activity feed populates on every cycle. Capture the previous sync cursor before the transaction; failures are logged and won’t block dashboard updates.

- **Bug Fixes**
  - Call `sync_activity()` after committing dashboard data; capture `activity_since` with `get_latest_sync_at` before the transaction to use the previous timestamp (7‑day fallback on first run).
  - Expose `get_latest_sync_at` as `pub(crate)` for cross-module access.
  - Remove stale `#[allow(dead_code)]` annotations now that functions are used.

<sup>Written for commit 94a43aa023e7a57a7a7642679f8d49dc7759b496. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard sync now also pulls recent activity using the latest sync cursor (falls back to 7 days); activity sync runs after dashboard commit and won’t block the overall sync if it fails.

* **Refactor**
  * Internal cleanup and visibility adjustments for cache components to improve maintainability and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->