### PR TITLE
fix(workspace): auto-archive workspaces for merged/closed PRs

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -309,6 +309,32 @@ pub(crate) async fn run_force_sync(
     if let Err(e) = app_handle.emit("github:updated", &stats) {
         warn!("failed to emit github:updated after force sync: {e}");
     }
+
+    // Post-sync: archive workspaces for merged/closed PRs past the configured delay.
+    let config = get_config(pool).await.unwrap_or_default();
+    let pty_state: tauri::State<'_, PtyManagerState> = app_handle.state();
+    match workspace_cleanup_inner(
+        pool,
+        &pty_state,
+        config.archive_delay_hours,
+        config.archive_delay_closed_hours,
+    )
+    .await
+    {
+        Ok(archived_ids) => {
+            for ws_id in &archived_ids {
+                let payload = crate::types::WorkspaceStateChanged {
+                    workspace_id: ws_id.clone(),
+                    new_state: WorkspaceState::Archived,
+                };
+                if let Err(e) = app_handle.emit("workspace:state_changed", &payload) {
+                    warn!("force-sync cleanup: failed to emit state_changed for '{ws_id}': {e}");
+                }
+            }
+        }
+        Err(e) => warn!("force-sync workspace cleanup failed: {e}"),
+    }
+
     Ok(stats)
 }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -311,7 +311,13 @@ pub(crate) async fn run_force_sync(
     }
 
     // Post-sync: archive workspaces for merged/closed PRs past the configured delay.
-    let config = get_config(pool).await.unwrap_or_default();
+    let config = match get_config(pool).await {
+        Ok(c) => c,
+        Err(e) => {
+            warn!("force-sync workspace cleanup: failed to read config: {e}");
+            return Ok(stats);
+        }
+    };
     let pty_state: tauri::State<'_, PtyManagerState> = app_handle.state();
     match workspace_cleanup_inner(
         pool,
@@ -330,6 +336,12 @@ pub(crate) async fn run_force_sync(
                 if let Err(e) = app_handle.emit("workspace:state_changed", &payload) {
                     warn!("force-sync cleanup: failed to emit state_changed for '{ws_id}': {e}");
                 }
+            }
+            if !archived_ids.is_empty() {
+                info!(
+                    "force-sync cleanup: archived {} workspace(s)",
+                    archived_ids.len()
+                );
             }
         }
         Err(e) => warn!("force-sync workspace cleanup failed: {e}"),

--- a/src-tauri/src/github/polling.rs
+++ b/src-tauri/src/github/polling.rs
@@ -8,7 +8,7 @@
 use std::time::Duration;
 
 use sqlx::SqlitePool;
-use tauri::{AppHandle, Emitter};
+use tauri::{AppHandle, Emitter, Manager};
 use tracing::{info, warn};
 
 use crate::cache::config::get_config;
@@ -37,6 +37,11 @@ pub(crate) trait PollingContext: Send + Sync + 'static {
 
     /// Notify the frontend that the token is expired/invalid (401).
     fn emit_auth_expired(&self, error: &str);
+
+    /// Archive workspaces whose PRs have been merged/closed. No-op by default.
+    fn cleanup_workspaces(&self) -> impl std::future::Future<Output = ()> + Send {
+        std::future::ready(())
+    }
 }
 
 // ── Real implementation ──────────────────────────────────────────
@@ -85,6 +90,44 @@ impl PollingContext for RealPollingContext {
             warn!("failed to emit auth:expired: {e}");
         }
     }
+
+    async fn cleanup_workspaces(&self) {
+        let config = match get_config(&self.pool).await {
+            Ok(c) => c,
+            Err(e) => {
+                warn!("post-sync cleanup: failed to read config: {e}");
+                return;
+            }
+        };
+        let pty_state: tauri::State<'_, crate::commands::PtyManagerState> = self.app_handle.state();
+        match crate::commands::workspace_cleanup_inner(
+            &self.pool,
+            &pty_state,
+            config.archive_delay_hours,
+            config.archive_delay_closed_hours,
+        )
+        .await
+        {
+            Ok(archived_ids) => {
+                for ws_id in &archived_ids {
+                    let payload = crate::types::WorkspaceStateChanged {
+                        workspace_id: ws_id.clone(),
+                        new_state: crate::types::WorkspaceState::Archived,
+                    };
+                    if let Err(e) = self.app_handle.emit("workspace:state_changed", &payload) {
+                        warn!("post-sync cleanup: failed to emit state_changed for '{ws_id}': {e}");
+                    }
+                }
+                if !archived_ids.is_empty() {
+                    info!(
+                        "post-sync cleanup: archived {} workspace(s)",
+                        archived_ids.len()
+                    );
+                }
+            }
+            Err(e) => warn!("post-sync cleanup failed: {e}"),
+        }
+    }
 }
 
 // ── Core loop ────────────────────────────────────────────────────
@@ -111,6 +154,7 @@ pub(crate) async fn poll_once(ctx: &(impl PollingContext + ?Sized)) -> PollOutco
                 stats.pending_reviews
             );
             ctx.emit_updated(&stats);
+            ctx.cleanup_workspaces().await;
             PollOutcome::Ok
         }
         // In the polling path, AppError::Auth can only originate from an HTTP 401
@@ -211,6 +255,7 @@ mod tests {
         updates: Arc<Mutex<Vec<DashboardStats>>>,
         errors: Arc<Mutex<Vec<String>>>,
         auth_expired: Arc<Mutex<Vec<String>>>,
+        cleanup_calls: Arc<Mutex<u32>>,
     }
 
     /// Mock context that returns pre-configured sync results.
@@ -265,6 +310,10 @@ mod tests {
                 .lock()
                 .expect("lock poisoned")
                 .push(error.to_string());
+        }
+
+        async fn cleanup_workspaces(&self) {
+            *self.recorder.cleanup_calls.lock().expect("lock poisoned") += 1;
         }
     }
 
@@ -501,5 +550,41 @@ mod tests {
         let updates = recorder.updates.lock().unwrap();
         assert_eq!(updates.len(), 1, "one successful update after recovery");
         assert_eq!(updates[0], stats, "recovered stats should match");
+    }
+
+    #[tokio::test]
+    async fn test_poll_once_calls_cleanup_on_success() {
+        let stats = make_stats(2);
+        let (ctx, recorder) = MockCtx::new(vec![Ok(stats)]);
+
+        let outcome = poll_once(&ctx).await;
+
+        assert!(
+            matches!(outcome, PollOutcome::Ok),
+            "poll_once should return Ok on success"
+        );
+        let calls = *recorder.cleanup_calls.lock().expect("lock poisoned");
+        assert_eq!(
+            calls, 1,
+            "cleanup_workspaces should be called once after a successful sync"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_poll_once_skips_cleanup_on_error() {
+        let err = AppError::GitHub("network error".into());
+        let (ctx, recorder) = MockCtx::new(vec![Err(err)]);
+
+        let outcome = poll_once(&ctx).await;
+
+        assert!(
+            matches!(outcome, PollOutcome::Failed),
+            "poll_once should return Failed on error"
+        );
+        let calls = *recorder.cleanup_calls.lock().expect("lock poisoned");
+        assert_eq!(
+            calls, 0,
+            "cleanup_workspaces should not be called on sync failure"
+        );
     }
 }

--- a/src-tauri/src/workspace/lifecycle.rs
+++ b/src-tauri/src/workspace/lifecycle.rs
@@ -640,4 +640,34 @@ mod tests {
 
         pool.close().await;
     }
+
+    #[tokio::test]
+    async fn test_cleanup_delay_zero_archives_immediately() {
+        let (pool, _tmp) = test_pool().await;
+        upsert_repo(&pool, &sample_repo()).await.unwrap();
+
+        // Merged PR with updated_at 1 second in the past so delay=0 catches it
+        let just_past =
+            (Utc::now() - Duration::seconds(1)).to_rfc3339_opts(SecondsFormat::Millis, true);
+        insert_test_pr(&pool, "pr-1", 42, crate::types::PrState::Merged, &just_past).await;
+
+        // Suspended workspace linked to this PR
+        let mut ws = sample_workspace("ws-1", 42);
+        ws.state = WorkspaceState::Suspended;
+        ws.worktree_path = None;
+        create_workspace(&pool, &ws).await.unwrap();
+
+        let pty_state = PtyManagerState::new();
+        let archived = workspace_cleanup_inner(&pool, &pty_state, 0, 0)
+            .await
+            .unwrap();
+
+        assert_eq!(archived.len(), 1, "delay=0 should archive immediately");
+        assert_eq!(archived[0], "ws-1");
+
+        let ws = get_workspace(&pool, "ws-1").await.unwrap().unwrap();
+        assert_eq!(ws.state, WorkspaceState::Archived);
+
+        pool.close().await;
+    }
 }

--- a/src/components/MyPRs/MyPrCard.test.tsx
+++ b/src/components/MyPRs/MyPrCard.test.tsx
@@ -239,4 +239,28 @@ describe("MyPrCard", () => {
       expect(dot).toHaveAttribute("aria-hidden", "true");
     }
   });
+
+  it("should NOT render WsBadge when PR is merged with suspended workspace", () => {
+    const data: PullRequestWithReview = {
+      ...basePr,
+      pullRequest: { ...basePr.pullRequest, state: "merged" },
+      workspace: { id: "ws-1", state: "suspended", lastNoteContent: null },
+    };
+    render(
+      <MyPrCard data={data} onOpen={vi.fn()} onWorkspaceAction={vi.fn()} />,
+    );
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("should render WsBadge when PR is open with suspended workspace", () => {
+    const data: PullRequestWithReview = {
+      ...basePr,
+      workspace: { id: "ws-1", state: "suspended", lastNoteContent: null },
+    };
+    render(
+      <MyPrCard data={data} onOpen={vi.fn()} onWorkspaceAction={vi.fn()} />,
+    );
+    expect(screen.getByRole("button", { name: "Wake workspace for PR #99" })).toBeInTheDocument();
+    expect(screen.getByText("wake")).toBeInTheDocument();
+  });
 });

--- a/src/components/MyPRs/MyPrCard.tsx
+++ b/src/components/MyPRs/MyPrCard.tsx
@@ -131,7 +131,7 @@ export function MyPrCard({
         </div>
       </a>
 
-      {onWorkspaceAction && ((workspace && workspace.state !== "archived") || ((pr.state === "open" || pr.state === "draft") && pr.headRefName)) && (
+      {onWorkspaceAction && (pr.state === "open" || pr.state === "draft") && ((workspace && workspace.state !== "archived") || pr.headRefName) && (
         <WsBadge
           state={workspace?.state === "archived" ? undefined : workspace?.state}
           loading={loading}

--- a/src/components/ReviewQueue/ReviewCard.test.tsx
+++ b/src/components/ReviewQueue/ReviewCard.test.tsx
@@ -121,4 +121,16 @@ describe("ReviewCard", () => {
     const link = screen.getByRole("link");
     expect(link).toHaveAttribute("aria-label", "PR #42: Fix login bug by alice");
   });
+
+  it("should NOT render WsBadge when PR is closed with suspended workspace", () => {
+    const data: PullRequestWithReview = {
+      ...mockData,
+      pullRequest: { ...mockData.pullRequest, state: "closed" },
+      workspace: { id: "ws-1", state: "suspended", lastNoteContent: null },
+    };
+    render(
+      <ReviewCard data={data} onOpen={vi.fn()} onWorkspaceAction={vi.fn()} />,
+    );
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
 });

--- a/src/components/ReviewQueue/ReviewCard.tsx
+++ b/src/components/ReviewQueue/ReviewCard.tsx
@@ -74,7 +74,7 @@ export function ReviewCard({
         </div>
       </a>
 
-      {onWorkspaceAction && ((workspace && workspace.state !== "archived") || (pr.state === "open" && pr.headRefName)) && (
+      {onWorkspaceAction && pr.state === "open" && ((workspace && workspace.state !== "archived") || pr.headRefName) && (
         <WsBadge
           state={workspace?.state === "archived" ? undefined : workspace?.state}
           loading={loading}


### PR DESCRIPTION
## Summary

Closes #121

- **Backend**: Trigger `workspace_cleanup_inner()` after each GitHub sync (polling loop + force-sync) using the user's configured `archive_delay_hours` / `archive_delay_closed_hours`. This ensures workspaces for merged/closed PRs are archived as soon as the delay is met, rather than waiting for the next 60s lifecycle tick.
- **Frontend**: Guard `WsBadge` ("Wake workspace" button) visibility on PR state — only show for open/draft PRs. Previously, the button appeared for merged PRs with suspended workspaces.
- **Tests**: 3 new Rust tests (post-sync cleanup invocation, delay=0 behavior) + 3 new TS tests (WsBadge hidden for merged/closed PRs)

## Changes

| File | Change |
|------|--------|
| `src-tauri/src/github/polling.rs` | Add `cleanup_workspaces()` to `PollingContext` trait (default no-op), implement in `RealPollingContext`, call after sync |
| `src-tauri/src/commands.rs` | Add post-sync cleanup in `run_force_sync()` |
| `src-tauri/src/workspace/lifecycle.rs` | Add `test_cleanup_delay_zero_archives_immediately` |
| `src/components/MyPRs/MyPrCard.tsx` | Guard WsBadge on `pr.state === "open" \|\| "draft"` |
| `src/components/ReviewQueue/ReviewCard.tsx` | Guard WsBadge on `pr.state === "open"` |
| `**/MyPrCard.test.tsx` | 2 new tests |
| `**/ReviewCard.test.tsx` | 1 new test |

## Test plan

- [x] `cargo test cleanup_delay_zero` — passes
- [x] `cargo test poll_once` — 2 tests pass
- [x] `npx vitest run` — 474 tests pass
- [x] `npx oxlint .` — 0 errors
- [ ] Manual: merge a PR, force sync, verify workspace archived + "Wake" button gone

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically archive workspaces for merged/closed PRs right after each successful GitHub sync, using the configured delays. Hide the "Wake workspace" button for non-open PRs to prevent waking invalid workspaces.

- **Bug Fixes**
  - After each successful sync (polling and force-sync), run cleanup using `archive_delay_hours` / `archive_delay_closed_hours`; warn and skip if config read fails.
  - Emit `workspace:state_changed` when archiving and log archived counts on force-sync.
  - Show `WsBadge` only for open/draft PRs in MyPRs and only for open PRs in Review Queue.
  - Tests cover cleanup invocation on success (skipped on error), delay=0 immediate archive, and button visibility.

<sup>Written for commit b1f2344b7dcb9a3d1c102a51c0042f2a59b1a15d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic workspace cleanup and archival now runs after successful syncs; archived workspaces trigger state-change notifications. Cleanup is best-effort and skipped on authentication or rate-limit failures.

* **Bug Fixes**
  * Workspace action badge/button visibility tightened: shown only for open (or draft, where applicable) PRs when workspace or branch info is available; hidden for archived/suspended cases.

* **Tests**
  * Added unit and integration tests covering cleanup behavior and badge rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->