### PR TITLE
fix(ui): include suspended workspaces in stats counter

### DIFF
--- a/src-tauri/src/cache/dashboard.rs
+++ b/src-tauri/src/cache/dashboard.rs
@@ -222,7 +222,7 @@ fn count_to_u32(count: i64) -> u32 {
 /// - `pending_reviews`: review requests for the user with status `pending` (open/draft PRs only)
 /// - `open_prs`: pull requests authored by the user in `open` or `draft` state
 /// - `open_issues`: issues authored by the user in `open` state
-/// - `active_workspaces`: all workspaces in `active` state (global, not user-scoped)
+/// - `total_workspaces`: all workspaces in `active` or `suspended` state (excludes archived) (global, not user-scoped)
 /// - `unread_activity`: all activity events with `is_read = 0` (global, not user-scoped)
 pub async fn compute_dashboard_stats(
     pool: &SqlitePool,
@@ -236,7 +236,7 @@ pub async fn compute_dashboard_stats(
           AND pr.state IN ('open', 'draft')), \
          (SELECT COUNT(*) FROM pull_requests WHERE author = $1 AND state IN ('open', 'draft')), \
          (SELECT COUNT(*) FROM issues WHERE author = $1 AND state = 'open'), \
-         (SELECT COUNT(*) FROM workspaces WHERE state = 'active'), \
+         (SELECT COUNT(*) FROM workspaces WHERE state IN ('active', 'suspended')), \
          (SELECT COUNT(*) FROM activity WHERE is_read = 0)",
     )
     .bind(username)
@@ -247,7 +247,7 @@ pub async fn compute_dashboard_stats(
         pending_reviews: count_to_u32(row.0),
         open_prs: count_to_u32(row.1),
         open_issues: count_to_u32(row.2),
-        active_workspaces: count_to_u32(row.3),
+        total_workspaces: count_to_u32(row.3),
         unread_activity: count_to_u32(row.4),
     })
 }
@@ -547,7 +547,7 @@ mod tests {
         assert_eq!(stats.pending_reviews, 0);
         assert_eq!(stats.open_prs, 0);
         assert_eq!(stats.open_issues, 0);
-        assert_eq!(stats.active_workspaces, 0);
+        assert_eq!(stats.total_workspaces, 0);
         assert_eq!(stats.unread_activity, 0);
         pool.close().await;
     }
@@ -623,6 +623,18 @@ mod tests {
             updated_at: "2026-03-20T10:00:00Z".to_string(),
         };
         create_workspace(&pool, &ws).await.unwrap();
+        // 1 suspended workspace (should also count)
+        let ws2 = Workspace {
+            id: "ws-2".to_string(),
+            repo_id: "repo-1".to_string(),
+            pull_request_number: 2,
+            state: WorkspaceState::Suspended,
+            worktree_path: None,
+            session_id: None,
+            created_at: "2026-03-20T10:00:00Z".to_string(),
+            updated_at: "2026-03-20T10:00:00Z".to_string(),
+        };
+        create_workspace(&pool, &ws2).await.unwrap();
 
         // 2 unread activities, 1 read (should not count)
         let act1 = Activity {
@@ -659,7 +671,7 @@ mod tests {
         assert_eq!(stats.pending_reviews, 1, "only pending review requests");
         assert_eq!(stats.open_prs, 2, "only open/draft PRs by alice");
         assert_eq!(stats.open_issues, 1, "only open issues by alice");
-        assert_eq!(stats.active_workspaces, 1, "only active workspaces");
+        assert_eq!(stats.total_workspaces, 2, "active + suspended workspaces");
         assert_eq!(stats.unread_activity, 1, "only unread activity");
         pool.close().await;
     }

--- a/src-tauri/src/cache/stats.rs
+++ b/src-tauri/src/cache/stats.rs
@@ -12,7 +12,7 @@ use crate::types::PersonalStats;
 /// - `avg_review_response_hours`: average hours between review request and review submission
 ///   for this user as reviewer (all time). `0.0` when no data.
 /// - `reviews_given_this_week`: reviews submitted by the user in the current ISO week.
-/// - `active_workspace_count`: workspaces in `active` state (global, not user-scoped —
+/// - `total_workspace_count`: workspaces in `active` or `suspended` state (global, not user-scoped —
 ///   the workspaces table has no owner column).
 pub async fn compute_personal_stats(
     pool: &SqlitePool,
@@ -46,7 +46,7 @@ pub async fn compute_personal_stats(
          (SELECT COUNT(*) FROM reviews \
           WHERE reviewer = $1 \
           AND submitted_at >= {monday}), \
-         (SELECT COUNT(*) FROM workspaces WHERE state = 'active')"
+         (SELECT COUNT(*) FROM workspaces WHERE state IN ('active', 'suspended'))"
     );
 
     let row: (i64, f64, i64, i64) = sqlx::query_as(&sql).bind(username).fetch_one(pool).await?;
@@ -56,7 +56,7 @@ pub async fn compute_personal_stats(
         prs_merged_this_week: u32::try_from(row.0).unwrap_or(u32::MAX),
         avg_review_response_hours: if row.1 < 0.0 { 0.0 } else { row.1 },
         reviews_given_this_week: u32::try_from(row.2).unwrap_or(u32::MAX),
-        active_workspace_count: u32::try_from(row.3).unwrap_or(u32::MAX),
+        total_workspace_count: u32::try_from(row.3).unwrap_or(u32::MAX),
     })
 }
 
@@ -136,7 +136,7 @@ mod tests {
         assert_eq!(stats.prs_merged_this_week, 0);
         assert_eq!(stats.avg_review_response_hours, 0.0);
         assert_eq!(stats.reviews_given_this_week, 0);
-        assert_eq!(stats.active_workspace_count, 0);
+        assert_eq!(stats.total_workspace_count, 0);
 
         pool.close().await;
     }
@@ -195,7 +195,7 @@ mod tests {
         };
         create_workspace(&pool, &ws).await.unwrap();
 
-        // 1 suspended workspace (should not count)
+        // 1 suspended workspace (should also count)
         let ws2 = Workspace {
             id: "ws-2".to_string(),
             repo_id: "repo-1".to_string(),
@@ -223,7 +223,10 @@ mod tests {
             stats.reviews_given_this_week, 1,
             "1 review by alice this week"
         );
-        assert_eq!(stats.active_workspace_count, 1, "1 active workspace");
+        assert_eq!(
+            stats.total_workspace_count, 2,
+            "active + suspended workspaces"
+        );
 
         pool.close().await;
     }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1564,14 +1564,14 @@ mod tests {
             pending_reviews: 3,
             open_prs: 7,
             open_issues: 2,
-            active_workspaces: 1,
+            total_workspaces: 1,
             unread_activity: 5,
         };
         let json = serde_json::to_value(&stats).unwrap();
         assert_eq!(json["pendingReviews"], 3);
         assert_eq!(json["openPrs"], 7);
         assert_eq!(json["openIssues"], 2);
-        assert_eq!(json["activeWorkspaces"], 1);
+        assert_eq!(json["totalWorkspaces"], 1);
         assert_eq!(json["unreadActivity"], 5);
     }
 

--- a/src-tauri/src/github/polling.rs
+++ b/src-tauri/src/github/polling.rs
@@ -322,7 +322,7 @@ mod tests {
             pending_reviews: pending,
             open_prs: 5,
             open_issues: 2,
-            active_workspaces: 1,
+            total_workspaces: 1,
             unread_activity: 0,
         }
     }

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -278,7 +278,7 @@ pub struct DashboardStats {
     pub pending_reviews: u32,
     pub open_prs: u32,
     pub open_issues: u32,
-    pub active_workspaces: u32,
+    pub total_workspaces: u32,
     pub unread_activity: u32,
 }
 
@@ -289,7 +289,7 @@ pub struct PersonalStats {
     pub prs_merged_this_week: u32,
     pub avg_review_response_hours: f64,
     pub reviews_given_this_week: u32,
-    pub active_workspace_count: u32,
+    pub total_workspace_count: u32,
 }
 
 // ── IPC payloads (T-011) ──────────────────────────────────────
@@ -1006,14 +1006,14 @@ mod tests {
             pending_reviews: 5,
             open_prs: 12,
             open_issues: 3,
-            active_workspaces: 2,
+            total_workspaces: 2,
             unread_activity: 8,
         };
         let json = serde_json::to_string(&stats).unwrap();
         assert!(json.contains("\"pendingReviews\""));
         assert!(json.contains("\"openPrs\""));
         assert!(json.contains("\"openIssues\""));
-        assert!(json.contains("\"activeWorkspaces\""));
+        assert!(json.contains("\"totalWorkspaces\""));
         assert!(json.contains("\"unreadActivity\""));
         let deserialized: DashboardStats = serde_json::from_str(&json).unwrap();
         assert_eq!(stats, deserialized);
@@ -1025,13 +1025,13 @@ mod tests {
             prs_merged_this_week: 3,
             avg_review_response_hours: 2.5,
             reviews_given_this_week: 7,
-            active_workspace_count: 1,
+            total_workspace_count: 1,
         };
         let json = serde_json::to_string(&stats).unwrap();
         assert!(json.contains("\"prsMergedThisWeek\""));
         assert!(json.contains("\"avgReviewResponseHours\""));
         assert!(json.contains("\"reviewsGivenThisWeek\""));
-        assert!(json.contains("\"activeWorkspaceCount\""));
+        assert!(json.contains("\"totalWorkspaceCount\""));
         let deserialized: PersonalStats = serde_json::from_str(&json).unwrap();
         assert_eq!(stats, deserialized);
     }

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -15,7 +15,7 @@ vi.mock("./lib/tauri", async (importOriginal) => {
 vi.mock("./hooks/useGitHubData", () => ({
   useGitHubData: vi.fn().mockReturnValue({
     dashboard: { syncedAt: "2026-03-28T10:00:00Z", reviewRequests: [], myPullRequests: [], assignedIssues: [], recentActivity: [], workspaces: [] },
-    stats: { pendingReviews: 3, openPrs: 5, openIssues: 2, activeWorkspaces: 1, unreadActivity: 0 },
+    stats: { pendingReviews: 3, openPrs: 5, openIssues: 2, totalWorkspaces: 1, unreadActivity: 0 },
     isLoading: false,
     error: null,
     authExpired: false,

--- a/src/components/Settings/Settings.test.tsx
+++ b/src/components/Settings/Settings.test.tsx
@@ -88,7 +88,7 @@ function makePersonalStats(overrides: Partial<PersonalStats> = {}): PersonalStat
     prsMergedThisWeek: 3,
     avgReviewResponseHours: 2.5,
     reviewsGivenThisWeek: 7,
-    activeWorkspaceCount: 1,
+    totalWorkspaceCount: 1,
     ...overrides,
   };
 }
@@ -344,7 +344,7 @@ describe("Settings", () => {
         prsMergedThisWeek: 5,
         avgReviewResponseHours: 3.2,
         reviewsGivenThisWeek: 12,
-        activeWorkspaceCount: 2,
+        totalWorkspaceCount: 2,
       }),
     );
 

--- a/src/components/Settings/Stats.tsx
+++ b/src/components/Settings/Stats.tsx
@@ -52,7 +52,7 @@ export function Stats(): ReactElement {
       <StatItem label="PRs merged this week" value={String(stats.prsMergedThisWeek)} />
       <StatItem label="Avg review response" value={avgHours} />
       <StatItem label="Reviews given this week" value={String(stats.reviewsGivenThisWeek)} />
-      <StatItem label="Active workspaces" value={String(stats.activeWorkspaceCount)} />
+      <StatItem label="Workspaces" value={String(stats.totalWorkspaceCount)} />
     </div>
   );
 }

--- a/src/components/Sidebar/Sidebar.test.tsx
+++ b/src/components/Sidebar/Sidebar.test.tsx
@@ -12,7 +12,7 @@ vi.mock("../../hooks/useGitHubData", () => ({
       pendingReviews: 3,
       openPrs: 7,
       openIssues: 2,
-      activeWorkspaces: 1,
+      totalWorkspaces: 1,
       unreadActivity: 4,
     },
     dashboard: {

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -12,7 +12,7 @@ import { RepoList } from "./RepoList";
 interface NavEntry {
   readonly label: string;
   readonly view: DashboardView;
-  readonly countKey?: "pendingReviews" | "openPrs" | "openIssues" | "activeWorkspaces" | "unreadActivity";
+  readonly countKey?: "pendingReviews" | "openPrs" | "openIssues" | "totalWorkspaces" | "unreadActivity";
 }
 
 const NAV_ITEMS: readonly NavEntry[] = [
@@ -21,7 +21,7 @@ const NAV_ITEMS: readonly NavEntry[] = [
   { label: "My PRs", view: "mine", countKey: "openPrs" },
   { label: "Issues", view: "issues", countKey: "openIssues" },
   { label: "Activity", view: "feed", countKey: "unreadActivity" },
-  { label: "Workspaces", view: "workspaces", countKey: "activeWorkspaces" },
+  { label: "Workspaces", view: "workspaces", countKey: "totalWorkspaces" },
   { label: "Settings", view: "settings" },
 ];
 

--- a/src/components/StatsBar/StatsBar.test.tsx
+++ b/src/components/StatsBar/StatsBar.test.tsx
@@ -16,7 +16,7 @@ const MOCK_STATS: DashboardStats = {
   pendingReviews: 3,
   openPrs: 5,
   openIssues: 2,
-  activeWorkspaces: 1,
+  totalWorkspaces: 1,
   unreadActivity: 7,
 };
 

--- a/src/components/StatsBar/StatsBar.tsx
+++ b/src/components/StatsBar/StatsBar.tsx
@@ -79,7 +79,7 @@ export function StatsBar(): ReactElement {
         />
         <StatItem
           label="Workspaces"
-          value={stats?.activeWorkspaces ?? null}
+          value={stats?.totalWorkspaces ?? null}
           testId="stat-workspaces"
         />
       </div>

--- a/src/hooks/useGitHubData.test.ts
+++ b/src/hooks/useGitHubData.test.ts
@@ -32,7 +32,7 @@ const MOCK_STATS: DashboardStats = {
   pendingReviews: 3,
   openPrs: 5,
   openIssues: 2,
-  activeWorkspaces: 1,
+  totalWorkspaces: 1,
   unreadActivity: 7,
 };
 

--- a/src/lib/types.test.ts
+++ b/src/lib/types.test.ts
@@ -308,7 +308,7 @@ describe("Composite struct shapes", () => {
       pendingReviews: 5,
       openPrs: 12,
       openIssues: 3,
-      activeWorkspaces: 2,
+      totalWorkspaces: 2,
       unreadActivity: 8,
     };
     const stats = coerceFixture<DashboardStats>(json);
@@ -321,7 +321,7 @@ describe("Composite struct shapes", () => {
       prsMergedThisWeek: 3,
       avgReviewResponseHours: 2.5,
       reviewsGivenThisWeek: 7,
-      activeWorkspaceCount: 1,
+      totalWorkspaceCount: 1,
     };
     const stats = coerceFixture<PersonalStats>(json);
     expect(stats.prsMergedThisWeek).toBe(3);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -167,7 +167,7 @@ export interface DashboardStats {
   readonly pendingReviews: number;
   readonly openPrs: number;
   readonly openIssues: number;
-  readonly activeWorkspaces: number;
+  readonly totalWorkspaces: number;
   readonly unreadActivity: number;
 }
 
@@ -185,7 +185,7 @@ export interface PersonalStats {
   readonly prsMergedThisWeek: number;
   readonly avgReviewResponseHours: number;
   readonly reviewsGivenThisWeek: number;
-  readonly activeWorkspaceCount: number;
+  readonly totalWorkspaceCount: number;
 }
 
 // ── IPC payloads (T-011) ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Stats bar showed "0 Workspaces" despite suspended workspaces existing in the sidebar
- SQL queries in `dashboard.rs` and `stats.rs` only counted `state = 'active'`, excluding suspended workspaces
- Changed to `state IN ('active', 'suspended')` to include suspended workspaces in the count
- Renamed `active_workspaces` → `total_workspaces` across the full stack for clarity

Closes #123

## Test plan

- [x] Rust tests updated — suspended workspace now counted (assertion: active + suspended = 2)
- [x] `cargo test` passes (346 tests)
- [x] `npx vitest run` passes (480 tests)
- [x] TypeScript typecheck passes
- [x] oxlint passes (0 errors)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Workspaces counter to include suspended workspaces, so the stats bar no longer shows 0 when only suspended workspaces exist. Renames the metric to “total workspaces” for clarity. Closes #123.

- **Bug Fixes**
  - SQL now counts `state IN ('active', 'suspended')` in `dashboard.rs` and `stats.rs` (excludes archived).
  - Renamed fields: `active_workspaces` → `total_workspaces` and `activeWorkspaceCount` → `totalWorkspaceCount` (Rust structs, JSON keys, TS types, IPC).
  - Updated Sidebar/StatsBar/Settings to display the new count/label; all tests and mocks updated.

<sup>Written for commit d78dbda13da6ae36cfaa2abe24a33aa936f60d30. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated workspace count metrics to include both active and suspended workspaces in the total displayed. Workspace labels updated in dashboard and statistics displays to reflect this change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->