### PR TITLE
fix(ui): add hover states to all interactive elements

### DIFF
--- a/src/components/ActivityFeed/ActivityFeed.tsx
+++ b/src/components/ActivityFeed/ActivityFeed.tsx
@@ -49,7 +49,7 @@ export function ActivityFeed({ activities, onMarkAllRead }: ActivityFeedProps): 
               onClick={() => setFilter(f)}
               className={`rounded px-2 py-2 text-xs capitalize transition-colors ${
                 filter === f
-                  ? "bg-accent text-bg font-semibold"
+                  ? "bg-accent text-bg font-semibold hover:bg-accent/80"
                   : "text-dim hover:text-foreground"
               }`}
             >

--- a/src/components/Issues/Issues.tsx
+++ b/src/components/Issues/Issues.tsx
@@ -65,7 +65,7 @@ export function Issues({ issues, onOpen }: IssuesProps): ReactElement {
           onClick={() => setTab("open")}
           className={`rounded px-2 py-2 text-xs transition-colors ${
             tab === "open"
-              ? "bg-accent text-bg font-semibold"
+              ? "bg-accent text-bg font-semibold hover:bg-accent/80"
               : "text-dim hover:text-foreground"
           }`}
         >
@@ -77,7 +77,7 @@ export function Issues({ issues, onOpen }: IssuesProps): ReactElement {
           onClick={() => setTab("closed")}
           className={`rounded px-2 py-2 text-xs transition-colors ${
             tab === "closed"
-              ? "bg-accent text-bg font-semibold"
+              ? "bg-accent text-bg font-semibold hover:bg-accent/80"
               : "text-dim hover:text-foreground"
           }`}
         >

--- a/src/components/MyPRs/MyPRs.tsx
+++ b/src/components/MyPRs/MyPRs.tsx
@@ -61,7 +61,7 @@ export function MyPRs({
           onClick={() => setTab("open")}
           className={`rounded px-2 py-2 text-xs transition-colors ${
             tab === "open"
-              ? "bg-accent text-bg font-semibold"
+              ? "bg-accent text-bg font-semibold hover:bg-accent/80"
               : "text-dim hover:text-foreground"
           }`}
         >
@@ -73,7 +73,7 @@ export function MyPRs({
           onClick={() => setTab("merged")}
           className={`rounded px-2 py-2 text-xs transition-colors ${
             tab === "merged"
-              ? "bg-accent text-bg font-semibold"
+              ? "bg-accent text-bg font-semibold hover:bg-accent/80"
               : "text-dim hover:text-foreground"
           }`}
         >

--- a/src/components/ReviewQueue/ReviewQueue.tsx
+++ b/src/components/ReviewQueue/ReviewQueue.tsx
@@ -117,7 +117,7 @@ export function ReviewQueue({
               }
               className={`rounded px-2 py-2 text-xs transition-colors ${
                 priorityFilter === f
-                  ? "bg-accent text-bg font-semibold"
+                  ? "bg-accent text-bg font-semibold hover:bg-accent/80"
                   : "text-dim hover:text-foreground"
               }`}
             >
@@ -133,7 +133,7 @@ export function ReviewQueue({
             onChange={(e) =>
               setFilter({ repo: e.target.value || undefined })
             }
-            className="rounded border border-border bg-surface px-2 py-2 text-xs text-foreground"
+            className="cursor-pointer rounded border border-border bg-surface px-2 py-2 text-xs text-foreground transition-colors hover:border-foreground"
           >
             <option value="">All repos</option>
             {repos.map((id) => (

--- a/src/components/Sidebar/NavItem.tsx
+++ b/src/components/Sidebar/NavItem.tsx
@@ -24,7 +24,7 @@ export function NavItem({
       aria-label={count !== undefined && count > 0 ? `${label} (${count})` : undefined}
       className={`flex w-full items-center justify-between rounded px-2 py-1.5 text-left text-sm ${
         isActive
-          ? "bg-surface text-white"
+          ? "bg-surface text-white hover:bg-surface-hover"
           : "text-dim hover:bg-surface-hover hover:text-foreground"
       }`}
     >

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -133,7 +133,7 @@ export function Sidebar(): ReactElement {
           onClick={toggleFocusMode}
           className={`w-full rounded px-2 py-2 text-xs font-medium ${
             focusMode
-              ? "bg-accent text-bg font-semibold"
+              ? "bg-accent text-bg font-semibold hover:bg-accent/80"
               : "text-dim hover:text-foreground"
           }`}
         >

--- a/src/components/Workspace/WorkspaceSwitcher.tsx
+++ b/src/components/Workspace/WorkspaceSwitcher.tsx
@@ -99,7 +99,7 @@ export function WorkspaceSwitcher({
               onKeyDown={(e) => handleKeyDown(e, i)}
               className={`flex items-center gap-1.5 rounded px-2.5 py-2 text-xs transition-colors ${
                 isActive
-                  ? "bg-surface-hover text-accent"
+                  ? "bg-surface-hover text-accent hover:brightness-95"
                   : "text-dim hover:bg-surface-hover hover:text-text"
               }`}
             >

--- a/src/components/Workspace/WorkspaceSwitcher.tsx
+++ b/src/components/Workspace/WorkspaceSwitcher.tsx
@@ -99,7 +99,7 @@ export function WorkspaceSwitcher({
               onKeyDown={(e) => handleKeyDown(e, i)}
               className={`flex items-center gap-1.5 rounded px-2.5 py-2 text-xs transition-colors ${
                 isActive
-                  ? "bg-surface-hover text-accent hover:brightness-95"
+                  ? "bg-surface-hover text-accent hover:bg-accent/10"
                   : "text-dim hover:bg-surface-hover hover:text-text"
               }`}
             >


### PR DESCRIPTION
Closes #133

## Summary
- Add `hover:bg-accent/80` to all active filter/tab buttons (ReviewQueue, MyPRs, Issues, ActivityFeed, Sidebar FocusToggle)
- Add `hover:bg-surface-hover` to NavItem active state
- Add `hover:brightness-95` to WorkspaceSwitcher active tab
- Add `cursor-pointer transition-colors hover:border-foreground` to repo select dropdown

## Test plan
- [ ] Hover over each active filter button and verify subtle background darkening
- [ ] Hover over active NavItem in sidebar and verify background change
- [ ] Hover over active workspace tab and verify subtle brightness change
- [ ] Hover over repo select dropdown and verify border highlight
- [ ] Verify no regressions on inactive element hover states

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add consistent hover feedback to active buttons, tabs, and the repo dropdown to improve affordance. Includes a smoother hover on the active workspace tab; closes #133.

- **New Features**
  - Active filters/tabs (ReviewQueue, MyPRs, Issues, ActivityFeed, Sidebar FocusToggle): `hover:bg-accent/80`
  - Sidebar NavItem (active): `hover:bg-surface-hover`
  - WorkspaceSwitcher (active tab): `hover:bg-accent/10`
  - Repo select dropdown: `cursor-pointer`, `transition-colors`, `hover:border-foreground`

<sup>Written for commit 5048e6f9a97ae8c654261577e192883a227dc228. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Enhanced hover states across the app: improved visual feedback for filters, tabs, navigation items, toggles, workspace switcher and selector controls to make interactive elements more responsive and discoverable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->