### PR TITLE
fix(ui): display repo name in issues page

### DIFF
--- a/src/components/Issues/IssueCard.test.tsx
+++ b/src/components/Issues/IssueCard.test.tsx
@@ -23,7 +23,7 @@ function makeIssue(overrides: Partial<Issue> = {}): Issue {
 
 describe("IssueCard", () => {
   it("should render issue with title and number", () => {
-    render(<IssueCard issue={makeIssue()} onOpen={vi.fn()} />);
+    render(<IssueCard issue={makeIssue()} repoName="repo-name" onOpen={vi.fn()} />);
 
     expect(screen.getByText("Fix login bug")).toBeInTheDocument();
     expect(screen.getByText("#42")).toBeInTheDocument();
@@ -33,6 +33,7 @@ describe("IssueCard", () => {
     render(
       <IssueCard
         issue={makeIssue({ labels: ["bug", "enhancement"] })}
+        repoName="repo-name"
         onOpen={vi.fn()}
       />,
     );
@@ -42,7 +43,7 @@ describe("IssueCard", () => {
   });
 
   it("should show green dot for open issues", () => {
-    render(<IssueCard issue={makeIssue({ state: "open" })} onOpen={vi.fn()} />);
+    render(<IssueCard issue={makeIssue({ state: "open" })} repoName="repo-name" onOpen={vi.fn()} />);
 
     const dot = screen.getByTestId("issue-state-dot");
     expect(dot.className).toContain("bg-green");
@@ -50,23 +51,23 @@ describe("IssueCard", () => {
 
   it("should show purple dot for closed issues", () => {
     render(
-      <IssueCard issue={makeIssue({ state: "closed" })} onOpen={vi.fn()} />,
+      <IssueCard issue={makeIssue({ state: "closed" })} repoName="repo-name" onOpen={vi.fn()} />,
     );
 
     const dot = screen.getByTestId("issue-state-dot");
     expect(dot.className).toContain("bg-purple");
   });
 
-  it("should display repo id", () => {
+  it("should display repo name", () => {
     render(
-      <IssueCard issue={makeIssue({ repoId: "my-repo" })} onOpen={vi.fn()} />,
+      <IssueCard issue={makeIssue({ repoId: "repo-1" })} repoName="my-repo" onOpen={vi.fn()} />,
     );
 
     expect(screen.getByText("my-repo")).toBeInTheDocument();
   });
 
   it("should display relative time", () => {
-    render(<IssueCard issue={makeIssue()} onOpen={vi.fn()} />);
+    render(<IssueCard issue={makeIssue()} repoName="repo-name" onOpen={vi.fn()} />);
 
     expect(screen.getByTestId("time-ago")).toBeInTheDocument();
   });
@@ -75,7 +76,7 @@ describe("IssueCard", () => {
     const onOpen = vi.fn();
     const user = userEvent.setup();
 
-    render(<IssueCard issue={makeIssue()} onOpen={onOpen} />);
+    render(<IssueCard issue={makeIssue()} repoName="repo-name" onOpen={onOpen} />);
 
     await user.click(screen.getByText("Fix login bug"));
 
@@ -85,13 +86,13 @@ describe("IssueCard", () => {
   });
 
   it("should have aria-label on link describing the issue", () => {
-    render(<IssueCard issue={makeIssue()} onOpen={vi.fn()} />);
+    render(<IssueCard issue={makeIssue()} repoName="repo-name" onOpen={vi.fn()} />);
     const link = screen.getByRole("link");
     expect(link).toHaveAttribute("aria-label", "Issue #42: Fix login bug (open)");
   });
 
   it("should mark state dot as aria-hidden", () => {
-    render(<IssueCard issue={makeIssue()} onOpen={vi.fn()} />);
+    render(<IssueCard issue={makeIssue()} repoName="repo-name" onOpen={vi.fn()} />);
     const dot = screen.getByTestId("issue-state-dot");
     expect(dot).toHaveAttribute("aria-hidden", "true");
   });

--- a/src/components/Issues/IssueCard.tsx
+++ b/src/components/Issues/IssueCard.tsx
@@ -5,6 +5,7 @@ import { LabelTag } from "../atoms/LabelTag";
 
 interface IssueCardProps {
   readonly issue: Issue;
+  readonly repoName: string;
   readonly onOpen: (url: string) => void;
 }
 
@@ -13,7 +14,7 @@ const STATE_DOT_COLOR: Record<IssueState, string> = {
   closed: "bg-purple",
 };
 
-export function IssueCard({ issue, onOpen }: IssueCardProps): ReactElement {
+export function IssueCard({ issue, repoName, onOpen }: IssueCardProps): ReactElement {
   function handleClick(e: MouseEvent) {
     e.preventDefault();
     onOpen(issue.url);
@@ -40,7 +41,7 @@ export function IssueCard({ issue, onOpen }: IssueCardProps): ReactElement {
       </div>
 
       <div className="flex min-w-0 items-center gap-2 pl-[18px]">
-        <span className="shrink-0 truncate text-xs text-dim">{issue.repoId}</span>
+        <span className="shrink-0 truncate text-xs text-dim">{repoName}</span>
         {issue.labels.length > 0 && (
           <span className="flex min-w-0 items-center gap-1 overflow-hidden">
             {issue.labels.map((label) => (

--- a/src/components/Issues/Issues.test.tsx
+++ b/src/components/Issues/Issues.test.tsx
@@ -1,8 +1,34 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { Issue } from "../../lib/types";
+import type { Issue, Repo } from "../../lib/types";
 import { Issues } from "./Issues";
+
+const { mockUseQuery } = vi.hoisted(() => ({ mockUseQuery: vi.fn() }));
+
+vi.mock("@tanstack/react-query", async () => {
+  const actual = await vi.importActual("@tanstack/react-query");
+  return {
+    ...actual,
+    useQuery: mockUseQuery,
+  };
+});
+
+function makeRepo(overrides: Partial<Repo> = {}): Repo {
+  return {
+    id: "repo-1",
+    org: "org",
+    name: "repo",
+    fullName: "org/repo",
+    url: "https://github.com/org/repo",
+    defaultBranch: "main",
+    isArchived: false,
+    enabled: true,
+    localPath: null,
+    lastSyncAt: null,
+    ...overrides,
+  };
+}
 
 function makeIssue(overrides: Partial<Issue> = {}): Issue {
   return {
@@ -32,6 +58,7 @@ const onOpen = vi.fn();
 
 beforeEach(() => {
   onOpen.mockClear();
+  mockUseQuery.mockReturnValue({ data: [makeRepo()] });
 });
 
 describe("Issues", () => {
@@ -95,5 +122,27 @@ describe("Issues", () => {
     await user.click(screen.getByText("Open issue one"));
 
     expect(onOpen).toHaveBeenCalledWith(openIssue1.url);
+  });
+
+  it("should display repo name instead of repo id", () => {
+    render(<Issues issues={[openIssue1]} onOpen={onOpen} />);
+
+    expect(screen.getByText("repo")).toBeInTheDocument();
+  });
+
+  it("should use fullName when repo names are ambiguous", () => {
+    const issue1 = makeIssue({ number: 1, title: "Issue in org-a", state: "open", repoId: "repo-a" });
+    const issue2 = makeIssue({ number: 2, title: "Issue in org-b", state: "open", repoId: "repo-b" });
+    mockUseQuery.mockReturnValue({
+      data: [
+        makeRepo({ id: "repo-a", org: "org-a", name: "shared", fullName: "org-a/shared" }),
+        makeRepo({ id: "repo-b", org: "org-b", name: "shared", fullName: "org-b/shared" }),
+      ],
+    });
+
+    render(<Issues issues={[issue1, issue2]} onOpen={onOpen} />);
+
+    expect(screen.getByText("org-a/shared")).toBeInTheDocument();
+    expect(screen.getByText("org-b/shared")).toBeInTheDocument();
   });
 });

--- a/src/components/Issues/Issues.tsx
+++ b/src/components/Issues/Issues.tsx
@@ -1,4 +1,6 @@
+import { useQuery } from "@tanstack/react-query";
 import { type ReactElement, useMemo, useState } from "react";
+import { listRepos } from "../../lib/tauri";
 import type { Issue } from "../../lib/types";
 import { useRegisterNavigableItems } from "../../hooks/useRegisterNavigableItems";
 import { EmptyState } from "../atoms/EmptyState";
@@ -22,6 +24,22 @@ function isClosed(issue: Issue): boolean {
 
 export function Issues({ issues, onOpen }: IssuesProps): ReactElement {
   const [tab, setTab] = useState<Tab>("open");
+
+  const { data: repos } = useQuery({ queryKey: ["repos"], queryFn: listRepos });
+
+  const repoMap = useMemo<Map<string, string>>(() => {
+    if (!repos) return new Map();
+    const nameCounts = new Map<string, number>();
+    for (const repo of repos) {
+      nameCounts.set(repo.name, (nameCounts.get(repo.name) ?? 0) + 1);
+    }
+    return new Map(
+      repos.map((repo) => [
+        repo.id,
+        nameCounts.get(repo.name) === 1 ? repo.name : repo.fullName,
+      ]),
+    );
+  }, [repos]);
 
   const openIssues = issues.filter(isOpen);
   const closedIssues = issues.filter(isClosed);
@@ -72,7 +90,7 @@ export function Issues({ issues, onOpen }: IssuesProps): ReactElement {
       ) : (
         <div className="flex flex-col gap-1">
           {visible.map((issue) => (
-            <IssueCard key={issue.id} issue={issue} onOpen={onOpen} />
+            <IssueCard key={issue.id} issue={issue} repoName={repoMap.get(issue.repoId) ?? issue.repoId} onOpen={onOpen} />
           ))}
         </div>
       )}

--- a/src/components/Overview/Overview.test.tsx
+++ b/src/components/Overview/Overview.test.tsx
@@ -17,6 +17,7 @@ vi.mock("../../hooks/useGitHubData", () => ({
 
 vi.mock("../../lib/tauri", () => ({
   markAllActivityRead: vi.fn().mockResolvedValue(0),
+  listRepos: vi.fn().mockResolvedValue([]),
 }));
 
 import { useGitHubData } from "../../hooks/useGitHubData";


### PR DESCRIPTION
## Summary

- Display human-readable repo names instead of raw `repoId` in the Issues page, fixing confusion from duplicate issue numbers across repositories
- Reuse the existing `repoMap` pattern from CommandPalette (fetch repos via TanStack Query, build id→name map with fullName fallback for ambiguous names)
- Update Overview test mock to include `listRepos` since Issues now uses `useQuery`

Closes #124

## Test plan

- [x] 482/482 tests passing (vitest)
- [x] TypeScript typecheck passes
- [x] oxlint passes (0 errors)
- [x] IssueCard renders repo name prop instead of repoId
- [x] Issues resolves repo names via repoMap
- [x] Ambiguous repo names fallback to fullName (e.g. `org-a/shared`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Display repo names instead of internal `repoId` on the Issues page to make duplicate issue numbers across repos easy to distinguish.

- **Bug Fixes**
  - Build repo id→name map with `@tanstack/react-query` (`useQuery(listRepos)`), falling back to `fullName` when names collide.
  - Pass `repoName` to `IssueCard` and render it instead of `repoId`.
  - Update tests to mock repo fetching, cover ambiguous names, and align `IssueCard` expectations.

<sup>Written for commit b918d0bc0f038b02cf8027a1a0e8da22f1c456ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Issue cards now display repository names instead of repository IDs for improved readability.
  * When multiple repositories share the same name, disambiguated identifiers are displayed to prevent confusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->