### PR TITLE
feat(ui): add loading indicator during GitHub sync

### DIFF
--- a/src/components/StatsBar/StatsBar.test.tsx
+++ b/src/components/StatsBar/StatsBar.test.tsx
@@ -41,6 +41,7 @@ describe("StatsBar", () => {
       stats: MOCK_STATS,
       dashboard: { syncedAt: "2026-03-28T10:00:00Z" },
       isLoading: false,
+      isSyncing: false,
       error: null,
     });
 
@@ -62,6 +63,7 @@ describe("StatsBar", () => {
       stats: MOCK_STATS,
       dashboard: { syncedAt: new Date(Date.now() - 30_000).toISOString() },
       isLoading: false,
+      isSyncing: false,
       error: null,
     });
 
@@ -75,6 +77,7 @@ describe("StatsBar", () => {
       stats: MOCK_STATS,
       dashboard: { syncedAt: "2026-03-28T10:00:00Z" },
       isLoading: false,
+      isSyncing: false,
       error: null,
     });
 
@@ -89,6 +92,7 @@ describe("StatsBar", () => {
       stats: null,
       dashboard: null,
       isLoading: true,
+      isSyncing: false,
       error: null,
     });
 
@@ -103,6 +107,7 @@ describe("StatsBar", () => {
       stats: MOCK_STATS,
       dashboard: { syncedAt: new Date(Date.now() - 120_000).toISOString() },
       isLoading: false,
+      isSyncing: false,
       error: null,
     });
 
@@ -116,6 +121,7 @@ describe("StatsBar", () => {
       stats: MOCK_STATS,
       dashboard: { syncedAt: new Date(Date.now() - 7_200_000).toISOString() },
       isLoading: false,
+      isSyncing: false,
       error: null,
     });
 
@@ -129,6 +135,7 @@ describe("StatsBar", () => {
       stats: MOCK_STATS,
       dashboard: { syncedAt: null },
       isLoading: false,
+      isSyncing: false,
       error: null,
     });
 
@@ -143,6 +150,7 @@ describe("StatsBar", () => {
       stats: MOCK_STATS,
       dashboard: { syncedAt: "2026-03-28T10:00:00Z" },
       isLoading: false,
+      isSyncing: false,
       error: null,
     });
 
@@ -157,6 +165,7 @@ describe("StatsBar", () => {
       stats: MOCK_STATS,
       dashboard: { syncedAt: "2026-03-28T10:00:00Z" },
       isLoading: false,
+      isSyncing: false,
       error: null,
     });
 
@@ -170,6 +179,7 @@ describe("StatsBar", () => {
       stats: MOCK_STATS,
       dashboard: { syncedAt: "not-a-date" },
       isLoading: false,
+      isSyncing: false,
       error: null,
     });
 
@@ -178,11 +188,44 @@ describe("StatsBar", () => {
     expect(screen.getByText(/never synced/i)).toBeInTheDocument();
   });
 
+  it("should show syncing indicator when sync is in progress", () => {
+    (useGitHubData as Mock).mockReturnValue({
+      stats: MOCK_STATS,
+      dashboard: { syncedAt: "2026-03-28T10:00:00Z" },
+      isLoading: false,
+      isSyncing: true,
+      error: null,
+    });
+
+    render(<StatsBar />, { wrapper: createWrapper() });
+
+    const syncIndicator = screen.getByText(/syncing/i);
+    expect(syncIndicator).toBeInTheDocument();
+    expect(syncIndicator).toHaveClass("animate-pulse");
+    expect(screen.queryByText(/synced.*ago/i)).not.toBeInTheDocument();
+  });
+
+  it("should show synced time when not syncing", () => {
+    (useGitHubData as Mock).mockReturnValue({
+      stats: MOCK_STATS,
+      dashboard: { syncedAt: new Date(Date.now() - 60_000).toISOString() },
+      isLoading: false,
+      isSyncing: false,
+      error: null,
+    });
+
+    render(<StatsBar />, { wrapper: createWrapper() });
+
+    expect(screen.getByText(/synced.*ago/i)).toBeInTheDocument();
+    expect(screen.queryByText(/syncing/i)).not.toBeInTheDocument();
+  });
+
   it("should have role=region and aria-label on stats container", () => {
     (useGitHubData as Mock).mockReturnValue({
       stats: MOCK_STATS,
       dashboard: { syncedAt: "2026-03-28T10:00:00Z" },
       isLoading: false,
+      isSyncing: false,
       error: null,
     });
 

--- a/src/components/StatsBar/StatsBar.tsx
+++ b/src/components/StatsBar/StatsBar.tsx
@@ -42,7 +42,7 @@ function StatItem({ label, value, testId, highlight }: StatItemProps): ReactElem
 }
 
 export function StatsBar(): ReactElement {
-  const { stats, dashboard } = useGitHubData();
+  const { stats, dashboard, isSyncing } = useGitHubData();
   const focusMode = useDashboardStore((s) => s.focusMode);
   const [now, setNow] = useState(() => Date.now());
 
@@ -89,7 +89,11 @@ export function StatsBar(): ReactElement {
             FOCUS MODE
           </span>
         )}
-        <span className="text-xs text-dim">{formatSyncedTime(syncedAt, now)}</span>
+        {isSyncing ? (
+          <span className="text-xs text-dim animate-pulse">syncing...</span>
+        ) : (
+          <span className="text-xs text-dim">{formatSyncedTime(syncedAt, now)}</span>
+        )}
       </div>
     </div>
   );

--- a/src/components/StatsBar/StatsBar.tsx
+++ b/src/components/StatsBar/StatsBar.tsx
@@ -90,7 +90,7 @@ export function StatsBar(): ReactElement {
           </span>
         )}
         {isSyncing ? (
-          <span className="text-xs text-dim animate-pulse">syncing...</span>
+          <span className="text-xs text-dim animate-pulse" aria-live="polite">syncing...</span>
         ) : (
           <span className="text-xs text-dim">{formatSyncedTime(syncedAt, now)}</span>
         )}


### PR DESCRIPTION
## Summary

- Show animated "syncing..." text with `animate-pulse` in StatsBar while a force sync is in progress
- Replace static "synced Xm ago" timestamp during sync with a clear visual indicator
- Consume the existing `isSyncing` state already exported by `useGitHubData()` hook

Closes #137

## Test plan

- [x] New test: syncing indicator shown when `isSyncing` is true
- [x] New test: synced time shown when `isSyncing` is false
- [x] All 13 StatsBar tests pass
- [x] Full suite: 479/479 tests pass, 0 regressions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a clear syncing state to `StatsBar`: when `isSyncing` from `useGitHubData()` is true, show an animated “syncing...” and hide the “synced X ago” timestamp. The indicator uses aria-live="polite" so screen readers announce status changes.

<sup>Written for commit c4612291dea1154e89b396ec596820b52d26711c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * StatsBar shows a pulsing "syncing" indicator (with polite live region) while synchronization is active, and otherwise displays the regular "synced … ago" timestamp.
* **Tests**
  * Updated test coverage to verify both the syncing indicator and the synced-time display across loading and edge-case scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->