### PR TITLE
fix(workspace): guard PTY commands for suspended workspaces

### DIFF
--- a/src/components/Workspace/Terminal.test.tsx
+++ b/src/components/Workspace/Terminal.test.tsx
@@ -205,4 +205,55 @@ describe("Terminal", () => {
       expect(unlistenStdout).toHaveBeenCalledOnce();
     });
   });
+
+  it("should not call ptyWrite when disabled", () => {
+    render(<Terminal ptyId="ws-1" disabled />);
+
+    expect(mockOnData).toHaveBeenCalledOnce();
+    const onDataCallback = (mockOnData as Mock).mock.calls[0]![0] as (data: string) => void;
+
+    onDataCallback("a");
+
+    expect(ptyWrite).not.toHaveBeenCalled();
+  });
+
+  it("should not call ptyResize when disabled", () => {
+    let resizeCallback: ResizeObserverCallback | null = null;
+    const mockObserve = vi.fn();
+    const mockDisconnect = vi.fn();
+
+    const MockResizeObserver = vi.fn(function (
+      this: { observe: Mock; disconnect: Mock; unobserve: Mock },
+      cb: ResizeObserverCallback,
+    ) {
+      resizeCallback = cb;
+      this.observe = mockObserve;
+      this.disconnect = mockDisconnect;
+      this.unobserve = vi.fn();
+    });
+
+    vi.stubGlobal("ResizeObserver", MockResizeObserver);
+
+    render(<Terminal ptyId="ws-1" disabled />);
+
+    act(() => {
+      resizeCallback!([], {} as ResizeObserver);
+    });
+
+    expect(ptyResize).not.toHaveBeenCalled();
+
+    vi.unstubAllGlobals();
+  });
+
+  it("should show suspended overlay when disabled", () => {
+    render(<Terminal ptyId="ws-1" disabled />);
+
+    expect(screen.getByTestId("terminal-suspended-overlay")).toBeInTheDocument();
+  });
+
+  it("should not show suspended overlay when enabled", () => {
+    render(<Terminal ptyId="ws-1" />);
+
+    expect(screen.queryByTestId("terminal-suspended-overlay")).toBeNull();
+  });
 });

--- a/src/components/Workspace/Terminal.tsx
+++ b/src/components/Workspace/Terminal.tsx
@@ -24,10 +24,13 @@ const PRISM_THEME = {
 
 interface TerminalProps {
   readonly ptyId: string;
+  readonly disabled?: boolean;
 }
 
-export function Terminal({ ptyId }: TerminalProps) {
+export function Terminal({ ptyId, disabled }: TerminalProps) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const disabledRef = useRef(disabled);
+  disabledRef.current = disabled;
 
   useEffect(() => {
     const container = containerRef.current;
@@ -50,6 +53,7 @@ export function Terminal({ ptyId }: TerminalProps) {
 
     // stdin: forward user keystrokes to PTY
     term.onData((data) => {
+      if (disabledRef.current) return;
       ptyWrite({ workspaceId: ptyId, data }).catch((err: unknown) => {
         console.error("[Terminal] ptyWrite failed:", err);
       });
@@ -65,6 +69,7 @@ export function Terminal({ ptyId }: TerminalProps) {
     // resize: observe container and notify PTY
     const resizeObserver = new ResizeObserver(() => {
       fitAddon.fit();
+      if (disabledRef.current) return;
       const dims = fitAddon.proposeDimensions();
       if (dims) {
         ptyResize({ workspaceId: ptyId, cols: dims.cols, rows: dims.rows }).catch(
@@ -86,10 +91,22 @@ export function Terminal({ ptyId }: TerminalProps) {
   }, [ptyId]);
 
   return (
-    <div
-      ref={containerRef}
-      data-testid={`terminal-${ptyId}`}
-      className="h-full w-full overflow-hidden bg-[#0a0a09]"
-    />
+    <div className="relative h-full w-full">
+      <div
+        ref={containerRef}
+        data-testid={`terminal-${ptyId}`}
+        className="h-full w-full overflow-hidden bg-[#0a0a09]"
+      />
+      {disabled && (
+        <div
+          data-testid="terminal-suspended-overlay"
+          className="absolute inset-0 flex items-center justify-center bg-black/70"
+        >
+          <p className="text-sm text-neutral-400">
+            Workspace suspended
+          </p>
+        </div>
+      )}
+    </div>
   );
 }

--- a/src/components/Workspace/Terminal.tsx
+++ b/src/components/Workspace/Terminal.tsx
@@ -103,7 +103,7 @@ export function Terminal({ ptyId, disabled }: TerminalProps) {
           className="absolute inset-0 flex items-center justify-center bg-black/70"
         >
           <p className="text-sm text-neutral-400">
-            Workspace suspended
+            Workspace suspended — click Wake to resume
           </p>
         </div>
       )}

--- a/src/components/Workspace/WorkspaceView.test.tsx
+++ b/src/components/Workspace/WorkspaceView.test.tsx
@@ -20,14 +20,14 @@ vi.mock("./WorkspaceSwitcher", () => ({
 }));
 
 vi.mock("./Terminal", () => ({
-  Terminal: ({ ptyId }: { ptyId: string }) => (
-    <div data-testid={`terminal-${ptyId}`} />
+  Terminal: ({ ptyId, disabled }: { ptyId: string; disabled?: boolean }) => (
+    <div data-testid={`terminal-${ptyId}`} data-disabled={disabled ? "true" : "false"} />
   ),
 }));
 
 vi.mock("./WorkspaceStatusBar", () => ({
-  WorkspaceStatusBar: ({ workspaceId }: { workspaceId: string }) => (
-    <div data-testid="workspace-statusbar">{workspaceId}</div>
+  WorkspaceStatusBar: ({ workspaceId, disabled }: { workspaceId: string; disabled?: boolean }) => (
+    <div data-testid="workspace-statusbar" data-disabled={disabled ? "true" : "false"}>{workspaceId}</div>
   ),
 }));
 
@@ -284,6 +284,39 @@ describe("WorkspaceView", () => {
       expect(resumeWorkspace).not.toHaveBeenCalled();
       expect(setActiveWorkspace).toHaveBeenCalledWith("ws-click");
     });
+  });
+
+  it("should pass disabled=false to Terminal for active workspace", () => {
+    useWorkspacesStore.setState({ activeWorkspaceId: "ws-1" });
+
+    renderWithQuery(
+      <WorkspaceView
+        workspaces={WORKSPACES}
+        statusInfo={STATUS_INFO}
+        entries={[]}
+        onBackToDashboard={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("terminal-ws-1")).toHaveAttribute("data-disabled", "false");
+  });
+
+  it("should pass disabled=true to Terminal and StatusBar for suspended workspace", () => {
+    act(() => {
+      useWorkspacesStore.setState({ activeWorkspaceId: "ws-2" });
+    });
+
+    renderWithQuery(
+      <WorkspaceView
+        workspaces={WORKSPACES}
+        statusInfo={STATUS_INFO}
+        entries={[]}
+        onBackToDashboard={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("terminal-ws-2")).toHaveAttribute("data-disabled", "true");
+    expect(screen.getByTestId("workspace-statusbar")).toHaveAttribute("data-disabled", "true");
   });
 
   it("should call resumeWorkspace then set active when clicking a suspended workspace", async () => {

--- a/src/components/Workspace/WorkspaceView.test.tsx
+++ b/src/components/Workspace/WorkspaceView.test.tsx
@@ -21,13 +21,13 @@ vi.mock("./WorkspaceSwitcher", () => ({
 
 vi.mock("./Terminal", () => ({
   Terminal: ({ ptyId, disabled }: { ptyId: string; disabled?: boolean }) => (
-    <div data-testid={`terminal-${ptyId}`} data-disabled={disabled ? "true" : "false"} />
+    <div data-testid={`terminal-${ptyId}`} data-disabled={String(disabled)} />
   ),
 }));
 
 vi.mock("./WorkspaceStatusBar", () => ({
   WorkspaceStatusBar: ({ workspaceId, disabled }: { workspaceId: string; disabled?: boolean }) => (
-    <div data-testid="workspace-statusbar" data-disabled={disabled ? "true" : "false"}>{workspaceId}</div>
+    <div data-testid="workspace-statusbar" data-disabled={String(disabled)}>{workspaceId}</div>
   ),
 }));
 

--- a/src/components/Workspace/WorkspaceView.tsx
+++ b/src/components/Workspace/WorkspaceView.tsx
@@ -26,7 +26,7 @@ export function WorkspaceView({
   const setActiveWorkspace = useWorkspacesStore((s) => s.setActiveWorkspace);
   const active = workspaces.find((w) => w.id === activeWorkspaceId);
   const info = active ? statusInfo[active.id] : undefined;
-  const isSuspended = active !== undefined && active.state !== "active";
+  const isSuspended = active !== undefined && active.state === "suspended";
 
   const visibleEntries = useMemo(
     () => entries.filter((e) => e.workspace.state !== "archived"),

--- a/src/components/Workspace/WorkspaceView.tsx
+++ b/src/components/Workspace/WorkspaceView.tsx
@@ -26,6 +26,7 @@ export function WorkspaceView({
   const setActiveWorkspace = useWorkspacesStore((s) => s.setActiveWorkspace);
   const active = workspaces.find((w) => w.id === activeWorkspaceId);
   const info = active ? statusInfo[active.id] : undefined;
+  const isSuspended = active !== undefined && active.state !== "active";
 
   const visibleEntries = useMemo(
     () => entries.filter((e) => e.workspace.state !== "archived"),
@@ -64,7 +65,7 @@ export function WorkspaceView({
       {active ? (
         <>
           <div className="min-h-0 flex-1">
-            <Terminal ptyId={active.id} />
+            <Terminal ptyId={active.id} disabled={isSuspended} />
           </div>
           {info && (
             <WorkspaceStatusBar
@@ -76,6 +77,7 @@ export function WorkspaceView({
               sessionName={info.sessionName}
               sessionCount={info.sessionCount}
               githubUrl={info.githubUrl}
+              disabled={isSuspended}
             />
           )}
         </>


### PR DESCRIPTION
## Summary

- Guard `ptyWrite` and `ptyResize` IPC calls in Terminal component when workspace is not active
- Show "Workspace suspended" overlay instead of empty black terminal with errors
- Pass `disabled` prop from WorkspaceView to both Terminal and WorkspaceStatusBar

Closes #122

## Changes

- **Terminal.tsx**: Added `disabled` prop with `useRef` for stale closure access. Guards PTY calls and renders suspended overlay
- **WorkspaceView.tsx**: Computes `isSuspended` from workspace state, passes `disabled` to Terminal and StatusBar
- **Terminal.test.tsx**: 4 new tests (no ptyWrite/ptyResize when disabled, overlay visibility)
- **WorkspaceView.test.tsx**: 2 new tests (disabled prop passing for active/suspended workspaces)

## Test plan

- [x] 480/480 tests passing (6 new + 474 existing)
- [x] oxlint: 0 warnings, 0 errors
- [ ] Manual: open suspended workspace tab, verify no console errors
- [ ] Manual: verify overlay appears with "Workspace suspended" text
- [ ] Manual: wake workspace, verify terminal resumes normally

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes PTY errors in suspended workspaces by disabling terminal input/resize and showing a clear "Workspace suspended — click Wake to resume" overlay. `WorkspaceView` now passes a `disabled` state to `Terminal` and `WorkspaceStatusBar` based on `state === "suspended"`.

- **Bug Fixes**
  - Guard `ptyWrite` and `ptyResize` in `Terminal` using a `disabled` ref.
  - Show a suspended overlay with a wake instruction instead of an empty terminal.
  - Compute `isSuspended` with `state === "suspended"` and pass `disabled` to `Terminal` and `WorkspaceStatusBar`.

<sup>Written for commit 2fd79c17da4840f40f8a105a8413f0af5d4fd58c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Suspended workspaces show a full overlay on the terminal with a "Workspace suspended — click Wake to resume" message and block interaction.
  * Terminal and status bar render as disabled when a workspace is suspended.

* **Tests**
  * Added tests verifying terminal disabled behavior, overlay rendering, and suspension state propagation to terminal and status bar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->