### PR TITLE
feat(settings): add Claude Code configuration section

### DIFF
--- a/src-tauri/src/cache/config.rs
+++ b/src-tauri/src/cache/config.rs
@@ -13,6 +13,8 @@ const KEY_AUTO_SUSPEND: &str = "auto_suspend_minutes";
 const KEY_GITHUB_TOKEN: &str = "github_token";
 const KEY_DATA_DIR: &str = "data_dir";
 const KEY_WORKSPACES_DIR: &str = "workspaces_dir";
+const KEY_CLAUDE_AUTH_MODE: &str = "claude_auth_mode";
+const KEY_CLAUDE_AUTO_GENERATE_MD: &str = "claude_auto_generate_md";
 
 /// Minimum allowed value for `poll_interval_secs`.
 const MIN_POLL_INTERVAL_SECS: u64 = 30;
@@ -20,6 +22,21 @@ const MIN_POLL_INTERVAL_SECS: u64 = 30;
 const MIN_MAX_ACTIVE_WORKSPACES: u32 = 1;
 /// Minimum allowed value for `auto_suspend_minutes`.
 const MIN_AUTO_SUSPEND_MINUTES: u64 = 5;
+
+/// Allowed values for `claude_auth_mode`.
+const VALID_CLAUDE_AUTH_MODES: &[&str] = &["oauth", "api_key"];
+
+/// Validate `claude_auth_mode` against the allowlist.
+fn validate_claude_auth_mode(mode: &str) -> Result<&str, AppError> {
+    if VALID_CLAUDE_AUTH_MODES.contains(&mode) {
+        Ok(mode)
+    } else {
+        Err(AppError::Config(format!(
+            "invalid claude_auth_mode: '{mode}'; expected one of: {}",
+            VALID_CLAUDE_AUTH_MODES.join(", ")
+        )))
+    }
+}
 
 /// Row from the `config` key-value table.
 #[derive(sqlx::FromRow)]
@@ -136,6 +153,25 @@ pub async fn get_config(pool: &SqlitePool) -> Result<AppConfig, AppError> {
             KEY_WORKSPACES_DIR => {
                 config.workspaces_dir = Some(row.value);
             }
+            KEY_CLAUDE_AUTH_MODE => match row.value.as_str() {
+                "oauth" | "api_key" => config.claude_auth_mode = row.value,
+                _ => {
+                    warn!(
+                        "ignoring invalid config value for '{}': '{}', expected 'oauth' or 'api_key'",
+                        KEY_CLAUDE_AUTH_MODE, row.value
+                    );
+                }
+            },
+            KEY_CLAUDE_AUTO_GENERATE_MD => {
+                if let Ok(v) = row.value.parse::<bool>() {
+                    config.claude_auto_generate_md = v;
+                } else {
+                    warn!(
+                        "ignoring non-parseable config value for '{}': '{}', using default",
+                        KEY_CLAUDE_AUTO_GENERATE_MD, row.value
+                    );
+                }
+            }
             _ => {} // ignore unknown keys for forward-compat
         }
     }
@@ -153,6 +189,7 @@ pub async fn set_config(pool: &SqlitePool, config: &AppConfig) -> Result<AppConf
     let poll_interval = clamp_poll_interval(config.poll_interval_secs);
     let max_workspaces = clamp_max_workspaces(config.max_active_workspaces);
     let auto_suspend = clamp_auto_suspend(config.auto_suspend_minutes);
+    let claude_auth_mode = validate_claude_auth_mode(&config.claude_auth_mode)?;
 
     let mut tx = pool.begin().await?;
 
@@ -180,6 +217,13 @@ pub async fn set_config(pool: &SqlitePool, config: &AppConfig) -> Result<AppConf
         config.workspaces_dir.as_deref(),
     )
     .await?;
+    upsert_key(&mut *tx, KEY_CLAUDE_AUTH_MODE, claude_auth_mode).await?;
+    upsert_key(
+        &mut *tx,
+        KEY_CLAUDE_AUTO_GENERATE_MD,
+        &config.claude_auto_generate_md.to_string(),
+    )
+    .await?;
 
     tx.commit().await?;
 
@@ -193,6 +237,8 @@ pub async fn set_config(pool: &SqlitePool, config: &AppConfig) -> Result<AppConf
         github_token: config.github_token.clone(),
         data_dir: config.data_dir.clone(),
         workspaces_dir: config.workspaces_dir.clone(),
+        claude_auth_mode: claude_auth_mode.to_string(),
+        claude_auto_generate_md: config.claude_auto_generate_md,
     })
 }
 
@@ -294,6 +340,8 @@ mod tests {
             github_token: Some("ghp_test".to_string()),
             data_dir: Some("/custom/data".to_string()),
             workspaces_dir: Some("/custom/ws".to_string()),
+            claude_auth_mode: "oauth".to_string(),
+            claude_auto_generate_md: false,
         };
 
         let result = set_config(&pool, &config).await.unwrap();

--- a/src-tauri/src/cache/config.rs
+++ b/src-tauri/src/cache/config.rs
@@ -153,15 +153,18 @@ pub async fn get_config(pool: &SqlitePool) -> Result<AppConfig, AppError> {
             KEY_WORKSPACES_DIR => {
                 config.workspaces_dir = Some(row.value);
             }
-            KEY_CLAUDE_AUTH_MODE => match row.value.as_str() {
-                "oauth" | "api_key" => config.claude_auth_mode = row.value,
-                _ => {
+            KEY_CLAUDE_AUTH_MODE => {
+                if validate_claude_auth_mode(&row.value).is_ok() {
+                    config.claude_auth_mode = row.value;
+                } else {
                     warn!(
-                        "ignoring invalid config value for '{}': '{}', expected 'oauth' or 'api_key'",
-                        KEY_CLAUDE_AUTH_MODE, row.value
+                        "ignoring invalid config value for '{}': '{}', expected one of: {}",
+                        KEY_CLAUDE_AUTH_MODE,
+                        row.value,
+                        VALID_CLAUDE_AUTH_MODES.join(", ")
                     );
                 }
-            },
+            }
             KEY_CLAUDE_AUTO_GENERATE_MD => {
                 if let Ok(v) = row.value.parse::<bool>() {
                     config.claude_auto_generate_md = v;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1650,6 +1650,8 @@ mod tests {
             github_token: Some("ghp_test".into()),
             data_dir: None,
             workspaces_dir: Some("/ws".into()),
+            claude_auth_mode: "oauth".to_string(),
+            claude_auto_generate_md: false,
         };
         let json = serde_json::to_value(&config).unwrap();
         assert_eq!(json["pollIntervalSecs"], 120);
@@ -1709,6 +1711,8 @@ mod tests {
             github_token: None,
             data_dir: None,
             workspaces_dir: None,
+            claude_auth_mode: "oauth".to_string(),
+            claude_auto_generate_md: false,
         };
         let partial = PartialAppConfig {
             poll_interval_secs: Some(60),
@@ -1719,6 +1723,8 @@ mod tests {
             github_token: None,
             data_dir: None,
             workspaces_dir: None,
+            claude_auth_mode: None,
+            claude_auto_generate_md: None,
         };
         let merged = merge_partial_config(&base, &partial);
         assert_eq!(merged.poll_interval_secs, 60);
@@ -1736,6 +1742,8 @@ mod tests {
             github_token: Some("ghp_old".into()),
             data_dir: Some("/data".into()),
             workspaces_dir: None,
+            claude_auth_mode: "oauth".to_string(),
+            claude_auto_generate_md: false,
         };
         // Double-option: Some(None) means "explicitly set to null"
         let partial = PartialAppConfig {
@@ -1747,6 +1755,8 @@ mod tests {
             github_token: Some(None), // clear it
             data_dir: None,           // leave as-is
             workspaces_dir: None,
+            claude_auth_mode: None,
+            claude_auto_generate_md: None,
         };
         let merged = merge_partial_config(&base, &partial);
         assert!(
@@ -2244,6 +2254,8 @@ mod tests {
                 github_token: None,
                 data_dir: None,
                 workspaces_dir: Some(ws_base.path().to_string_lossy().to_string()),
+                claude_auth_mode: "oauth".to_string(),
+                claude_auto_generate_md: false,
             },
         )
         .await
@@ -2299,6 +2311,8 @@ mod tests {
                 github_token: None,
                 data_dir: None,
                 workspaces_dir: Some(ws_base.path().to_string_lossy().to_string()),
+                claude_auth_mode: "oauth".to_string(),
+                claude_auto_generate_md: false,
             },
         )
         .await
@@ -2375,6 +2389,8 @@ mod tests {
                 github_token: None,
                 data_dir: None,
                 workspaces_dir: Some(ws_base.path().to_string_lossy().to_string()),
+                claude_auth_mode: "oauth".to_string(),
+                claude_auto_generate_md: false,
             },
         )
         .await
@@ -2429,6 +2445,8 @@ mod tests {
                 github_token: None,
                 data_dir: None,
                 workspaces_dir: Some(ws_base.path().to_string_lossy().to_string()),
+                claude_auth_mode: "oauth".to_string(),
+                claude_auto_generate_md: false,
             },
         )
         .await
@@ -2499,6 +2517,8 @@ mod tests {
                 github_token: None,
                 data_dir: None,
                 workspaces_dir: Some(ws_base.path().to_string_lossy().to_string()),
+                claude_auth_mode: "oauth".to_string(),
+                claude_auto_generate_md: false,
             },
         )
         .await
@@ -2570,6 +2590,8 @@ mod tests {
                 github_token: None,
                 data_dir: None,
                 workspaces_dir: Some(ws_base.path().to_string_lossy().to_string()),
+                claude_auth_mode: "oauth".to_string(),
+                claude_auto_generate_md: false,
             },
         )
         .await
@@ -2639,6 +2661,8 @@ mod tests {
                 github_token: None,
                 data_dir: None,
                 workspaces_dir: Some(ws_base.path().to_string_lossy().to_string()),
+                claude_auth_mode: "oauth".to_string(),
+                claude_auto_generate_md: false,
             },
         )
         .await

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -391,6 +391,10 @@ pub struct AppConfig {
     pub data_dir: Option<String>,
     /// Override for the workspaces root directory (`~/.prism/workspaces/` by default).
     pub workspaces_dir: Option<String>,
+    /// Claude Code authentication mode: "oauth" or "api_key" (default: "oauth").
+    pub claude_auth_mode: String,
+    /// Whether to auto-generate CLAUDE.md files in workspaces (default: false).
+    pub claude_auto_generate_md: bool,
 }
 
 impl fmt::Debug for AppConfig {
@@ -410,6 +414,8 @@ impl fmt::Debug for AppConfig {
             )
             .field("data_dir", &self.data_dir)
             .field("workspaces_dir", &self.workspaces_dir)
+            .field("claude_auth_mode", &self.claude_auth_mode)
+            .field("claude_auto_generate_md", &self.claude_auto_generate_md)
             .finish()
     }
 }
@@ -425,6 +431,8 @@ impl Default for AppConfig {
             github_token: None,
             data_dir: None,
             workspaces_dir: None,
+            claude_auth_mode: "oauth".to_string(),
+            claude_auto_generate_md: false,
         }
     }
 }
@@ -474,6 +482,8 @@ pub struct PartialAppConfig {
     pub data_dir: Option<Option<String>>,
     #[serde(deserialize_with = "deserialize_double_option", default)]
     pub workspaces_dir: Option<Option<String>>,
+    pub claude_auth_mode: Option<String>,
+    pub claude_auto_generate_md: Option<bool>,
 }
 
 /// Merge a partial update into a base config, returning a new config.
@@ -508,6 +518,13 @@ pub fn merge_partial_config(base: &AppConfig, partial: &PartialAppConfig) -> App
             Some(v) => v.clone(),
             None => base.workspaces_dir.clone(),
         },
+        claude_auth_mode: partial
+            .claude_auth_mode
+            .clone()
+            .unwrap_or_else(|| base.claude_auth_mode.clone()),
+        claude_auto_generate_md: partial
+            .claude_auto_generate_md
+            .unwrap_or(base.claude_auto_generate_md),
     }
 }
 
@@ -1117,6 +1134,8 @@ mod tests {
             github_token: Some("test-token".to_string()),
             data_dir: Some("/custom/data".to_string()),
             workspaces_dir: None,
+            claude_auth_mode: "oauth".to_string(),
+            claude_auto_generate_md: false,
         };
         let json = serde_json::to_string(&config).unwrap();
         assert!(json.contains("\"pollIntervalSecs\""));

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -391,7 +391,7 @@ pub struct AppConfig {
     pub data_dir: Option<String>,
     /// Override for the workspaces root directory (`~/.prism/workspaces/` by default).
     pub workspaces_dir: Option<String>,
-    /// Claude Code authentication mode: "oauth" or "api_key" (default: "oauth").
+    /// Claude Code authentication mode: `oauth` or `api_key` (default: `oauth`).
     pub claude_auth_mode: String,
     /// Whether to auto-generate CLAUDE.md files in workspaces (default: false).
     pub claude_auto_generate_md: bool,

--- a/src/components/Settings/Settings.test.tsx
+++ b/src/components/Settings/Settings.test.tsx
@@ -52,6 +52,8 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     githubToken: "test-token",
     dataDir: null,
     workspacesDir: null,
+    claudeAuthMode: "oauth",
+    claudeAutoGenerateMd: false,
     ...overrides,
   };
 }
@@ -265,7 +267,8 @@ describe("Settings", () => {
 
     renderWithProviders(<Settings />);
 
-    const toggle = await screen.findByRole("checkbox");
+    const reposSection = await screen.findByTestId("settings-repos");
+    const toggle = within(reposSection).getByRole("checkbox");
     await user.click(toggle);
 
     expect(mockedSetRepoEnabled).toHaveBeenCalledWith("repo-1", false);
@@ -385,5 +388,58 @@ describe("Settings", () => {
     renderWithProviders(<Settings />);
 
     expect(await screen.findByText("N/A")).toBeInTheDocument();
+  });
+
+  it("should render Claude Code section", async () => {
+    setupMocks();
+    renderWithProviders(<Settings />);
+    expect(await screen.findByTestId("settings-claude-code")).toBeInTheDocument();
+    expect(screen.getByText("Claude Code")).toBeInTheDocument();
+  });
+
+  it("should render auth mode select with default value", async () => {
+    setupMocks(makeConfig({ claudeAuthMode: "oauth" }));
+    renderWithProviders(<Settings />);
+    const section = await screen.findByTestId("settings-claude-code");
+    const select = within(section).getByRole("combobox");
+    expect(select).toHaveValue("oauth");
+  });
+
+  it("should call config mutation when auth mode changes", async () => {
+    const user = userEvent.setup();
+    const updatedConfig = makeConfig({ claudeAuthMode: "api_key" });
+    setupMocks();
+    mockedSetConfig.mockResolvedValue(updatedConfig);
+
+    renderWithProviders(<Settings />);
+
+    const section = await screen.findByTestId("settings-claude-code");
+    const select = within(section).getByRole("combobox");
+    await user.selectOptions(select, "api_key");
+
+    expect(mockedSetConfig).toHaveBeenCalledWith({ claudeAuthMode: "api_key" });
+  });
+
+  it("should render auto-generate CLAUDE.md toggle", async () => {
+    setupMocks(makeConfig({ claudeAutoGenerateMd: false }));
+    renderWithProviders(<Settings />);
+    const section = await screen.findByTestId("settings-claude-code");
+    const checkbox = within(section).getByRole("checkbox");
+    expect(checkbox).not.toBeChecked();
+  });
+
+  it("should call config mutation when auto-generate toggle changes", async () => {
+    const user = userEvent.setup();
+    const updatedConfig = makeConfig({ claudeAutoGenerateMd: true });
+    setupMocks(makeConfig({ claudeAutoGenerateMd: false }));
+    mockedSetConfig.mockResolvedValue(updatedConfig);
+
+    renderWithProviders(<Settings />);
+
+    const section = await screen.findByTestId("settings-claude-code");
+    const checkbox = within(section).getByRole("checkbox");
+    await user.click(checkbox);
+
+    expect(mockedSetConfig).toHaveBeenCalledWith({ claudeAutoGenerateMd: true });
   });
 });

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -169,7 +169,7 @@ export function Settings(): ReactElement {
           <span className="text-dim text-sm">Auth mode</span>
           <select
             value={config.claudeAuthMode}
-            onChange={(e) => configMutation.mutate({ claudeAuthMode: e.target.value })}
+            onChange={(e) => configMutation.mutate({ claudeAuthMode: e.target.value as "oauth" | "api_key" })}
             className="bg-surface border-border rounded border px-2 py-1 font-mono text-sm text-white"
           >
             <option value="oauth">OAuth</option>

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -163,6 +163,30 @@ export function Settings(): ReactElement {
         />
       </div>
 
+      <div data-testid="settings-claude-code" className="flex flex-col gap-3">
+        <h2 className="text-accent text-sm font-semibold uppercase tracking-wider">Claude Code</h2>
+        <label className="flex items-center justify-between gap-4">
+          <span className="text-dim text-sm">Auth mode</span>
+          <select
+            value={config.claudeAuthMode}
+            onChange={(e) => configMutation.mutate({ claudeAuthMode: e.target.value })}
+            className="bg-surface border-border rounded border px-2 py-1 font-mono text-sm text-white"
+          >
+            <option value="oauth">OAuth</option>
+            <option value="api_key">API Key</option>
+          </select>
+        </label>
+        <label className="flex items-center justify-between gap-3 py-1">
+          <span className="text-dim text-sm">Auto-generate CLAUDE.md</span>
+          <input
+            type="checkbox"
+            checked={config.claudeAutoGenerateMd}
+            onChange={(e) => configMutation.mutate({ claudeAutoGenerateMd: e.target.checked })}
+            className="accent-accent h-4 w-4"
+          />
+        </label>
+      </div>
+
       <div data-testid="settings-repos" className="flex flex-col gap-3">
         <h2 className="text-accent text-sm font-semibold uppercase tracking-wider">Repositories</h2>
         {reposQuery.isLoading ? (

--- a/src/components/Workspace/WorkspaceSwitcher.test.tsx
+++ b/src/components/Workspace/WorkspaceSwitcher.test.tsx
@@ -61,6 +61,8 @@ function resetStores() {
       githubToken: null,
       dataDir: null,
       workspacesDir: null,
+      claudeAuthMode: "oauth",
+      claudeAutoGenerateMd: false,
     },
   });
 }
@@ -152,6 +154,8 @@ describe("WorkspaceSwitcher", () => {
         githubToken: null,
         dataDir: null,
         workspacesDir: null,
+        claudeAuthMode: "oauth",
+        claudeAutoGenerateMd: false,
       },
     });
 
@@ -206,6 +210,8 @@ describe("WorkspaceSwitcher", () => {
         githubToken: null,
         dataDir: null,
         workspacesDir: null,
+        claudeAuthMode: "oauth",
+        claudeAutoGenerateMd: false,
       },
     });
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -227,6 +227,8 @@ export interface AppConfig {
   readonly githubToken: string | null;
   readonly dataDir: string | null;
   readonly workspacesDir: string | null;
+  readonly claudeAuthMode: string;
+  readonly claudeAutoGenerateMd: boolean;
 }
 
 /** Partial update payload for `config_set`. Mirrors Rust `PartialAppConfig`.
@@ -244,6 +246,8 @@ export interface PartialAppConfig {
   readonly githubToken?: string | null;
   readonly dataDir?: string | null;
   readonly workspacesDir?: string | null;
+  readonly claudeAuthMode?: string;
+  readonly claudeAutoGenerateMd?: boolean;
 }
 
 // ── Debug (T-087) ───────────────────────────────────────────────

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -227,7 +227,7 @@ export interface AppConfig {
   readonly githubToken: string | null;
   readonly dataDir: string | null;
   readonly workspacesDir: string | null;
-  readonly claudeAuthMode: string;
+  readonly claudeAuthMode: "oauth" | "api_key";
   readonly claudeAutoGenerateMd: boolean;
 }
 
@@ -246,7 +246,7 @@ export interface PartialAppConfig {
   readonly githubToken?: string | null;
   readonly dataDir?: string | null;
   readonly workspacesDir?: string | null;
-  readonly claudeAuthMode?: string;
+  readonly claudeAuthMode?: "oauth" | "api_key";
   readonly claudeAutoGenerateMd?: boolean;
 }
 

--- a/src/stores/settings.test.ts
+++ b/src/stores/settings.test.ts
@@ -9,6 +9,8 @@ const fakeConfig: AppConfig = {
   githubToken: "FAKE_TOKEN_FOR_TESTING",
   dataDir: "/home/user/.local/share/prism",
   workspacesDir: "/home/user/.prism/workspaces",
+  claudeAuthMode: "oauth",
+  claudeAutoGenerateMd: false,
 };
 
 describe("useSettingsStore", () => {
@@ -35,6 +37,8 @@ describe("useSettingsStore", () => {
       githubToken: null,
       dataDir: null,
       workspacesDir: null,
+      claudeAuthMode: "oauth",
+      claudeAutoGenerateMd: false,
     };
     useSettingsStore.getState().setConfig(minimal);
     expect(useSettingsStore.getState().config).toEqual(minimal);


### PR DESCRIPTION
## Summary

- Add "Claude Code" section to Settings page between Workspaces and Repositories sections
- Auth mode select (OAuth / API Key) with server-side allowlist validation
- Auto-generate CLAUDE.md toggle (boolean)
- Full-stack: Rust config keys → TypeScript types → React UI
- 5 new tests, all 471 TS tests + 340 Rust tests pass

Closes #110

## Changes

| File | Description |
|------|-------------|
| `src-tauri/src/cache/config.rs` | New config keys, read/write logic, allowlist validation |
| `src-tauri/src/types.rs` | `AppConfig` + `PartialAppConfig` struct fields, merge logic |
| `src-tauri/src/commands.rs` | Test struct literals updated |
| `src/lib/types.ts` | TypeScript interface fields |
| `src/components/Settings/Settings.tsx` | New "Claude Code" section with select + checkbox |
| `src/components/Settings/Settings.test.tsx` | 5 new tests for the section |
| Test files (2) | Updated `AppConfig` literals with new defaults |

## Test plan

- [x] `cargo check` — clean
- [x] `cargo test cache::config` — 6/6 pass
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx oxlint .` — 0 warnings
- [x] `npx vitest run` — 471/471 pass
- [ ] Manual: open Settings, verify "Claude Code" section visible
- [ ] Manual: change auth mode, refresh, verify persisted
- [ ] Manual: toggle auto-generate, refresh, verify persisted

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new “Claude Code” section in Settings to choose auth mode (OAuth or API Key) and toggle auto-generating CLAUDE.md, with values persisted and validated server-side. Completes Linear #110.

- **New Features**
  - New Settings section between Workspaces and Repositories with auth mode select and CLAUDE.md toggle.
  - Server-side allowlist validation for `claude_auth_mode` (`oauth` | `api_key`) and safe parsing for the toggle; sensible defaults.
  - Full-stack wiring: Rust `AppConfig` keys and validation → TypeScript types → React UI; values persist across restarts.
  - 5 new UI tests; config literals updated; all existing Rust and TypeScript tests pass.

- **Refactors**
  - Reused `VALID_CLAUDE_AUTH_MODES` in `get_config` and narrowed `claudeAuthMode` to the `"oauth" | "api_key"` union in TypeScript.
  - Fixed Rust doc comment formatting with backticks to satisfy clippy.

<sup>Written for commit 22cf54602a0f6d154f37b945ccd71f4433abb8bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Claude Code" settings section with an authentication mode selector (OAuth or API key) and an auto-generate CLAUDE.md toggle. Settings persist and are validated so invalid values are ignored or defaulted.

* **Tests**
  * Updated test fixtures and test cases across the app to cover the new configuration fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->