### PR TITLE
fix(cache): resolve issue desync between dashboard and Issues page

### DIFF
--- a/src-tauri/src/cache/dashboard.rs
+++ b/src-tauri/src/cache/dashboard.rs
@@ -9,7 +9,7 @@ use crate::types::{
 };
 
 use super::activity::get_recent_activity;
-use super::issues::get_issues_for_author;
+use super::issues::get_all_issues;
 use super::pull_requests::{PR_COLS, PullRequestRow};
 use super::reviews::{compute_review_summary, get_review_requests_for_user};
 use super::workspaces::list_workspaces;
@@ -50,9 +50,9 @@ pub async fn assemble_dashboard_data(
     let my_prs = fetch_prs_by_author(pool, username).await?;
     let my_pull_requests = enrich_prs(pool, my_prs, &workspace_map).await?;
 
-    // 4. Issues authored by user (the issues table has no assignee column;
-    //    in this schema "assigned" maps to "authored" for the current user)
-    let assigned_issues = get_issues_for_author(pool, username).await?;
+    // 4. Issues assigned to user — the sync fetches by assignee, so all
+    //    issues in the table belong to the current user regardless of author.
+    let assigned_issues = get_all_issues(pool).await?;
 
     // 5. Recent activity
     let recent_activity = get_recent_activity(pool, 50, 0).await?;
@@ -221,7 +221,7 @@ fn count_to_u32(count: i64) -> u32 {
 /// Returns a [`DashboardStats`] with counts of:
 /// - `pending_reviews`: review requests for the user with status `pending` (open/draft PRs only)
 /// - `open_prs`: pull requests authored by the user in `open` or `draft` state
-/// - `open_issues`: issues authored by the user in `open` state
+/// - `open_issues`: all issues in `open` state (sync fetches by assignee, so all rows belong to the user)
 /// - `total_workspaces`: all workspaces in `active` or `suspended` state (excludes archived) (global, not user-scoped)
 /// - `unread_activity`: all activity events with `is_read = 0` (global, not user-scoped)
 pub async fn compute_dashboard_stats(
@@ -235,7 +235,7 @@ pub async fn compute_dashboard_stats(
           WHERE rr.reviewer = $1 AND rr.status = 'pending' \
           AND pr.state IN ('open', 'draft')), \
          (SELECT COUNT(*) FROM pull_requests WHERE author = $1 AND state IN ('open', 'draft')), \
-         (SELECT COUNT(*) FROM issues WHERE author = $1 AND state = 'open'), \
+         (SELECT COUNT(*) FROM issues WHERE state = 'open'), \
          (SELECT COUNT(*) FROM workspaces WHERE state IN ('active', 'suspended')), \
          (SELECT COUNT(*) FROM activity WHERE is_read = 0)",
     )
@@ -581,7 +581,8 @@ mod tests {
         };
         upsert_review_request(&pool, &rr_approved).await.unwrap();
 
-        // 1 open issue by alice, 1 closed (should not count)
+        // 1 open issue by alice, 1 open by bob (both count — sync fetches by assignee),
+        // 1 closed by alice (should not count)
         let issue_open = Issue {
             id: "issue-1".to_string(),
             number: 1,
@@ -596,6 +597,21 @@ mod tests {
             updated_at: "2026-03-20T15:00:00Z".to_string(),
         };
         upsert_issue(&pool, &issue_open).await.unwrap();
+        // Issue authored by bob but assigned to alice — still counted
+        let issue_bob = Issue {
+            id: "issue-3".to_string(),
+            number: 3,
+            title: "Bob's issue assigned to alice".to_string(),
+            author: "bob".to_string(),
+            state: IssueState::Open,
+            priority: Priority::High,
+            repo_id: "repo-1".to_string(),
+            url: "https://github.com/mpiton/prism/issues/3".to_string(),
+            labels: vec![],
+            created_at: "2026-03-01T10:00:00Z".to_string(),
+            updated_at: "2026-03-20T15:00:00Z".to_string(),
+        };
+        upsert_issue(&pool, &issue_bob).await.unwrap();
         let issue_closed = Issue {
             id: "issue-2".to_string(),
             number: 2,
@@ -670,7 +686,7 @@ mod tests {
 
         assert_eq!(stats.pending_reviews, 1, "only pending review requests");
         assert_eq!(stats.open_prs, 2, "only open/draft PRs by alice");
-        assert_eq!(stats.open_issues, 1, "only open issues by alice");
+        assert_eq!(stats.open_issues, 2, "all open issues regardless of author");
         assert_eq!(stats.total_workspaces, 2, "active + suspended workspaces");
         assert_eq!(stats.unread_activity, 1, "only unread activity");
         pool.close().await;

--- a/src-tauri/src/cache/dashboard.rs
+++ b/src-tauri/src/cache/dashboard.rs
@@ -19,7 +19,7 @@ use super::workspaces::list_workspaces;
 /// Composes data from multiple cache tables into a single [`DashboardData`]:
 /// 1. PRs where the user has a **pending** review request
 /// 2. PRs authored by the user
-/// 3. Issues authored by the user
+/// 3. Issues assigned to the user
 /// 4. Recent activity (last 50 events)
 /// 5. All workspaces
 ///

--- a/src-tauri/src/cache/issues.rs
+++ b/src-tauri/src/cache/issues.rs
@@ -165,32 +165,33 @@ pub async fn get_all_issues(pool: &SqlitePool) -> Result<Vec<Issue>, AppError> {
 /// Delete issues whose IDs are not in `current_ids`, across all repos.
 /// Returns the number of deleted rows.
 ///
-/// When `current_ids` is empty, treats it as a no-op and returns 0. An empty
-/// list likely signals a partial GraphQL response (null `assigned_issues`),
-/// not "the user has zero assigned issues" — wiping the table would be unsafe.
+/// The caller is responsible for distinguishing "no data" from "zero issues".
+/// Pass only authoritative ID lists (i.e. when the GraphQL response was
+/// complete and not paginated). When `current_ids` is empty, all issues are
+/// deleted — the user genuinely has zero assigned issues.
 ///
 /// Uses a fetch-then-delete strategy: fetches all existing IDs, computes the
 /// set difference in Rust, then deletes stale IDs in chunks of 998 to stay
 /// under `SQLite`'s parameter limit (999).
 ///
-/// Accepts a pool reference (runs outside the sync transaction — stale
-/// cleanup is best-effort, similar to activity sync).
+/// Accepts `&mut SqliteConnection` so it can run inside the caller's
+/// transaction, preventing races with concurrent syncs.
 pub async fn delete_issues_not_in(
-    pool: &SqlitePool,
+    conn: &mut sqlx::SqliteConnection,
     current_ids: &[String],
 ) -> Result<u64, AppError> {
     const CHUNK_SIZE: usize = 998;
 
-    // Empty current_ids is treated as a no-op: a partial GraphQL response
-    // may omit the assigned_issues field entirely, yielding an empty Vec.
-    // Wiping the table in that case would be data-destructive.
     if current_ids.is_empty() {
-        return Ok(0);
+        let result = sqlx::query("DELETE FROM issues")
+            .execute(&mut *conn)
+            .await?;
+        return Ok(result.rows_affected());
     }
 
     // Fetch all existing issue IDs
     let existing: Vec<(String,)> = sqlx::query_as("SELECT id FROM issues")
-        .fetch_all(pool)
+        .fetch_all(&mut *conn)
         .await?;
 
     // Compute stale IDs (exist in DB but not in current_ids)
@@ -219,7 +220,7 @@ pub async fn delete_issues_not_in(
             query = query.bind(id);
         }
 
-        let result = query.execute(pool).await?;
+        let result = query.execute(&mut *conn).await?;
         total_deleted += result.rows_affected();
     }
 
@@ -602,7 +603,9 @@ mod tests {
         upsert_issue(&pool, &i3).await.unwrap();
 
         let current_ids = vec!["issue-1".to_string(), "issue-3".to_string()];
-        let deleted = delete_issues_not_in(&pool, &current_ids).await.unwrap();
+        let mut conn = pool.acquire().await.unwrap();
+        let deleted = delete_issues_not_in(&mut conn, &current_ids).await.unwrap();
+        drop(conn);
 
         assert_eq!(deleted, 1, "should delete 1 stale issue");
 
@@ -631,14 +634,18 @@ mod tests {
             .await
             .unwrap();
 
-        let deleted = delete_issues_not_in(&pool, &[]).await.unwrap();
-        assert_eq!(deleted, 0, "empty current_ids is a no-op (safety guard)");
+        let mut conn = pool.acquire().await.unwrap();
+        let deleted = delete_issues_not_in(&mut conn, &[]).await.unwrap();
+        drop(conn);
+        assert_eq!(
+            deleted, 3,
+            "empty current_ids deletes all (authoritative empty)"
+        );
 
         let remaining = get_all_issues(&pool).await.unwrap();
-        assert_eq!(
-            remaining.len(),
-            3,
-            "all issues preserved when current_ids is empty"
+        assert!(
+            remaining.is_empty(),
+            "all issues deleted on authoritative empty"
         );
 
         pool.close().await;

--- a/src-tauri/src/cache/issues.rs
+++ b/src-tauri/src/cache/issues.rs
@@ -151,6 +151,81 @@ pub async fn get_issues_for_author(
     rows.into_iter().map(Issue::try_from).collect()
 }
 
+/// Return all issues in the database, ordered by `updated_at DESC`.
+///
+/// No author filter — sync fetches issues assigned to the current user,
+/// so all rows in the table belong to them regardless of the `author` field.
+pub async fn get_all_issues(pool: &SqlitePool) -> Result<Vec<Issue>, AppError> {
+    let sql = format!("SELECT {ISSUE_COLS} FROM issues ORDER BY updated_at DESC");
+    let rows: Vec<IssueRow> = sqlx::query_as(&sql).fetch_all(pool).await?;
+
+    rows.into_iter().map(Issue::try_from).collect()
+}
+
+/// Delete issues whose IDs are not in `current_ids`, across all repos.
+/// Returns the number of deleted rows.
+///
+/// When `current_ids` is empty, treats it as a no-op and returns 0. An empty
+/// list likely signals a partial GraphQL response (null `assigned_issues`),
+/// not "the user has zero assigned issues" — wiping the table would be unsafe.
+///
+/// Uses a fetch-then-delete strategy: fetches all existing IDs, computes the
+/// set difference in Rust, then deletes stale IDs in chunks of 998 to stay
+/// under `SQLite`'s parameter limit (999).
+///
+/// Accepts a pool reference (runs outside the sync transaction — stale
+/// cleanup is best-effort, similar to activity sync).
+pub async fn delete_issues_not_in(
+    pool: &SqlitePool,
+    current_ids: &[String],
+) -> Result<u64, AppError> {
+    const CHUNK_SIZE: usize = 998;
+
+    // Empty current_ids is treated as a no-op: a partial GraphQL response
+    // may omit the assigned_issues field entirely, yielding an empty Vec.
+    // Wiping the table in that case would be data-destructive.
+    if current_ids.is_empty() {
+        return Ok(0);
+    }
+
+    // Fetch all existing issue IDs
+    let existing: Vec<(String,)> = sqlx::query_as("SELECT id FROM issues")
+        .fetch_all(pool)
+        .await?;
+
+    // Compute stale IDs (exist in DB but not in current_ids)
+    let keep: std::collections::HashSet<&str> = current_ids.iter().map(String::as_str).collect();
+    let stale_ids: Vec<&str> = existing
+        .iter()
+        .map(|(id,)| id.as_str())
+        .filter(|id| !keep.contains(id))
+        .collect();
+
+    if stale_ids.is_empty() {
+        return Ok(0);
+    }
+
+    let mut total_deleted: u64 = 0;
+
+    for chunk in stale_ids.chunks(CHUNK_SIZE) {
+        let placeholders: Vec<String> = (1..=chunk.len()).map(|i| format!("${i}")).collect();
+        let sql = format!(
+            "DELETE FROM issues WHERE id IN ({})",
+            placeholders.join(", ")
+        );
+
+        let mut query = sqlx::query(&sql);
+        for id in chunk {
+            query = query.bind(id);
+        }
+
+        let result = query.execute(pool).await?;
+        total_deleted += result.rows_affected();
+    }
+
+    Ok(total_deleted)
+}
+
 /// Delete issues for a repo whose IDs are not in `current_ids`.
 /// Returns the number of deleted rows.
 ///
@@ -484,5 +559,88 @@ mod tests {
             priority_from_str("CRITICAL").is_err(),
             "wrong case should fail"
         );
+    }
+
+    #[tokio::test]
+    async fn test_get_all_issues_returns_all_regardless_of_author() {
+        let (pool, _tmp) = test_pool().await;
+        upsert_repo(&pool, &sample_repo()).await.unwrap();
+
+        let i1 = sample_issue("issue-1", 1, "Alice issue");
+        let mut i2 = sample_issue("issue-2", 2, "Bob issue");
+        i2.author = "bob".to_string();
+        let mut i3 = sample_issue("issue-3", 3, "Carol issue");
+        i3.author = "carol".to_string();
+        i3.updated_at = "2026-04-01T10:00:00Z".to_string();
+
+        upsert_issue(&pool, &i1).await.unwrap();
+        upsert_issue(&pool, &i2).await.unwrap();
+        upsert_issue(&pool, &i3).await.unwrap();
+
+        let all = get_all_issues(&pool).await.unwrap();
+        assert_eq!(
+            all.len(),
+            3,
+            "should return all issues regardless of author"
+        );
+        assert_eq!(all[0].id, "issue-3", "ordered by updated_at DESC");
+
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_delete_issues_not_in_removes_stale() {
+        let (pool, _tmp) = test_pool().await;
+        upsert_repo(&pool, &sample_repo()).await.unwrap();
+
+        let i1 = sample_issue("issue-1", 1, "Keep");
+        let i2 = sample_issue("issue-2", 2, "Delete");
+        let i3 = sample_issue("issue-3", 3, "Keep too");
+
+        upsert_issue(&pool, &i1).await.unwrap();
+        upsert_issue(&pool, &i2).await.unwrap();
+        upsert_issue(&pool, &i3).await.unwrap();
+
+        let current_ids = vec!["issue-1".to_string(), "issue-3".to_string()];
+        let deleted = delete_issues_not_in(&pool, &current_ids).await.unwrap();
+
+        assert_eq!(deleted, 1, "should delete 1 stale issue");
+
+        let remaining = get_all_issues(&pool).await.unwrap();
+        assert_eq!(remaining.len(), 2);
+        let ids: Vec<&str> = remaining.iter().map(|i| i.id.as_str()).collect();
+        assert!(ids.contains(&"issue-1"));
+        assert!(ids.contains(&"issue-3"));
+        assert!(!ids.contains(&"issue-2"));
+
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_delete_issues_not_in_empty_deletes_all() {
+        let (pool, _tmp) = test_pool().await;
+        upsert_repo(&pool, &sample_repo()).await.unwrap();
+
+        upsert_issue(&pool, &sample_issue("issue-1", 1, "First"))
+            .await
+            .unwrap();
+        upsert_issue(&pool, &sample_issue("issue-2", 2, "Second"))
+            .await
+            .unwrap();
+        upsert_issue(&pool, &sample_issue("issue-3", 3, "Third"))
+            .await
+            .unwrap();
+
+        let deleted = delete_issues_not_in(&pool, &[]).await.unwrap();
+        assert_eq!(deleted, 0, "empty current_ids is a no-op (safety guard)");
+
+        let remaining = get_all_issues(&pool).await.unwrap();
+        assert_eq!(
+            remaining.len(),
+            3,
+            "all issues preserved when current_ids is empty"
+        );
+
+        pool.close().await;
     }
 }

--- a/src-tauri/src/cache/sync.rs
+++ b/src-tauri/src/cache/sync.rs
@@ -9,7 +9,7 @@ use sqlx::SqlitePool;
 
 use crate::cache::activity::upsert_activity;
 use crate::cache::dashboard::{compute_dashboard_stats, get_latest_sync_at};
-use crate::cache::issues::upsert_issue;
+use crate::cache::issues::{delete_issues_not_in, upsert_issue};
 use crate::cache::pull_requests::upsert_pull_request;
 use crate::cache::repos::{list_repos, upsert_repo};
 use crate::cache::reviews::upsert_review;
@@ -164,7 +164,7 @@ pub async fn sync_dashboard(
     let mut tx = pool.begin().await?;
 
     #[allow(clippy::explicit_auto_deref)] // &mut *tx required: Transaction → SqliteConnection
-    persist_response(&mut *tx, &data).await?;
+    let synced_issue_ids = persist_response(&mut *tx, &data).await?;
 
     let now = chrono::Utc::now().to_rfc3339();
     for repo in &enabled {
@@ -177,6 +177,13 @@ pub async fn sync_dashboard(
     }
 
     tx.commit().await?;
+
+    // Stale issue cleanup is best-effort — don't fail dashboard sync if it errors.
+    match delete_issues_not_in(pool, &synced_issue_ids).await {
+        Ok(n) if n > 0 => tracing::info!("stale issue cleanup: {n} removed"),
+        Ok(_) => {}
+        Err(e) => tracing::warn!("stale issue cleanup failed: {e}"),
+    }
 
     // Activity sync is best-effort — don't fail dashboard sync if it errors.
     match sync_activity(client, pool, username, &activity_since).await {
@@ -264,7 +271,7 @@ fn build_query_variables(
 async fn persist_response(
     conn: &mut sqlx::SqliteConnection,
     data: &dashboard_data::ResponseData,
-) -> Result<(), AppError> {
+) -> Result<Vec<String>, AppError> {
     let mut seen_pr_ids: HashSet<String> = HashSet::new();
 
     if let Some(nodes) = &data.review_requests.nodes {
@@ -287,16 +294,19 @@ async fn persist_response(
         }
     }
 
+    let mut synced_issue_ids: Vec<String> = Vec::new();
+
     if let Some(nodes) = &data.assigned_issues.nodes {
         for node in nodes.iter().filter_map(|n| n.as_ref()) {
             if let Some(issue_fields) = node.as_issue_fields() {
                 let issue = map_issue(issue_fields)?;
+                synced_issue_ids.push(issue.id.clone());
                 upsert_issue(&mut *conn, &issue).await?;
             }
         }
     }
 
-    Ok(())
+    Ok(synced_issue_ids)
 }
 
 /// Persist a single PR with its associated reviews and review requests.

--- a/src-tauri/src/cache/sync.rs
+++ b/src-tauri/src/cache/sync.rs
@@ -176,14 +176,16 @@ pub async fn sync_dashboard(
             .await?;
     }
 
-    tx.commit().await?;
-
-    // Stale issue cleanup is best-effort — don't fail dashboard sync if it errors.
-    match delete_issues_not_in(pool, &synced_issue_ids).await {
-        Ok(n) if n > 0 => tracing::info!("stale issue cleanup: {n} removed"),
-        Ok(_) => {}
-        Err(e) => tracing::warn!("stale issue cleanup failed: {e}"),
+    // Stale issue cleanup inside the transaction: only when we have an
+    // authoritative (non-paginated) issue list. None means partial data
+    // (null field or paginated response) — skip cleanup to avoid deleting
+    // valid issues beyond the first page.
+    if let Some(ref ids) = synced_issue_ids {
+        #[allow(clippy::explicit_auto_deref)]
+        delete_issues_not_in(&mut *tx, ids).await?;
     }
+
+    tx.commit().await?;
 
     // Activity sync is best-effort — don't fail dashboard sync if it errors.
     match sync_activity(client, pool, username, &activity_since).await {
@@ -268,10 +270,15 @@ fn build_query_variables(
 /// Extracts PRs from `review_requests` and `my_pull_requests` search results,
 /// deduplicates by PR ID, then upserts all entities including reviews
 /// and review requests. Issues are extracted from `assigned_issues`.
+///
+/// Returns `Some(ids)` when the issues result is authoritative (nodes present
+/// and not paginated), or `None` when the data is partial (null field or
+/// `has_next_page` is true). The caller uses this to decide whether stale
+/// issue cleanup is safe.
 async fn persist_response(
     conn: &mut sqlx::SqliteConnection,
     data: &dashboard_data::ResponseData,
-) -> Result<Vec<String>, AppError> {
+) -> Result<Option<Vec<String>>, AppError> {
     let mut seen_pr_ids: HashSet<String> = HashSet::new();
 
     if let Some(nodes) = &data.review_requests.nodes {
@@ -294,6 +301,12 @@ async fn persist_response(
         }
     }
 
+    // Track whether the issues result is authoritative. If nodes is None
+    // (partial response) or has_next_page is true (paginated — the query
+    // caps at first:100), we cannot safely delete issues not in this set.
+    let issues_authoritative =
+        data.assigned_issues.nodes.is_some() && !data.assigned_issues.page_info.has_next_page;
+
     let mut synced_issue_ids: Vec<String> = Vec::new();
 
     if let Some(nodes) = &data.assigned_issues.nodes {
@@ -306,7 +319,11 @@ async fn persist_response(
         }
     }
 
-    Ok(synced_issue_ids)
+    if issues_authoritative {
+        Ok(Some(synced_issue_ids))
+    } else {
+        Ok(None)
+    }
 }
 
 /// Persist a single PR with its associated reviews and review requests.
@@ -904,7 +921,12 @@ mod tests {
                     dashboard_data::DashboardDataMyPullRequestsNodes::PullRequest(pr),
                 )]),
             },
-            assigned_issues: dashboard_data::DashboardDataAssignedIssues { nodes: None },
+            assigned_issues: dashboard_data::DashboardDataAssignedIssues {
+                page_info: dashboard_data::DashboardDataAssignedIssuesPageInfo {
+                    has_next_page: false,
+                },
+                nodes: None,
+            },
         };
 
         {
@@ -1012,7 +1034,12 @@ mod tests {
                 )]),
             },
             my_pull_requests: dashboard_data::DashboardDataMyPullRequests { nodes: None },
-            assigned_issues: dashboard_data::DashboardDataAssignedIssues { nodes: None },
+            assigned_issues: dashboard_data::DashboardDataAssignedIssues {
+                page_info: dashboard_data::DashboardDataAssignedIssuesPageInfo {
+                    has_next_page: false,
+                },
+                nodes: None,
+            },
         };
 
         let mut tx = pool.begin().await.unwrap();

--- a/src-tauri/src/github/graphql/dashboard.graphql
+++ b/src-tauri/src/github/graphql/dashboard.graphql
@@ -75,6 +75,7 @@ query DashboardData(
     }
   }
   assignedIssues: search(query: $issuesQuery, type: ISSUE, first: $first) {
+    pageInfo { hasNextPage }
     nodes {
       __typename
       ... on Issue { ...IssueFields }

--- a/src/components/Overview/Overview.test.tsx
+++ b/src/components/Overview/Overview.test.tsx
@@ -126,6 +126,7 @@ function setupMock(dashboard: DashboardData | null = makeDashboard()) {
     isLoading: false,
     error: null,
     authExpired: false,
+    syncError: null,
     forceSync: vi.fn(),
     isSyncing: false,
   });
@@ -240,6 +241,7 @@ describe("Overview", () => {
       isLoading: true,
       error: null,
       authExpired: false,
+      syncError: null,
       forceSync: vi.fn(),
       isSyncing: false,
     });
@@ -256,6 +258,7 @@ describe("Overview", () => {
       isLoading: false,
       error: new Error("Network error"),
       authExpired: false,
+      syncError: null,
       forceSync: vi.fn(),
       isSyncing: false,
     });
@@ -272,6 +275,7 @@ describe("Overview", () => {
       isLoading: false,
       error: new Error("Stats failed"),
       authExpired: false,
+      syncError: null,
       forceSync: vi.fn(),
       isSyncing: false,
     });

--- a/src/hooks/useGitHubData.test.ts
+++ b/src/hooks/useGitHubData.test.ts
@@ -163,12 +163,12 @@ describe("useGitHubData", () => {
     const { unmount } = renderHook(() => useGitHubData(), { wrapper });
 
     await waitFor(() => {
-      expect(onEvent).toHaveBeenCalledTimes(3);
+      expect(onEvent).toHaveBeenCalledTimes(4);
     });
 
     unmount();
-    // All 3 listeners should be cleaned up
-    expect(unlistenFn).toHaveBeenCalledTimes(3);
+    // All 4 listeners should be cleaned up (updated, expired, restored, sync_error)
+    expect(unlistenFn).toHaveBeenCalledTimes(4);
   });
 
   it("should set authExpired when auth:expired event fires", async () => {

--- a/src/hooks/useGitHubData.test.ts
+++ b/src/hooks/useGitHubData.test.ts
@@ -168,7 +168,9 @@ describe("useGitHubData", () => {
 
     unmount();
     // All 4 listeners should be cleaned up (updated, expired, restored, sync_error)
-    expect(unlistenFn).toHaveBeenCalledTimes(4);
+    await waitFor(() => {
+      expect(unlistenFn).toHaveBeenCalledTimes(4);
+    });
   });
 
   it("should set syncError on github:sync_error and clear on github:updated", async () => {
@@ -204,10 +206,10 @@ describe("useGitHubData", () => {
     const updatedCall = (onEvent as Mock).mock.calls.find(
       (c: unknown[]) => c[0] === "github:updated",
     );
-    const updatedCallback = updatedCall![1] as () => void;
+    const updatedCallback = updatedCall![1] as () => Promise<void>;
 
-    await act(() => {
-      updatedCallback();
+    await act(async () => {
+      await updatedCallback();
     });
 
     expect(result.current.syncError).toBeNull();

--- a/src/hooks/useGitHubData.test.ts
+++ b/src/hooks/useGitHubData.test.ts
@@ -171,6 +171,48 @@ describe("useGitHubData", () => {
     expect(unlistenFn).toHaveBeenCalledTimes(4);
   });
 
+  it("should set syncError on github:sync_error and clear on github:updated", async () => {
+    (getGithubDashboard as Mock).mockResolvedValue(MOCK_DASHBOARD);
+    (getGithubStats as Mock).mockResolvedValue(MOCK_STATS);
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useGitHubData(), { wrapper });
+
+    expect(result.current.syncError).toBeNull();
+
+    await waitFor(() => {
+      expect(onEvent).toHaveBeenCalledWith(
+        "github:sync_error",
+        expect.any(Function),
+      );
+    });
+
+    // Fire sync_error
+    const syncErrorCall = (onEvent as Mock).mock.calls.find(
+      (c: unknown[]) => c[0] === "github:sync_error",
+    );
+    expect(syncErrorCall).toBeDefined();
+    const syncErrorCallback = syncErrorCall![1] as (payload: string) => void;
+
+    await act(() => {
+      syncErrorCallback("502 Bad Gateway");
+    });
+
+    expect(result.current.syncError).toBe("502 Bad Gateway");
+
+    // Fire github:updated to clear the error
+    const updatedCall = (onEvent as Mock).mock.calls.find(
+      (c: unknown[]) => c[0] === "github:updated",
+    );
+    const updatedCallback = updatedCall![1] as () => void;
+
+    await act(() => {
+      updatedCallback();
+    });
+
+    expect(result.current.syncError).toBeNull();
+  });
+
   it("should set authExpired when auth:expired event fires", async () => {
     (getGithubDashboard as Mock).mockResolvedValue(MOCK_DASHBOARD);
     (getGithubStats as Mock).mockResolvedValue(MOCK_STATS);

--- a/src/hooks/useGitHubData.ts
+++ b/src/hooks/useGitHubData.ts
@@ -45,6 +45,9 @@ export function useGitHubData(refetchInterval?: number) {
       setSyncError(null);
       await invalidateGitHub(queryClient);
     },
+    onError: (err: unknown) => {
+      setSyncError(err instanceof Error ? err.message : "Force sync failed");
+    },
   });
 
   useEffect(() => {

--- a/src/hooks/useGitHubData.ts
+++ b/src/hooks/useGitHubData.ts
@@ -21,6 +21,7 @@ function invalidateGitHub(queryClient: ReturnType<typeof useQueryClient>) {
 export function useGitHubData(refetchInterval?: number) {
   const queryClient = useQueryClient();
   const [authExpired, setAuthExpired] = useState(false);
+  const [syncError, setSyncError] = useState<string | null>(null);
 
   const dashboardQuery = useQuery({
     queryKey: ["github", "dashboard"],
@@ -41,6 +42,7 @@ export function useGitHubData(refetchInterval?: number) {
   const syncMutation = useMutation({
     mutationFn: forceGithubSync,
     onSuccess: async () => {
+      setSyncError(null);
       await invalidateGitHub(queryClient);
     },
   });
@@ -50,6 +52,7 @@ export function useGitHubData(refetchInterval?: number) {
     const unlisteners: (() => void)[] = [];
 
     onEvent(TAURI_EVENTS["github:updated"], async () => {
+      setSyncError(null);
       await invalidateGitHub(queryClient);
     }).then((fn) => {
       if (cancelled) {
@@ -86,6 +89,18 @@ export function useGitHubData(refetchInterval?: number) {
       console.error("[useGitHubData] failed to register auth:restored listener:", err);
     });
 
+    onEvent<string>(TAURI_EVENTS["github:sync_error"], (errorMsg) => {
+      setSyncError(typeof errorMsg === "string" ? errorMsg : "Sync failed");
+    }).then((fn) => {
+      if (cancelled) {
+        fn();
+      } else {
+        unlisteners.push(fn);
+      }
+    }).catch((err: unknown) => {
+      console.error("[useGitHubData] failed to register github:sync_error listener:", err);
+    });
+
     return () => {
       cancelled = true;
       for (const unlisten of unlisteners) {
@@ -100,6 +115,7 @@ export function useGitHubData(refetchInterval?: number) {
     isLoading: dashboardQuery.isLoading || statsQuery.isLoading,
     error: dashboardQuery.error ?? statsQuery.error ?? null,
     authExpired,
+    syncError,
     forceSync: syncMutation.mutate,
     isSyncing: syncMutation.isPending,
   };


### PR DESCRIPTION
## Summary

Fixes #157 — Issues displayed in the dashboard Overview and the dedicated Issues page were desynchronized after 502/504 polling errors.

**Root cause:** The sync fetched issues from GitHub by `assignee:{username}` but the dashboard queried SQLite with `WHERE author = $1`. Issues assigned to the user but authored by someone else were synced to the DB but never displayed. Additionally, `delete_stale_issues` was dead code, so old issues accumulated indefinitely.

**Changes:**
- **`issues.rs`**: Added `get_all_issues()` (no author filter) and `delete_issues_not_in()` with safety guard against empty-list data destruction
- **`dashboard.rs`**: Replaced `get_issues_for_author` with `get_all_issues`; removed author filter from stats COUNT sub-select
- **`sync.rs`**: `persist_response` now returns synced issue IDs; stale cleanup runs as best-effort after transaction commit
- **`useGitHubData.ts`**: Added `github:sync_error` event listener exposing `syncError` state; cleared on successful sync or force-sync

## Test plan

- [ ] Verify issues assigned to user but authored by others now appear in both dashboard and Issues page
- [ ] Verify stale issues (unassigned on GitHub) are cleaned up after successful sync
- [ ] Verify 502/504 polling errors don't wipe the issues table (empty current_ids is a no-op)
- [ ] Verify `syncError` is set on polling failure and cleared on next successful sync
- [ ] `cargo test` — all Rust tests pass (issues: 10, dashboard: 8, polling: 17)
- [ ] `npx vitest run` — all 486 TypeScript tests pass
- [ ] `cargo clippy -- -D warnings` — clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #157 by aligning dashboard issue queries with assignee-based sync and making stale-issue cleanup safe and transactional. The dashboard now shows all assigned issues regardless of author and surfaces sync errors, including force-sync failures.

- **Bug Fixes**
  - Replace author-scoped issue queries with `get_all_issues()`; dashboard stats now count all open issues.
  - Make stale cleanup transactional and pagination-aware: `persist_response()` returns `Option<Vec<String>>`; `delete_issues_not_in()` runs inside the sync transaction only when the issues result is authoritative (nodes present and not paginated), and deletes all on authoritative empty; skip cleanup on partial/paginated data.
  - Add `pageInfo { hasNextPage }` to the issues GraphQL query to detect pagination.

- **New Features**
  - Expose `syncError` in `useGitHubData`; listen to `github:sync_error`, clear on `github:updated` or successful/force sync, and set on force-sync failures via `onError`.

<sup>Written for commit 16ba9cd6f05374468210335ae8edacda5e7eb8d4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard now shows all issues assigned to you.
  * Visible sync error reporting added to the UI.

* **Bug Fixes / Improvements**
  * Stale-issue cleanup runs only after a complete (non-paginated) sync to prevent accidental deletions during partial syncs.
  * Open-issue counts updated to reflect global assigned issues, improving dashboard accuracy.

* **Tests**
  * Added/updated tests for global retrieval, stale deletion, pagination behavior, and sync-error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->