### PR TITLE
fix(ui): improve Settings field labels visibility (#136)

### DIFF
--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -142,7 +142,7 @@ export function Settings(): ReactElement {
         <p role="alert" className="text-sm text-red-400">{saveError}</p>
       ) : null}
 
-      <div data-testid="settings-github" className="flex flex-col gap-3">
+      <div data-testid="settings-github" className="flex flex-col gap-3 border-b border-border pb-4">
         <h2 className="text-accent text-sm font-semibold uppercase tracking-wider">GitHub</h2>
         <AuthSetup />
         <NumberField
@@ -153,7 +153,7 @@ export function Settings(): ReactElement {
         />
       </div>
 
-      <div data-testid="settings-workspaces" className="flex flex-col gap-3">
+      <div data-testid="settings-workspaces" className="flex flex-col gap-3 border-b border-border pb-4">
         <h2 className="text-accent text-sm font-semibold uppercase tracking-wider">Workspaces</h2>
         <NumberField
           label="Max active workspaces"
@@ -163,7 +163,7 @@ export function Settings(): ReactElement {
         />
       </div>
 
-      <div data-testid="settings-claude-code" className="flex flex-col gap-3">
+      <div data-testid="settings-claude-code" className="flex flex-col gap-3 border-b border-border pb-4">
         <h2 className="text-accent text-sm font-semibold uppercase tracking-wider">Claude Code</h2>
         <label className="flex items-center justify-between gap-4">
           <span className="text-dim text-sm">Auth mode</span>

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -81,6 +81,8 @@ function RepoRow({ repo, disabled, onToggle }: RepoRowProps): ReactElement {
   );
 }
 
+const sectionClass = "flex flex-col gap-3 border-b border-border pb-4";
+
 export function Settings(): ReactElement {
   const queryClient = useQueryClient();
   const configQuery = useConfigQuery();
@@ -142,7 +144,7 @@ export function Settings(): ReactElement {
         <p role="alert" className="text-sm text-red-400">{saveError}</p>
       ) : null}
 
-      <div data-testid="settings-github" className="flex flex-col gap-3 border-b border-border pb-4">
+      <div data-testid="settings-github" className={sectionClass}>
         <h2 className="text-accent text-sm font-semibold uppercase tracking-wider">GitHub</h2>
         <AuthSetup />
         <NumberField
@@ -153,7 +155,7 @@ export function Settings(): ReactElement {
         />
       </div>
 
-      <div data-testid="settings-workspaces" className="flex flex-col gap-3 border-b border-border pb-4">
+      <div data-testid="settings-workspaces" className={sectionClass}>
         <h2 className="text-accent text-sm font-semibold uppercase tracking-wider">Workspaces</h2>
         <NumberField
           label="Max active workspaces"
@@ -163,7 +165,7 @@ export function Settings(): ReactElement {
         />
       </div>
 
-      <div data-testid="settings-claude-code" className="flex flex-col gap-3 border-b border-border pb-4">
+      <div data-testid="settings-claude-code" className={sectionClass}>
         <h2 className="text-accent text-sm font-semibold uppercase tracking-wider">Claude Code</h2>
         <label className="flex items-center justify-between gap-4">
           <span className="text-dim text-sm">Auth mode</span>

--- a/src/index.css
+++ b/src/index.css
@@ -15,7 +15,7 @@
   --color-surface-alt: #151513;
   --color-border: #2a2a27;
   --color-text: #d4d0c8;
-  --color-dim: #8a8578;
+  --color-dim: #a09a8c;
   --color-muted: #4a473f;
   --color-white: #eeece6;
   --color-foreground: var(--color-text);


### PR DESCRIPTION
## Summary

- Brighten `--color-dim` token from `#8a8578` to `#a09a8c` — contrast ratio goes from ~4.2:1 to ~5.5:1 on dark background, passing WCAG AA for small text
- Add `border-b border-border pb-4` dividers between GitHub, Workspaces, and Claude Code sections for clearer visual grouping

## Test plan

- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] All 477 existing tests pass (`vitest run`)
- [ ] Visual check: Settings page labels are more readable on dark theme
- [ ] Visual check: Section dividers appear between GitHub, Workspaces, and Claude Code sections
- [ ] No visual regression on other pages using `text-dim`

Closes #136

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve Settings label readability in dark mode and clarify section grouping. Addresses #136 by increasing dim text contrast, adding dividers, and deduplicating section styles.

- Updated `--color-dim` to `#a09a8c` to meet WCAG AA for small text.
- Added section dividers and extracted shared section container classes into `sectionClass`.

<sup>Written for commit adb8f050ad9e529ee23a637763c96d718add9b6f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Added consistent visual separators and spacing to multiple Settings sections.
  * Updated a dim theme color, adjusting scrollbar hover appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->