### PR TITLE
fix(ui): increase interactive element height to 32px minimum

### DIFF
--- a/src/components/ActivityFeed/ActivityFeed.tsx
+++ b/src/components/ActivityFeed/ActivityFeed.tsx
@@ -47,7 +47,7 @@ export function ActivityFeed({ activities, onMarkAllRead }: ActivityFeedProps): 
               type="button"
               aria-pressed={filter === f}
               onClick={() => setFilter(f)}
-              className={`rounded px-2 py-0.5 text-xs capitalize transition-colors ${
+              className={`rounded px-2 py-2 text-xs capitalize transition-colors ${
                 filter === f
                   ? "bg-accent text-bg font-semibold"
                   : "text-dim hover:text-foreground"
@@ -61,7 +61,7 @@ export function ActivityFeed({ activities, onMarkAllRead }: ActivityFeedProps): 
         <button
           type="button"
           onClick={onMarkAllRead}
-          className="ml-auto rounded px-2 py-0.5 text-xs text-dim hover:text-foreground"
+          className="ml-auto rounded px-2 py-2 text-xs text-dim hover:text-foreground"
         >
           Mark all read
         </button>

--- a/src/components/Issues/Issues.tsx
+++ b/src/components/Issues/Issues.tsx
@@ -63,7 +63,7 @@ export function Issues({ issues, onOpen }: IssuesProps): ReactElement {
           type="button"
           aria-pressed={tab === "open"}
           onClick={() => setTab("open")}
-          className={`rounded px-2 py-0.5 text-xs transition-colors ${
+          className={`rounded px-2 py-2 text-xs transition-colors ${
             tab === "open"
               ? "bg-accent text-bg font-semibold"
               : "text-dim hover:text-foreground"
@@ -75,7 +75,7 @@ export function Issues({ issues, onOpen }: IssuesProps): ReactElement {
           type="button"
           aria-pressed={tab === "closed"}
           onClick={() => setTab("closed")}
-          className={`rounded px-2 py-0.5 text-xs transition-colors ${
+          className={`rounded px-2 py-2 text-xs transition-colors ${
             tab === "closed"
               ? "bg-accent text-bg font-semibold"
               : "text-dim hover:text-foreground"

--- a/src/components/MyPRs/MyPRs.tsx
+++ b/src/components/MyPRs/MyPRs.tsx
@@ -59,7 +59,7 @@ export function MyPRs({
           type="button"
           aria-pressed={tab === "open"}
           onClick={() => setTab("open")}
-          className={`rounded px-2 py-0.5 text-xs transition-colors ${
+          className={`rounded px-2 py-2 text-xs transition-colors ${
             tab === "open"
               ? "bg-accent text-bg font-semibold"
               : "text-dim hover:text-foreground"
@@ -71,7 +71,7 @@ export function MyPRs({
           type="button"
           aria-pressed={tab === "merged"}
           onClick={() => setTab("merged")}
-          className={`rounded px-2 py-0.5 text-xs transition-colors ${
+          className={`rounded px-2 py-2 text-xs transition-colors ${
             tab === "merged"
               ? "bg-accent text-bg font-semibold"
               : "text-dim hover:text-foreground"

--- a/src/components/ReviewQueue/ReviewQueue.tsx
+++ b/src/components/ReviewQueue/ReviewQueue.tsx
@@ -115,7 +115,7 @@ export function ReviewQueue({
               onClick={() =>
                 setFilter({ priority: f === "all" ? undefined : f })
               }
-              className={`rounded px-2 py-0.5 text-xs transition-colors ${
+              className={`rounded px-2 py-2 text-xs transition-colors ${
                 priorityFilter === f
                   ? "bg-accent text-bg font-semibold"
                   : "text-dim hover:text-foreground"
@@ -133,7 +133,7 @@ export function ReviewQueue({
             onChange={(e) =>
               setFilter({ repo: e.target.value || undefined })
             }
-            className="rounded border border-border bg-surface px-2 py-0.5 text-xs text-foreground"
+            className="rounded border border-border bg-surface px-2 py-2 text-xs text-foreground"
           >
             <option value="">All repos</option>
             {repos.map((id) => (

--- a/src/components/Sidebar/NavItem.tsx
+++ b/src/components/Sidebar/NavItem.tsx
@@ -22,7 +22,7 @@ export function NavItem({
       onClick={() => onClick(view)}
       aria-current={isActive ? "page" : undefined}
       aria-label={count !== undefined && count > 0 ? `${label} (${count})` : undefined}
-      className={`flex w-full items-center justify-between rounded px-2 py-1 text-left text-sm ${
+      className={`flex w-full items-center justify-between rounded px-2 py-1.5 text-left text-sm ${
         isActive
           ? "bg-surface text-white"
           : "text-dim hover:bg-surface-hover hover:text-foreground"

--- a/src/components/Sidebar/RepoList.tsx
+++ b/src/components/Sidebar/RepoList.tsx
@@ -15,7 +15,7 @@ export function RepoList({
       {repos.map((repo) => (
         <label
           key={repo.id}
-          className="flex cursor-pointer items-center gap-2 rounded px-2 py-1 text-xs text-dim hover:bg-surface-hover hover:text-foreground"
+          className="flex cursor-pointer items-center gap-2 rounded px-2 py-2 text-xs text-dim hover:bg-surface-hover hover:text-foreground"
         >
           <input
             type="checkbox"

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -131,7 +131,7 @@ export function Sidebar(): ReactElement {
           type="button"
           aria-pressed={focusMode}
           onClick={toggleFocusMode}
-          className={`w-full rounded px-2 py-1 text-xs font-medium ${
+          className={`w-full rounded px-2 py-2 text-xs font-medium ${
             focusMode
               ? "bg-accent text-bg font-semibold"
               : "text-dim hover:text-foreground"

--- a/src/components/Sidebar/WorkspaceList.tsx
+++ b/src/components/Sidebar/WorkspaceList.tsx
@@ -24,7 +24,7 @@ export function WorkspaceList({
           type="button"
           onClick={() => onWorkspaceClick(ws.id)}
           aria-label={`PR #${ws.pullRequestNumber} (${ws.state})`}
-          className="flex items-center gap-2 rounded px-2 py-1 text-left text-xs text-dim hover:bg-surface-hover hover:text-foreground"
+          className="flex items-center gap-2 rounded px-2 py-2 text-left text-xs text-dim hover:bg-surface-hover hover:text-foreground"
         >
           <span
             data-state={ws.state}

--- a/src/components/Workspace/WorkspaceStatusBar.tsx
+++ b/src/components/Workspace/WorkspaceStatusBar.tsx
@@ -85,7 +85,7 @@ export function WorkspaceStatusBar({
           type="button"
           aria-label="Git push"
           disabled={disabled}
-          className="rounded px-2 py-0.5 text-muted hover:bg-surface-hover hover:text-text disabled:cursor-not-allowed disabled:opacity-40"
+          className="rounded px-2 py-2 text-muted hover:bg-surface-hover hover:text-text disabled:cursor-not-allowed disabled:opacity-40"
           onClick={() => handlePtyCommand("git push")}
         >
           push
@@ -95,7 +95,7 @@ export function WorkspaceStatusBar({
           type="button"
           aria-label="Git pull"
           disabled={disabled}
-          className="rounded px-2 py-0.5 text-muted hover:bg-surface-hover hover:text-text disabled:cursor-not-allowed disabled:opacity-40"
+          className="rounded px-2 py-2 text-muted hover:bg-surface-hover hover:text-text disabled:cursor-not-allowed disabled:opacity-40"
           onClick={() => handlePtyCommand("git pull")}
         >
           pull
@@ -109,7 +109,7 @@ export function WorkspaceStatusBar({
           aria-disabled={disabled || undefined}
           tabIndex={disabled ? -1 : undefined}
           onClick={disabled ? (e) => e.preventDefault() : undefined}
-          className={`rounded px-2 py-0.5 text-muted hover:bg-surface-hover hover:text-text ${disabled ? "pointer-events-none opacity-40" : ""}`}
+          className={`rounded px-2 py-2 text-muted hover:bg-surface-hover hover:text-text ${disabled ? "pointer-events-none opacity-40" : ""}`}
         >
           github
         </a>

--- a/src/components/Workspace/WorkspaceSwitcher.tsx
+++ b/src/components/Workspace/WorkspaceSwitcher.tsx
@@ -77,7 +77,7 @@ export function WorkspaceSwitcher({
       <button
         type="button"
         onClick={onBackToDashboard}
-        className="mr-2 rounded px-2 py-1 text-xs text-dim hover:bg-surface-hover hover:text-text"
+        className="mr-2 rounded px-2 py-2 text-xs text-dim hover:bg-surface-hover hover:text-text"
       >
         Dashboard
       </button>
@@ -97,7 +97,7 @@ export function WorkspaceSwitcher({
               data-active={isActive ? "true" : "false"}
               onClick={() => setActiveWorkspace(ws.id)}
               onKeyDown={(e) => handleKeyDown(e, i)}
-              className={`flex items-center gap-1.5 rounded px-2.5 py-1 text-xs transition-colors ${
+              className={`flex items-center gap-1.5 rounded px-2.5 py-2 text-xs transition-colors ${
                 isActive
                   ? "bg-surface-hover text-accent"
                   : "text-dim hover:bg-surface-hover hover:text-text"

--- a/src/components/atoms/WsBadge.tsx
+++ b/src/components/atoms/WsBadge.tsx
@@ -26,7 +26,7 @@ export function WsBadge({ state, loading, onClick, ariaLabel }: WsBadgeProps): R
       onClick={loading ? undefined : onClick}
       disabled={loading}
       aria-label={ariaLabel}
-      className={`rounded border border-accent/30 px-2 py-0.5 text-xs text-accent ${loading ? "animate-pulse opacity-60" : "hover:bg-accent/10"}`}
+      className={`rounded border border-accent/30 px-2 py-2 text-xs text-accent ${loading ? "animate-pulse opacity-60" : "hover:bg-accent/10"}`}
     >
       {label}
     </button>


### PR DESCRIPTION
## Summary
- Increased vertical padding on all interactive elements (buttons, tabs, filters, links) to meet 32px minimum height target
- `text-xs` elements: `py-0.5`/`py-1` → `py-2` (16px line-height + 16px padding = 32px)
- `text-sm` elements: `py-1` → `py-1.5` (20px line-height + 12px padding = 32px)
- 11 files changed across dashboard filters, sidebar nav, workspace controls, and activity feed

Closes #132

## Components updated
| Component | Elements | Before | After |
|-----------|----------|--------|-------|
| ReviewQueue | Priority filters, repo select | 20px | 32px |
| MyPRs | Open/Merged tabs | 20px | 32px |
| Issues | Open/Closed tabs | 20px | 32px |
| ActivityFeed | Type filters, Mark all read | 20px | 32px |
| NavItem | Sidebar navigation | 28px | 32px |
| WorkspaceList | Sidebar workspace buttons | 24px | 32px |
| RepoList | Sidebar repo labels | 24px | 32px |
| Sidebar | Focus mode toggle | 24px | 32px |
| WorkspaceSwitcher | Dashboard + workspace tabs | 24px | 32px |
| WorkspaceStatusBar | Push/Pull/GitHub buttons | 20px | 32px |
| WsBadge | PR action badge | 20px | 32px |

## Test plan
- [x] `npx oxlint .` — 0 errors
- [x] `npx vitest run` — 482 tests passed
- [ ] Visual check: all filter buttons, tabs, and sidebar items are comfortably clickable
- [ ] Verify sidebar density with many repos (RepoList now shows ~6 items instead of ~8 in constrained view)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raised the minimum height of interactive elements to 32px for better accessibility and easier clicking across the app. Meets the 32px target requested in #132.

- **Refactors**
  - Set `text-xs` controls to `py-2` and `text-sm` to `py-1.5`.
  - Applied across buttons, tabs, filters, and sidebar controls (11 files): ReviewQueue, MyPRs, Issues, ActivityFeed, Sidebar items, Workspace Switcher/StatusBar, `WsBadge`.
  - Sidebar lists are slightly taller; expect fewer items visible in dense views.

<sup>Written for commit ce2e00e52584c27f579864c5e8237608a932b1ce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Increased vertical padding on filter buttons and tabs throughout the application (activity feeds, issues, pull requests).
  * Adjusted sidebar navigation and workspace control button spacing for improved visual consistency.
  * Updated workspace action button padding across multiple components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->