### PR TITLE
feat(ui): add title tooltips on truncated text elements

### DIFF
--- a/src/components/CommandPalette/CommandPalette.test.tsx
+++ b/src/components/CommandPalette/CommandPalette.test.tsx
@@ -416,4 +416,22 @@ describe("CommandPalette", () => {
     expect(screen.getByText("Pull Requests")).toBeInTheDocument();
     expect(screen.getByText("Issues")).toBeInTheDocument();
   });
+
+  it("should have title attribute on item title span", () => {
+    const pr = makePr();
+
+    (useGitHubData as Mock).mockReturnValue({
+      dashboard: makeDashboard({ reviewRequests: [pr] }),
+      stats: null,
+      isLoading: false,
+      error: null,
+      forceSync: vi.fn(),
+      isSyncing: false,
+    });
+
+    renderPalette({ open: true, onOpenChange: () => {} });
+
+    const titleSpan = screen.getByText("Fix login bug");
+    expect(titleSpan).toHaveAttribute("title", "Fix login bug");
+  });
 });

--- a/src/components/CommandPalette/CommandPalette.tsx
+++ b/src/components/CommandPalette/CommandPalette.tsx
@@ -63,7 +63,7 @@ function PaletteItemRow({ item }: { readonly item: PaletteItem }): ReactElement 
   return (
     <>
       <span className="shrink-0 text-fg/50">#{item.number}</span>
-      <span className="truncate">{item.title}</span>
+      <span className="truncate" title={item.title}>{item.title}</span>
       <span className="shrink-0 rounded bg-fg/10 px-1.5 py-0.5 text-xs text-fg/60">
         {item.repoName}
       </span>

--- a/src/components/Issues/IssueCard.test.tsx
+++ b/src/components/Issues/IssueCard.test.tsx
@@ -96,4 +96,16 @@ describe("IssueCard", () => {
     const dot = screen.getByTestId("issue-state-dot");
     expect(dot).toHaveAttribute("aria-hidden", "true");
   });
+
+  it("should have title attribute on issue title span", () => {
+    render(<IssueCard issue={makeIssue()} repoName="repo-name" onOpen={vi.fn()} />);
+    const titleSpan = screen.getByText("Fix login bug");
+    expect(titleSpan).toHaveAttribute("title", "Fix login bug");
+  });
+
+  it("should have title attribute on repo name span", () => {
+    render(<IssueCard issue={makeIssue()} repoName="my-repo" onOpen={vi.fn()} />);
+    const repoSpan = screen.getByText("my-repo");
+    expect(repoSpan).toHaveAttribute("title", "my-repo");
+  });
 });

--- a/src/components/Issues/IssueCard.tsx
+++ b/src/components/Issues/IssueCard.tsx
@@ -35,13 +35,13 @@ export function IssueCard({ issue, repoName, onOpen }: IssueCardProps): ReactEle
           className={`h-2.5 w-2.5 shrink-0 rounded-full ${STATE_DOT_COLOR[issue.state]}`}
         />
         <span className="shrink-0 text-xs text-dim">#{issue.number}</span>
-        <span className="min-w-0 truncate text-sm font-medium text-foreground">
+        <span className="min-w-0 truncate text-sm font-medium text-foreground" title={issue.title}>
           {issue.title}
         </span>
       </div>
 
       <div className="flex min-w-0 items-center gap-2 pl-[18px]">
-        <span className="shrink-0 truncate text-xs text-dim">{repoName}</span>
+        <span className="shrink-0 truncate text-xs text-dim" title={repoName}>{repoName}</span>
         {issue.labels.length > 0 && (
           <span className="flex min-w-0 items-center gap-1 overflow-hidden">
             {issue.labels.map((label) => (

--- a/src/components/Issues/IssueCard.tsx
+++ b/src/components/Issues/IssueCard.tsx
@@ -41,7 +41,7 @@ export function IssueCard({ issue, repoName, onOpen }: IssueCardProps): ReactEle
       </div>
 
       <div className="flex min-w-0 items-center gap-2 pl-[18px]">
-        <span className="shrink-0 truncate text-xs text-dim" title={repoName}>{repoName}</span>
+        <span className="min-w-0 truncate text-xs text-dim" title={repoName}>{repoName}</span>
         {issue.labels.length > 0 && (
           <span className="flex min-w-0 items-center gap-1 overflow-hidden">
             {issue.labels.map((label) => (

--- a/src/components/MyPRs/MyPrCard.test.tsx
+++ b/src/components/MyPRs/MyPrCard.test.tsx
@@ -263,4 +263,10 @@ describe("MyPrCard", () => {
     expect(screen.getByRole("button", { name: "Wake workspace for PR #99" })).toBeInTheDocument();
     expect(screen.getByText("wake")).toBeInTheDocument();
   });
+
+  it("should have title attribute on PR title span", () => {
+    render(<MyPrCard data={basePr} onOpen={vi.fn()} />);
+    const titleSpan = screen.getByText("Add dashboard feature");
+    expect(titleSpan).toHaveAttribute("title", "Add dashboard feature");
+  });
 });

--- a/src/components/MyPRs/MyPrCard.tsx
+++ b/src/components/MyPRs/MyPrCard.tsx
@@ -98,6 +98,7 @@ export function MyPrCard({
           <div className="flex min-w-0 items-center gap-2">
             <span
               className={`min-w-0 truncate text-sm font-medium text-foreground${merged ? " line-through" : ""}`}
+              title={pr.title}
             >
               {pr.title}
             </span>

--- a/src/components/ReviewQueue/ReviewCard.test.tsx
+++ b/src/components/ReviewQueue/ReviewCard.test.tsx
@@ -133,4 +133,10 @@ describe("ReviewCard", () => {
     );
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
   });
+
+  it("should have title attribute on PR title span", () => {
+    render(<ReviewCard data={mockData} onOpen={vi.fn()} />);
+    const titleSpan = screen.getByText("Fix login bug");
+    expect(titleSpan).toHaveAttribute("title", "Fix login bug");
+  });
 });

--- a/src/components/ReviewQueue/ReviewCard.tsx
+++ b/src/components/ReviewQueue/ReviewCard.tsx
@@ -56,8 +56,8 @@ export function ReviewCard({
         <PriorityBar priority={pr.priority} />
 
         <div className="flex min-w-0 flex-1 flex-col gap-1">
-          <div className="flex items-center gap-2">
-            <span className="truncate text-sm font-medium text-foreground" title={pr.title}>
+          <div className="flex min-w-0 items-center gap-2">
+            <span className="min-w-0 truncate text-sm font-medium text-foreground" title={pr.title}>
               {pr.title}
             </span>
             <span className="shrink-0 text-xs text-dim">#{pr.number}</span>

--- a/src/components/ReviewQueue/ReviewCard.tsx
+++ b/src/components/ReviewQueue/ReviewCard.tsx
@@ -57,7 +57,7 @@ export function ReviewCard({
 
         <div className="flex min-w-0 flex-1 flex-col gap-1">
           <div className="flex items-center gap-2">
-            <span className="truncate text-sm font-medium text-foreground">
+            <span className="truncate text-sm font-medium text-foreground" title={pr.title}>
               {pr.title}
             </span>
             <span className="shrink-0 text-xs text-dim">#{pr.number}</span>

--- a/src/components/Settings/Settings.test.tsx
+++ b/src/components/Settings/Settings.test.tsx
@@ -390,6 +390,15 @@ describe("Settings", () => {
     expect(await screen.findByText("N/A")).toBeInTheDocument();
   });
 
+  it("should have title attribute on repo name span", async () => {
+    setupMocks(makeConfig(), [makeRepo(1, { name: "my-repo" })]);
+
+    renderWithProviders(<Settings />);
+
+    const repoSpan = await screen.findByText("my-repo");
+    expect(repoSpan).toHaveAttribute("title", "my-repo");
+  });
+
   it("should render Claude Code section", async () => {
     setupMocks();
     renderWithProviders(<Settings />);

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -69,7 +69,7 @@ interface RepoRowProps {
 function RepoRow({ repo, disabled, onToggle }: RepoRowProps): ReactElement {
   return (
     <label className="flex items-center justify-between gap-3 py-1">
-      <span className="min-w-0 truncate font-mono text-sm text-white">{repo.name}</span>
+      <span className="min-w-0 truncate font-mono text-sm text-white" title={repo.name}>{repo.name}</span>
       <input
         type="checkbox"
         checked={repo.enabled}

--- a/src/components/Workspace/WorkspaceListPage.test.tsx
+++ b/src/components/Workspace/WorkspaceListPage.test.tsx
@@ -219,4 +219,22 @@ describe("WorkspaceListPage", () => {
 
     expect(screen.queryByText(/Total:/)).not.toBeInTheDocument();
   });
+
+  it("should have title attribute on branch span", () => {
+    render(
+      <WorkspaceListPage entries={[ACTIVE_ENTRY]} onWorkspaceClick={vi.fn()} />,
+    );
+
+    const branchSpan = screen.getByText("feat/login");
+    expect(branchSpan).toHaveAttribute("title", "feat/login");
+  });
+
+  it("should have title attribute on last note paragraph", () => {
+    render(
+      <WorkspaceListPage entries={[ACTIVE_ENTRY]} onWorkspaceClick={vi.fn()} />,
+    );
+
+    const noteEl = screen.getByText("Fixed auth flow, needs final review");
+    expect(noteEl).toHaveAttribute("title", "Fixed auth flow, needs final review");
+  });
 });

--- a/src/components/Workspace/WorkspaceListPage.tsx
+++ b/src/components/Workspace/WorkspaceListPage.tsx
@@ -57,7 +57,7 @@ export function WorkspaceListPage({
 
                 {branch && (
                   <div className="mt-0.5 flex items-center gap-2 text-xs text-dim">
-                    <span className="truncate">{branch}</span>
+                    <span className="truncate" title={branch}>{branch}</span>
                     {(ahead > 0 || behind > 0) && (
                       <span>
                         {ahead > 0 && <span className="text-green">+{ahead}</span>}
@@ -74,7 +74,7 @@ export function WorkspaceListPage({
                 </div>
 
                 {lastNote && (
-                  <p className="mt-1 truncate text-xs text-dim/70">{lastNote}</p>
+                  <p className="mt-1 truncate text-xs text-dim/70" title={lastNote}>{lastNote}</p>
                 )}
               </div>
             </button>


### PR DESCRIPTION
## Summary

- Add native HTML `title` attributes on all truncated text elements across 6 components
- Users can now hover to read full PR titles, issue titles, repo names, branch names, workspace notes, and command palette items
- Add tests for all modified components verifying `title` attribute presence

Closes #138

## Changes

| Component | Elements | 
|-----------|----------|
| IssueCard | issue title + repo name |
| ReviewCard | PR title |
| MyPrCard | PR title |
| CommandPalette | search result title |
| Settings | repo name |
| WorkspaceListPage | branch name + last note |

## Test plan

- [x] 487/487 tests passing
- [x] TypeScript typecheck passes
- [x] oxlint passes (0 warnings, 0 errors)
- [ ] Manual: hover truncated PR title in review queue, verify full title shows
- [ ] Manual: hover truncated issue title in issues list, verify full title shows

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds native HTML title tooltips to all truncated text so users can read full content on hover. Also fixes truncation behavior to be consistent across components.

- **New Features**
  - Added title attributes to truncated fields in `ReviewCard`, `MyPrCard`, `IssueCard` (issue title, repo), `CommandPalette` (item title), `Settings` (repo name), and `WorkspaceListPage` (branch, last note).
  - Added tests to verify the title attribute is present on each updated element.

- **Bug Fixes**
  - Ensured truncation works by switching `IssueCard` repo name from shrink-0 to min-w-0.
  - Added min-w-0 to `ReviewCard` title container and span for consistent flexbox truncation.

<sup>Written for commit b23b74e232ac8d6ea0dc9c98c0d3d4fbda8123d8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hover tooltips added so truncated PR titles, issue titles, repository names, branch names, and notes show full text on hover across PR lists, issue cards, settings, and workspace views.
* **Tests**
  * Added unit tests verifying tooltip/title attributes are present for the updated UI elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->