### PR TITLE
fix(ui): resolve tray menu actions not working on Linux (#154)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -546,7 +546,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6170,7 +6170,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,6 +13,9 @@ use std::sync::Mutex;
 use std::sync::atomic::AtomicBool;
 
 use sqlx::SqlitePool;
+
+/// Label of the main application window — shared between tray and app setup.
+pub(crate) const MAIN_WINDOW_LABEL: &str = "main";
 use tauri::Manager;
 use tracing::info;
 
@@ -212,7 +215,7 @@ pub fn run() {
             app.manage(SyncInFlight::default());
 
             // Set window icon from bundled PNG
-            if let Some(window) = app.get_webview_window(tray::MAIN_WINDOW_LABEL) {
+            if let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) {
                 let png_bytes = include_bytes!("../icons/icon.png");
                 if let Ok(img) =
                     image::load_from_memory_with_format(png_bytes, image::ImageFormat::Png)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -185,6 +185,9 @@ pub fn run() {
         builder = builder.plugin(tauri_plugin_pilot::init());
     }
 
+    #[cfg(not(any(target_os = "android", target_os = "ios")))]
+    let builder = builder.on_menu_event(tray::handle_menu_event);
+
     builder
         .setup(|app| {
             // Initialize SQLite database

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -212,7 +212,7 @@ pub fn run() {
             app.manage(SyncInFlight::default());
 
             // Set window icon from bundled PNG
-            if let Some(window) = app.get_webview_window("main") {
+            if let Some(window) = app.get_webview_window(tray::MAIN_WINDOW_LABEL) {
                 let png_bytes = include_bytes!("../icons/icon.png");
                 if let Ok(img) =
                     image::load_from_memory_with_format(png_bytes, image::ImageFormat::Png)

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -3,6 +3,7 @@ use tauri::menu::{Menu, MenuItem, PredefinedMenuItem};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
 use tracing::warn;
 
+pub(crate) const MAIN_WINDOW_LABEL: &str = "main";
 pub(crate) const TRAY_ID: &str = "prism_tray";
 pub(crate) const MENU_SHOW: &str = "show_prism";
 pub(crate) const MENU_FORCE_SYNC: &str = "force_sync";
@@ -73,7 +74,7 @@ pub fn update_tray_badge(app_handle: &tauri::AppHandle, pending_count: u32) -> R
 /// failure but does not abort — best-effort on compositors (Wayland) that
 /// restrict focus-stealing.
 fn show_main_window(app: &tauri::AppHandle) {
-    if let Some(window) = app.get_webview_window("main") {
+    if let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) {
         // unminimize first — no-op if already normal
         if let Err(e) = window.unminimize() {
             tracing::debug!("tray: unminimize failed (may not be minimized): {e}");
@@ -135,9 +136,10 @@ fn handle_tray_icon_event(tray: &tauri::tray::TrayIcon, event: TrayIconEvent) {
     } = event
     {
         let app = tray.app_handle();
-        if let Some(window) = app.get_webview_window("main") {
+        if let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) {
             let visible = window.is_visible().unwrap_or(false);
-            if visible {
+            let minimized = window.is_minimized().unwrap_or(false);
+            if visible && !minimized {
                 if let Err(e) = window.hide() {
                     warn!("tray: failed to hide window: {e}");
                 }

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -3,7 +3,6 @@ use tauri::menu::{Menu, MenuItem, PredefinedMenuItem};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
 use tracing::warn;
 
-pub(crate) const MAIN_WINDOW_LABEL: &str = "main";
 pub(crate) const TRAY_ID: &str = "prism_tray";
 pub(crate) const MENU_SHOW: &str = "show_prism";
 pub(crate) const MENU_FORCE_SYNC: &str = "force_sync";
@@ -74,7 +73,7 @@ pub fn update_tray_badge(app_handle: &tauri::AppHandle, pending_count: u32) -> R
 /// failure but does not abort — best-effort on compositors (Wayland) that
 /// restrict focus-stealing.
 fn show_main_window(app: &tauri::AppHandle) {
-    if let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) {
+    if let Some(window) = app.get_webview_window(crate::MAIN_WINDOW_LABEL) {
         // unminimize first — no-op if already normal
         if let Err(e) = window.unminimize() {
             tracing::debug!("tray: unminimize failed (may not be minimized): {e}");
@@ -136,7 +135,7 @@ fn handle_tray_icon_event(tray: &tauri::tray::TrayIcon, event: TrayIconEvent) {
     } = event
     {
         let app = tray.app_handle();
-        if let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) {
+        if let Some(window) = app.get_webview_window(crate::MAIN_WINDOW_LABEL) {
             let visible = window.is_visible().unwrap_or(false);
             let minimized = window.is_minimized().unwrap_or(false);
             if visible && !minimized {

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -50,7 +50,6 @@ pub fn setup_tray(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>
         .menu(&menu)
         .show_menu_on_left_click(false)
         .tooltip(tooltip)
-        .on_menu_event(handle_menu_event)
         .on_tray_icon_event(handle_tray_icon_event)
         .build(app)?;
 
@@ -68,28 +67,47 @@ pub fn update_tray_badge(app_handle: &tauri::AppHandle, pending_count: u32) -> R
         .map_err(|e| format!("failed to set tooltip: {e}"))
 }
 
+/// Attempt to show and focus the main application window.
+///
+/// Calls `unminimize`, `show`, then `set_focus` in sequence. Each step logs on
+/// failure but does not abort — best-effort on compositors (Wayland) that
+/// restrict focus-stealing.
+fn show_main_window(app: &tauri::AppHandle) {
+    if let Some(window) = app.get_webview_window("main") {
+        // unminimize first — no-op if already normal
+        if let Err(e) = window.unminimize() {
+            tracing::debug!("tray: unminimize failed (may not be minimized): {e}");
+        }
+        if let Err(e) = window.show() {
+            tracing::warn!("tray: failed to show window: {e}");
+        }
+        if let Err(e) = window.set_focus() {
+            tracing::warn!("tray: failed to focus window: {e}");
+        }
+    } else {
+        tracing::warn!("tray: main window not found");
+    }
+}
+
 #[allow(clippy::needless_pass_by_value)] // Signature imposed by Tauri on_menu_event callback
-fn handle_menu_event(app: &tauri::AppHandle, event: tauri::menu::MenuEvent) {
+pub(crate) fn handle_menu_event(app: &tauri::AppHandle, event: tauri::menu::MenuEvent) {
+    tracing::info!("tray: menu event received: {}", event.id().as_ref());
     match event.id().as_ref() {
         MENU_SHOW => {
-            if let Some(window) = app.get_webview_window("main") {
-                if let Err(e) = window.show() {
-                    warn!("tray: failed to show window: {e}");
-                }
-                if let Err(e) = window.set_focus() {
-                    warn!("tray: failed to focus window: {e}");
-                }
-            } else {
-                warn!("tray: main window not found for MENU_SHOW");
-            }
+            show_main_window(app);
         }
         MENU_FORCE_SYNC => {
             let handle = app.clone();
             tauri::async_runtime::spawn(async move {
+                tracing::info!("tray: force sync triggered from menu");
                 let pool = handle.state::<sqlx::SqlitePool>();
                 let cached = handle.state::<crate::commands::GithubUsername>();
                 match crate::commands::run_force_sync(&handle, &pool, &cached).await {
                     Ok(stats) => {
+                        tracing::info!(
+                            "tray: force sync completed, {} pending reviews",
+                            stats.pending_reviews
+                        );
                         if let Err(e) = update_tray_badge(&handle, stats.pending_reviews) {
                             warn!("tray: failed to update badge after sync: {e}");
                         }
@@ -109,6 +127,7 @@ fn handle_menu_event(app: &tauri::AppHandle, event: tauri::menu::MenuEvent) {
 
 #[allow(clippy::needless_pass_by_value)] // Signature imposed by Tauri on_tray_icon_event callback
 fn handle_tray_icon_event(tray: &tauri::tray::TrayIcon, event: TrayIconEvent) {
+    tracing::debug!("tray: icon event received: {event:?}");
     if let TrayIconEvent::Click {
         button: MouseButton::Left,
         button_state: MouseButtonState::Up,
@@ -123,12 +142,7 @@ fn handle_tray_icon_event(tray: &tauri::tray::TrayIcon, event: TrayIconEvent) {
                     warn!("tray: failed to hide window: {e}");
                 }
             } else {
-                if let Err(e) = window.show() {
-                    warn!("tray: failed to show window: {e}");
-                }
-                if let Err(e) = window.set_focus() {
-                    warn!("tray: failed to focus window: {e}");
-                }
+                show_main_window(app);
             }
         } else {
             warn!("tray: main window not found for tray icon click");


### PR DESCRIPTION
## Summary

- Move `on_menu_event` handler from `TrayIconBuilder` to app-level `Builder::on_menu_event` for more reliable DBus event routing on Linux (libayatana-appindicator)
- Extract `show_main_window()` helper with `unminimize` + `show` + `set_focus` sequence for better Wayland compositor compatibility
- Add diagnostic `tracing::info!` / `tracing::debug!` at all tray handler entry points to enable runtime debugging

## Root Cause

On Linux, the system tray uses libayatana-appindicator via DBus. The menu is rendered by the desktop environment (GNOME, KDE), not by the app. Menu events routed through `TrayIconBuilder::on_menu_event` may not fire reliably because DBus menu events follow a different code path than the tray-specific handler. Moving to `Builder::on_menu_event` (app-level) uses the global event handler which receives all menu events including tray menu events.

Additionally, `window.show()` + `window.set_focus()` can fail silently on Wayland compositors that restrict focus-stealing. The new `show_main_window()` helper adds `unminimize()` as a first step and logs each operation for debugging.

## Changes

| File | Change |
|------|--------|
| `src-tauri/src/tray.rs` | Extract `show_main_window()` helper, make `handle_menu_event` `pub(crate)`, remove `on_menu_event` from `TrayIconBuilder`, add diagnostic logging |
| `src-tauri/src/lib.rs` | Register `tray::handle_menu_event` on `Builder::on_menu_event` with desktop-only `#[cfg]` guard |

## Test plan

- [x] `cargo build` — compiles without errors
- [x] `cargo clippy` — zero warnings
- [x] `cargo test` — 348/349 pass (1 pre-existing failure unrelated to this change)
- [x] `npx vitest run` — 487 frontend tests pass
- [ ] Manual test on Linux X11 — verify "Show PRism" and "Force Sync" tray actions work
- [ ] Manual test on Linux Wayland — verify window focus behavior
- [ ] Verify no regression on macOS — tray left-click toggle still works

Closes #154

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes tray menu actions on Linux by moving menu event handling to the app-level handler. Improves window toggling on Wayland/minimized windows and adds tracing; also moves `MAIN_WINDOW_LABEL` to the crate root for mobile builds.

- **Bug Fixes**
  - Route DBus menu events via app-level `Builder::on_menu_event` (registers `tray::handle_menu_event`, desktop-only guard) instead of `TrayIconBuilder::on_menu_event`.
  - Add `show_main_window()` (unminimize → show → focus) and reuse for tray menu and left-click; use `is_minimized()` to correctly restore windows that report `is_visible() = true`.
  - Define `MAIN_WINDOW_LABEL` in the crate root and use it in `tray.rs` and `lib.rs` to replace hardcoded `"main"` and avoid mobile build issues.

<sup>Written for commit 6a342e4c22cb0dc42745e436a1f674f0e26f9b63. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated tray/menu registration so desktop menu actions are handled consistently.
  * Improved window restore behavior (better handling when minimized or hidden); unified show-from-tray behavior including left-click restore.

* **Chores**
  * Added diagnostic logging for menu/tray interactions and forced sync operations to aid troubleshooting.
  * Logged start and completion of force-sync triggered from the menu.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->