### PR TITLE
fix(ui): improve repo name display on issues page

### DIFF
--- a/src/components/Issues/IssueCard.tsx
+++ b/src/components/Issues/IssueCard.tsx
@@ -41,7 +41,7 @@ export function IssueCard({ issue, repoName, onOpen }: IssueCardProps): ReactEle
       </div>
 
       <div className="flex min-w-0 items-center gap-2 pl-[18px]">
-        <span className="min-w-0 truncate text-xs text-dim" title={repoName}>{repoName}</span>
+        <span className="shrink-0 rounded bg-fg/10 px-1.5 py-0.5 text-xs text-fg/60" title={repoName}>{repoName}</span>
         {issue.labels.length > 0 && (
           <span className="flex min-w-0 items-center gap-1 overflow-hidden">
             {issue.labels.map((label) => (

--- a/src/components/Issues/IssueCard.tsx
+++ b/src/components/Issues/IssueCard.tsx
@@ -41,7 +41,7 @@ export function IssueCard({ issue, repoName, onOpen }: IssueCardProps): ReactEle
       </div>
 
       <div className="flex min-w-0 items-center gap-2 pl-[18px]">
-        <span className="shrink-0 rounded bg-fg/10 px-1.5 py-0.5 text-xs text-fg/60" title={repoName}>{repoName}</span>
+        <span className="min-w-0 max-w-[40%] truncate rounded bg-fg/10 px-1.5 py-0.5 text-xs text-fg/60" title={repoName}>{repoName}</span>
         {issue.labels.length > 0 && (
           <span className="flex min-w-0 items-center gap-1 overflow-hidden">
             {issue.labels.map((label) => (

--- a/src/components/Issues/Issues.test.tsx
+++ b/src/components/Issues/Issues.test.tsx
@@ -137,13 +137,13 @@ describe("Issues", () => {
     expect(onOpen).toHaveBeenCalledWith(openIssue1.url);
   });
 
-  it("should display repo name instead of repo id", () => {
+  it("should display fullName instead of repo id", () => {
     render(<Issues issues={[openIssue1]} onOpen={onOpen} />);
 
-    expect(screen.getByText("repo")).toBeInTheDocument();
+    expect(screen.getByText("org/repo")).toBeInTheDocument();
   });
 
-  it("should use fullName when repo names are ambiguous", () => {
+  it("should always display fullName for all repos", () => {
     const issue1 = makeIssue({ number: 1, title: "Issue in org-a", state: "open", repoId: "repo-a" });
     const issue2 = makeIssue({ number: 2, title: "Issue in org-b", state: "open", repoId: "repo-b" });
     mockUseQuery.mockReturnValue({
@@ -157,5 +157,13 @@ describe("Issues", () => {
 
     expect(screen.getByText("org-a/shared")).toBeInTheDocument();
     expect(screen.getByText("org-b/shared")).toBeInTheDocument();
+  });
+
+  it("should fallback to repoId when repo not found in map", () => {
+    const orphanIssue = makeIssue({ number: 99, title: "Orphan issue", state: "open", repoId: "unknown-repo" });
+
+    render(<Issues issues={[orphanIssue]} onOpen={onOpen} />);
+
+    expect(screen.getByText("unknown-repo")).toBeInTheDocument();
   });
 });

--- a/src/components/Issues/Issues.tsx
+++ b/src/components/Issues/Issues.tsx
@@ -35,16 +35,7 @@ export function Issues({ issues, onOpen }: IssuesProps): ReactElement {
 
   const repoMap = useMemo<Map<string, string>>(() => {
     if (!repos) return new Map();
-    const nameCounts = new Map<string, number>();
-    for (const repo of repos) {
-      nameCounts.set(repo.name, (nameCounts.get(repo.name) ?? 0) + 1);
-    }
-    return new Map(
-      repos.map((repo) => [
-        repo.id,
-        nameCounts.get(repo.name) === 1 ? repo.name : repo.fullName,
-      ]),
-    );
+    return new Map(repos.map((repo) => [repo.id, repo.fullName]));
   }, [repos]);
 
   const openIssues = issues.filter(isOpen);


### PR DESCRIPTION
## Summary

- Always display repo `fullName` (org/repo format) instead of conditional short/long name logic
- Style repo name as a badge (rounded background, matching CommandPalette pattern) for better visual distinction
- Add edge case test for repo not found in map (fallback to repoId)

Closes #124

## Changes

- **Issues.tsx**: Simplified `repoMap` to always use `repo.fullName`, removed `nameCounts` deduplication logic
- **IssueCard.tsx**: Repo name styled as badge (`bg-fg/10 rounded px-1.5 py-0.5`) instead of plain dim text
- **Issues.test.tsx**: Updated expectations to match fullName format, added fallback edge case test

## Testing

- 21/21 component tests passing
- TypeScript: 0 errors
- oxlint: 0 warnings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always show repositories in org/repo on the Issues page. The repo name is now a small, truncated badge to keep layouts stable and make cross-repo context clear.

- **Bug Fixes**
  - Simplified `repoMap` to map repo ids to `repo.fullName`; removed dedupe logic.
  - Styled the repo name as a badge (`rounded bg-fg/10 px-1.5 py-0.5 text-fg/60`) with `max-w-[40%]` and truncation to prevent overflow.
  - Fallback to `repoId` when the repo is not found; tests updated to cover this.

<sup>Written for commit 2aa300ea59c56f765a126d0f4c76e067e9c0ff11. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repository names now consistently display in full organization/repository format across the issues list for clearer identification.

* **Style**
  * Repository identifiers use a pill-style badge for improved readability and visual consistency.

* **Bug Fixes**
  * UI now gracefully falls back to showing raw repository identifiers when lookup data is missing, avoiding display errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->