### PR TITLE
fix(ui): hide archived workspaces from switcher tabs, show in list (#123)

### DIFF
--- a/src/components/Workspace/WorkspaceListPage.test.tsx
+++ b/src/components/Workspace/WorkspaceListPage.test.tsx
@@ -229,6 +229,30 @@ describe("WorkspaceListPage", () => {
     expect(branchSpan).toHaveAttribute("title", "feat/login");
   });
 
+  it("should disable archived workspace entries", async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+
+    render(
+      <WorkspaceListPage entries={[ARCHIVED_ENTRY]} onWorkspaceClick={handleClick} />,
+    );
+
+    const btn = screen.getByRole("button", { name: /PR #7/ });
+    expect(btn).toBeDisabled();
+
+    await user.click(btn);
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+
+  it("should style archived entries with reduced opacity", () => {
+    render(
+      <WorkspaceListPage entries={[ARCHIVED_ENTRY]} onWorkspaceClick={vi.fn()} />,
+    );
+
+    const btn = screen.getByRole("button", { name: /PR #7/ });
+    expect(btn.className).toContain("opacity-50");
+  });
+
   it("should have title attribute on last note paragraph", () => {
     render(
       <WorkspaceListPage entries={[ACTIVE_ENTRY]} onWorkspaceClick={vi.fn()} />,

--- a/src/components/Workspace/WorkspaceListPage.tsx
+++ b/src/components/Workspace/WorkspaceListPage.tsx
@@ -39,8 +39,13 @@ export function WorkspaceListPage({
             <button
               type="button"
               onClick={() => onWorkspaceClick(workspace.id)}
+              disabled={workspace.state === "archived"}
               aria-label={`PR #${workspace.pullRequestNumber} (${workspace.state})`}
-              className="flex w-full items-start gap-3 px-4 py-3 text-left hover:bg-surface-hover"
+              className={`flex w-full items-start gap-3 px-4 py-3 text-left ${
+                workspace.state === "archived"
+                  ? "cursor-default opacity-50"
+                  : "hover:bg-surface-hover"
+              }`}
             >
               <span
                 data-state={workspace.state}

--- a/src/components/Workspace/WorkspaceSwitcher.test.tsx
+++ b/src/components/Workspace/WorkspaceSwitcher.test.tsx
@@ -72,7 +72,7 @@ describe("WorkspaceSwitcher", () => {
     resetStores();
   });
 
-  it("should render all workspace tabs", () => {
+  it("should render non-archived workspace tabs", () => {
     render(
       <WorkspaceSwitcher
         workspaces={WORKSPACES}
@@ -83,6 +83,7 @@ describe("WorkspaceSwitcher", () => {
     expect(screen.getByText("#42")).toBeInTheDocument();
     expect(screen.getByText("#99")).toBeInTheDocument();
     expect(screen.getByText("#7")).toBeInTheDocument();
+    expect(screen.queryByText("#15")).not.toBeInTheDocument();
   });
 
   it("should highlight active tab", () => {
@@ -138,11 +139,10 @@ describe("WorkspaceSwitcher", () => {
 
     const activeDot = screen.getByTestId("dot-ws-1");
     const suspendedDot = screen.getByTestId("dot-ws-2");
-    const archivedDot = screen.getByTestId("dot-ws-4");
 
     expect(activeDot.className).toContain("bg-green");
     expect(suspendedDot.className).toContain("bg-orange");
-    expect(archivedDot.className).toContain("bg-dim");
+    expect(screen.queryByTestId("dot-ws-4")).not.toBeInTheDocument();
   });
 
   it("should use maxActiveWorkspaces from settings store", () => {
@@ -178,7 +178,7 @@ describe("WorkspaceSwitcher", () => {
     );
 
     const tabs = screen.getAllByRole("tab");
-    expect(tabs).toHaveLength(4);
+    expect(tabs).toHaveLength(3);
 
     const activeTab = screen.getByTestId("tab-ws-1");
     const inactiveTab = screen.getByTestId("tab-ws-2");
@@ -256,7 +256,7 @@ describe("WorkspaceSwitcher", () => {
     firstTab.focus();
     await user.keyboard("{ArrowLeft}");
 
-    expect(useWorkspacesStore.getState().activeWorkspaceId).toBe("ws-4");
+    expect(useWorkspacesStore.getState().activeWorkspaceId).toBe("ws-3");
   });
 
   it("should navigate to first tab with Home key", async () => {
@@ -291,7 +291,7 @@ describe("WorkspaceSwitcher", () => {
     firstTab.focus();
     await user.keyboard("{End}");
 
-    expect(useWorkspacesStore.getState().activeWorkspaceId).toBe("ws-4");
+    expect(useWorkspacesStore.getState().activeWorkspaceId).toBe("ws-3");
   });
 
   it("should set tabIndex 0 on active tab and -1 on others", () => {

--- a/src/components/Workspace/WorkspaceSwitcher.tsx
+++ b/src/components/Workspace/WorkspaceSwitcher.tsx
@@ -1,4 +1,4 @@
-import { useRef, useCallback } from "react";
+import { useRef, useCallback, useMemo } from "react";
 import { useWorkspacesStore } from "../../stores/workspaces";
 import { useSettingsStore } from "../../stores/settings";
 import type { Workspace, WorkspaceState } from "../../lib/types";
@@ -30,15 +30,19 @@ export function WorkspaceSwitcher({
     useSettingsStore((s) => s.config?.maxActiveWorkspaces),
   );
 
+  const visibleWorkspaces = useMemo(
+    () => workspaces.filter((w) => w.state !== "archived"),
+    [workspaces],
+  );
   const activeCount = workspaces.filter((w) => w.state === "active").length;
   const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
-  const focusedId = workspaces.some((w) => w.id === activeWorkspaceId)
+  const focusedId = visibleWorkspaces.some((w) => w.id === activeWorkspaceId)
     ? activeWorkspaceId
-    : workspaces[0]?.id ?? null;
+    : visibleWorkspaces[0]?.id ?? null;
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent, index: number) => {
-      const count = workspaces.length;
+      const count = visibleWorkspaces.length;
       if (count === 0) return;
 
       let next: number | null = null;
@@ -60,13 +64,13 @@ export function WorkspaceSwitcher({
       }
 
       e.preventDefault();
-      const ws = workspaces[next];
+      const ws = visibleWorkspaces[next];
       if (ws) {
         setActiveWorkspace(ws.id);
         tabRefs.current[next]?.focus();
       }
     },
-    [workspaces, setActiveWorkspace],
+    [visibleWorkspaces, setActiveWorkspace],
   );
 
   return (
@@ -83,7 +87,7 @@ export function WorkspaceSwitcher({
       </button>
 
       <div className="flex items-center gap-1" role="tablist" aria-label="Workspaces">
-        {workspaces.map((ws, i) => {
+        {visibleWorkspaces.map((ws, i) => {
           const isActive = ws.id === focusedId;
           return (
             <button

--- a/src/components/Workspace/WorkspaceView.test.tsx
+++ b/src/components/Workspace/WorkspaceView.test.tsx
@@ -277,9 +277,7 @@ describe("WorkspaceView", () => {
 
     fireEvent.click(screen.getByTestId("workspace-item-ws-archived"));
 
-    await waitFor(() => {
-      expect(resumeWorkspace).not.toHaveBeenCalled();
-    });
+    expect(resumeWorkspace).not.toHaveBeenCalled();
   });
 
   it("should set active workspace when clicking an active workspace", async () => {

--- a/src/components/Workspace/WorkspaceView.test.tsx
+++ b/src/components/Workspace/WorkspaceView.test.tsx
@@ -242,7 +242,7 @@ describe("WorkspaceView", () => {
     expect(screen.queryByTestId("terminal-ws-1")).not.toBeInTheDocument();
   });
 
-  it("should filter out archived workspaces from list", () => {
+  it("should show archived workspaces in list", () => {
     useWorkspacesStore.setState({ activeWorkspaceId: null });
 
     const activeEntry = makeEntry({ workspaceOverrides: { id: "ws-active", state: "active", pullRequestNumber: 1 } });
@@ -258,7 +258,28 @@ describe("WorkspaceView", () => {
     );
 
     expect(screen.getByTestId("workspace-item-ws-active")).toBeInTheDocument();
-    expect(screen.queryByTestId("workspace-item-ws-archived")).not.toBeInTheDocument();
+    expect(screen.getByTestId("workspace-item-ws-archived")).toBeInTheDocument();
+  });
+
+  it("should not resume archived workspace on click", async () => {
+    useWorkspacesStore.setState({ activeWorkspaceId: null });
+
+    const archivedEntry = makeEntry({ workspaceOverrides: { id: "ws-archived", state: "archived", pullRequestNumber: 2 } });
+
+    renderWithQuery(
+      <WorkspaceView
+        workspaces={WORKSPACES}
+        statusInfo={{}}
+        entries={[archivedEntry]}
+        onBackToDashboard={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("workspace-item-ws-archived"));
+
+    await waitFor(() => {
+      expect(resumeWorkspace).not.toHaveBeenCalled();
+    });
   });
 
   it("should set active workspace when clicking an active workspace", async () => {

--- a/src/components/Workspace/WorkspaceView.tsx
+++ b/src/components/Workspace/WorkspaceView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState, type ReactElement } from "react";
+import { useCallback, useState, type ReactElement } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import type { Workspace, WorkspaceListEntry, WorkspaceStatusInfo } from "../../lib/types";
 import { resumeWorkspace } from "../../lib/tauri";
@@ -28,11 +28,6 @@ export function WorkspaceView({
   const info = active ? statusInfo[active.id] : undefined;
   const isSuspended = active !== undefined && active.state === "suspended";
 
-  const visibleEntries = useMemo(
-    () => entries.filter((e) => e.workspace.state !== "archived"),
-    [entries],
-  );
-
   const [waking, setWaking] = useState(false);
 
   const handleWakeWorkspace = useCallback(async () => {
@@ -51,8 +46,8 @@ export function WorkspaceView({
 
   const handleWorkspaceClick = useCallback(
     async (id: string) => {
-      const entry = visibleEntries.find((e) => e.workspace.id === id);
-      if (!entry) return;
+      const entry = entries.find((e) => e.workspace.id === id);
+      if (!entry || entry.workspace.state === "archived") return;
 
       try {
         if (entry.workspace.state === "suspended") {
@@ -65,7 +60,7 @@ export function WorkspaceView({
         console.error("[WorkspaceView] failed to resume workspace:", err);
       }
     },
-    [visibleEntries, queryClient, setActiveWorkspace],
+    [queryClient, setActiveWorkspace],
   );
 
   return (
@@ -113,7 +108,7 @@ export function WorkspaceView({
           )}
         </>
       ) : (
-        <WorkspaceListPage entries={visibleEntries} onWorkspaceClick={handleWorkspaceClick} />
+        <WorkspaceListPage entries={entries} onWorkspaceClick={handleWorkspaceClick} />
       )}
     </section>
   );

--- a/src/components/Workspace/WorkspaceView.tsx
+++ b/src/components/Workspace/WorkspaceView.tsx
@@ -60,7 +60,7 @@ export function WorkspaceView({
         console.error("[WorkspaceView] failed to resume workspace:", err);
       }
     },
-    [queryClient, setActiveWorkspace],
+    [entries, queryClient, setActiveWorkspace],
   );
 
   return (


### PR DESCRIPTION
## Summary

- Archived workspaces no longer appear as phantom tabs in the WorkspaceSwitcher
- Archived workspaces are now visible in the WorkspaceListPage with dimmed/disabled styling
- Clicking an archived workspace entry is a no-op (button disabled)
- Keyboard navigation in the switcher skips archived workspaces

Fixes #123

## Root cause

Three data sources for workspace display were inconsistent:
- **WorkspaceSwitcher** rendered ALL workspaces (including archived) as tabs
- **WorkspaceListPage** filtered out archived → showed "No workspaces yet"
- **StatsBar** counted only active+suspended → showed "0 Workspaces"

## Changes

| File | Change |
|------|--------|
| `WorkspaceSwitcher.tsx` | Filter archived from `visibleWorkspaces` used for rendering and keyboard nav |
| `WorkspaceView.tsx` | Remove archived filter, pass all entries to list page, guard click handler |
| `WorkspaceListPage.tsx` | Disable button + dimmed opacity for archived entries |
| `*.test.tsx` | Updated 3 test files: 62 tests pass |

## Test plan

- [x] 491 tests pass (`npx vitest run`)
- [x] TypeScript compiles (`npx tsc --noEmit`)
- [x] oxlint clean (`npm run lint`)
- [ ] Manual: verify archived workspaces appear dimmed in workspace list
- [ ] Manual: verify no phantom tabs for archived workspaces

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide archived workspaces in the switcher and keyboard nav, and show them in the list as disabled, dimmed entries. Removes phantom tabs and keeps workspace counts consistent across the UI (fixes #123).

- **Bug Fixes**
  - Filter archived workspaces from `WorkspaceSwitcher` tabs and focus order.
  - Show archived entries in `WorkspaceListPage` with a disabled button and reduced opacity.
  - In `WorkspaceView`, pass all entries to the list and ignore clicks on archived workspaces to prevent resume.

<sup>Written for commit 42a705cb0b91e08b062b2061058189aa15953733. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace switcher now hides archived workspaces for cleaner tab navigation.

* **Bug Fixes / Behavior**
  * Archived workspaces are shown in lists but rendered with reduced opacity and are non-interactive; clicking them no longer triggers actions.

* **Tests**
  * Updated and added tests to verify archived workspaces are excluded from the switcher, rendered disabled in lists, and do not trigger resume/navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->