### PR TITLE
fix(a11y): raise dim text contrast to WCAG AA compliance

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -15,7 +15,7 @@
   --color-surface-alt: #151513;
   --color-border: #2a2a27;
   --color-text: #d4d0c8;
-  --color-dim: #6b6860;
+  --color-dim: #8a8578;
   --color-muted: #4a473f;
   --color-white: #eeece6;
   --color-accent: #c8ff00;


### PR DESCRIPTION
## Summary

- Change `--color-dim` design token from `#6b6860` (3.40:1) to `#8a8578` (5.13:1) against `#111110` background
- Meets WCAG AA 4.5:1 minimum contrast threshold with comfortable margin
- Keeps warm undertone consistent with PRism palette

Closes #130

## Contrast measurements

| Color | Ratio | WCAG AA |
|-------|-------|---------|
| `#6b6860` (before) | 3.40:1 | FAIL |
| `#8a8578` (after) | 5.13:1 | PASS |

## Test plan

- [x] 482/482 vitest tests pass
- [ ] Visual check: sidebar repo names, card metadata, timestamps remain readable
- [ ] Verify no visual regression on light text elements

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises dim text contrast to meet WCAG AA on dark backgrounds by updating the `--color-dim` token. Improves readability of secondary text in sidebars and metadata. Closes #130.

- **Bug Fixes**
  - Update `--color-dim` from #6b6860 (3.40:1) to #8a8578 (5.13:1) against #111110 to pass 4.5:1 AA.

<sup>Written for commit d3a20a010d3093bc663be92e10f486cf29c57bf3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the application's dim color shade for improved visual consistency and a refined appearance across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->