### PR TITLE
fix(sync): fetch all PR/issue states from GitHub

### DIFF
--- a/src-tauri/src/cache/sync.rs
+++ b/src-tauri/src/cache/sync.rs
@@ -250,8 +250,8 @@ fn build_query_variables(
 
     Ok(dashboard_data::Variables {
         review_query: format!("type:pr {repo_filter} review-requested:{username} state:open"),
-        my_prs_query: format!("type:pr {repo_filter} author:{username} state:open"),
-        issues_query: format!("type:issue {repo_filter} author:{username} state:open"),
+        my_prs_query: format!("type:pr {repo_filter} author:{username}"),
+        issues_query: format!("type:issue {repo_filter} author:{username}"),
         first: 100,
     })
 }
@@ -571,6 +571,7 @@ mod tests {
         PrFieldsReviewsNodes, PrFieldsReviewsNodesAuthor, PrFieldsReviewsNodesAuthorOn,
         PullRequestReviewState, PullRequestState,
     };
+    use crate::types::{IssueState, PrState};
 
     async fn test_pool() -> (SqlitePool, tempfile::TempDir) {
         let tmp = tempfile::TempDir::new().unwrap();
@@ -830,6 +831,12 @@ mod tests {
         assert!(vars.my_prs_query.contains("author:octocat"));
         assert!(vars.issues_query.contains("author:octocat"));
         assert_eq!(vars.first, 100);
+
+        // review_query keeps state:open (only review open PRs)
+        assert!(vars.review_query.contains("state:open"));
+        // my_prs and issues fetch all states (open, closed, merged)
+        assert!(!vars.my_prs_query.contains("state:open"));
+        assert!(!vars.issues_query.contains("state:open"));
     }
 
     #[tokio::test]
@@ -1493,6 +1500,60 @@ mod tests {
 
         assert_eq!(count, 1);
         mock.assert_async().await;
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_sync_updates_pr_state_open_to_merged() {
+        let (pool, _tmp) = test_pool().await;
+        upsert_repo(&pool, &sample_repo()).await.unwrap();
+
+        // Insert PR as open
+        let mut pr = make_pr_fields("PR_1", 42, "Feature PR");
+        pr.state = PullRequestState::OPEN;
+        {
+            let mut conn = pool.acquire().await.unwrap();
+            persist_single_pr(&mut conn, &pr).await.unwrap();
+        }
+        let result = get_pull_request(&pool, "PR_1").await.unwrap();
+        assert_eq!(result.state, PrState::Open);
+
+        // Re-sync same PR as merged
+        pr.state = PullRequestState::MERGED;
+        {
+            let mut conn = pool.acquire().await.unwrap();
+            persist_single_pr(&mut conn, &pr).await.unwrap();
+        }
+        let result = get_pull_request(&pool, "PR_1").await.unwrap();
+        assert_eq!(result.state, PrState::Merged);
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_sync_updates_issue_state_open_to_closed() {
+        let (pool, _tmp) = test_pool().await;
+        upsert_repo(&pool, &sample_repo()).await.unwrap();
+
+        // Insert issue as open
+        let mut issue_fields = make_issue_fields("ISSUE_1", 10, "Bug report");
+        issue_fields.state = GqlIssueState::OPEN;
+        {
+            let issue = map_issue(&issue_fields).unwrap();
+            let mut conn = pool.acquire().await.unwrap();
+            upsert_issue(&mut *conn, &issue).await.unwrap();
+        }
+        let issues = get_issues_by_repo(&pool, "org/repo").await.unwrap();
+        assert_eq!(issues[0].state, IssueState::Open);
+
+        // Re-sync same issue as closed
+        issue_fields.state = GqlIssueState::CLOSED;
+        {
+            let issue = map_issue(&issue_fields).unwrap();
+            let mut conn = pool.acquire().await.unwrap();
+            upsert_issue(&mut *conn, &issue).await.unwrap();
+        }
+        let issues = get_issues_by_repo(&pool, "org/repo").await.unwrap();
+        assert_eq!(issues[0].state, IssueState::Closed);
         pool.close().await;
     }
 }

--- a/src-tauri/src/cache/sync.rs
+++ b/src-tauri/src/cache/sync.rs
@@ -251,7 +251,7 @@ fn build_query_variables(
     Ok(dashboard_data::Variables {
         review_query: format!("type:pr {repo_filter} review-requested:{username} state:open"),
         my_prs_query: format!("type:pr {repo_filter} author:{username} sort:updated"),
-        issues_query: format!("type:issue {repo_filter} author:{username} sort:updated"),
+        issues_query: format!("type:issue {repo_filter} assignee:{username} sort:updated"),
         first: 100,
     })
 }
@@ -829,7 +829,7 @@ mod tests {
         assert!(vars.review_query.contains("review-requested:octocat"));
         assert!(vars.review_query.contains("repo:org/repo"));
         assert!(vars.my_prs_query.contains("author:octocat"));
-        assert!(vars.issues_query.contains("author:octocat"));
+        assert!(vars.issues_query.contains("assignee:octocat"));
         assert_eq!(vars.first, 100);
 
         // review_query keeps state:open (only review open PRs)

--- a/src-tauri/src/cache/sync.rs
+++ b/src-tauri/src/cache/sync.rs
@@ -250,8 +250,8 @@ fn build_query_variables(
 
     Ok(dashboard_data::Variables {
         review_query: format!("type:pr {repo_filter} review-requested:{username} state:open"),
-        my_prs_query: format!("type:pr {repo_filter} author:{username}"),
-        issues_query: format!("type:issue {repo_filter} author:{username}"),
+        my_prs_query: format!("type:pr {repo_filter} author:{username} sort:updated"),
+        issues_query: format!("type:issue {repo_filter} author:{username} sort:updated"),
         first: 100,
     })
 }
@@ -834,9 +834,11 @@ mod tests {
 
         // review_query keeps state:open (only review open PRs)
         assert!(vars.review_query.contains("state:open"));
-        // my_prs and issues fetch all states (open, closed, merged)
+        // my_prs and issues fetch all states (open, closed, merged) sorted by update time
         assert!(!vars.my_prs_query.contains("state:open"));
         assert!(!vars.issues_query.contains("state:open"));
+        assert!(vars.my_prs_query.contains("sort:updated"));
+        assert!(vars.issues_query.contains("sort:updated"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Remove hardcoded `state:open` filter from `my_prs_query` and `issues_query` in `build_query_variables()` so merged PRs and closed issues are synced to the local SQLite database
- Keep `state:open` on `review_query` (only open PRs need review)
- Add tests for query string correctness and PR/issue state transitions (open→merged, open→closed)

Closes #120

## Test plan

- [x] `test_build_query_variables` — verifies `state:open` absent from my_prs/issues queries, present in review query
- [x] `test_sync_updates_pr_state_open_to_merged` — PR state transition via upsert
- [x] `test_sync_updates_issue_state_open_to_closed` — Issue state transition via upsert
- [x] All 29 sync tests pass, 471 frontend tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync now fetches PRs and assigned issues in all states and sorts by last update, so merged PRs and closed issues are stored and recent activity isn’t dropped. Review queries still target only open PRs. Closes #120.

- **Bug Fixes**
  - Updated `build_query_variables()` to remove `state:open` from `my_prs_query`/`issues_query`, add `sort:updated`, and switch `issues_query` to use `assignee:` instead of `author:`.
  - Expanded tests for query strings (`assignee:`, no `state:open`, includes `sort:updated`) and state transitions (PR open→merged, issue open→closed).

<sup>Written for commit 05927d26e1d7dcf3b5d5b8f7abf720da9eb92bd3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cache synchronization now retrieves all PRs and issues (not limited to open) and applies recent-update sorting so lists reflect latest activity; review-requested PRs remain filtered to open.
* **Tests**
  * Updated tests to validate new query shapes and sorting.
  * Added tests verifying state transitions for PRs and issues and that the cache updates when item states change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->