### PR TITLE
feat(ui): add visible GitHub link indicator on issue cards (#156)

### DIFF
--- a/src/components/Issues/IssueCard.test.tsx
+++ b/src/components/Issues/IssueCard.test.tsx
@@ -108,4 +108,16 @@ describe("IssueCard", () => {
     const repoSpan = screen.getByText("my-repo");
     expect(repoSpan).toHaveAttribute("title", "my-repo");
   });
+
+  it("should render external link indicator", () => {
+    render(<IssueCard issue={makeIssue()} repoName="repo-name" onOpen={vi.fn()} />);
+    const indicator = screen.getByTestId("external-link-indicator");
+    expect(indicator).toHaveTextContent("↗");
+  });
+
+  it("should mark external link indicator as aria-hidden", () => {
+    render(<IssueCard issue={makeIssue()} repoName="repo-name" onOpen={vi.fn()} />);
+    const indicator = screen.getByTestId("external-link-indicator");
+    expect(indicator).toHaveAttribute("aria-hidden", "true");
+  });
 });

--- a/src/components/Issues/IssueCard.tsx
+++ b/src/components/Issues/IssueCard.tsx
@@ -26,7 +26,7 @@ export function IssueCard({ issue, repoName, onOpen }: IssueCardProps): ReactEle
       href={issue.url}
       onClick={handleClick}
       aria-label={`Issue #${issue.number}: ${issue.title} (${issue.state})`}
-      className="flex min-w-0 cursor-pointer flex-col gap-1 rounded border border-border px-3 py-2 no-underline hover:bg-surface-hover"
+      className="group/card flex min-w-0 cursor-pointer flex-col gap-1 rounded border border-border px-3 py-2 no-underline hover:bg-surface-hover"
     >
       <div className="flex min-w-0 items-center gap-2">
         <span
@@ -34,7 +34,16 @@ export function IssueCard({ issue, repoName, onOpen }: IssueCardProps): ReactEle
           aria-hidden="true"
           className={`h-2.5 w-2.5 shrink-0 rounded-full ${STATE_DOT_COLOR[issue.state]}`}
         />
-        <span className="shrink-0 text-xs text-dim">#{issue.number}</span>
+        <span className="shrink-0 text-xs text-dim">
+          #{issue.number}
+          <span
+            data-testid="external-link-indicator"
+            aria-hidden="true"
+            className="ml-0.5 opacity-0 transition-opacity group-hover/card:opacity-100"
+          >
+            ↗
+          </span>
+        </span>
         <span className="min-w-0 truncate text-sm font-medium text-foreground" title={issue.title}>
           {issue.title}
         </span>

--- a/src/components/Issues/IssueCard.tsx
+++ b/src/components/Issues/IssueCard.tsx
@@ -39,7 +39,7 @@ export function IssueCard({ issue, repoName, onOpen }: IssueCardProps): ReactEle
           <span
             data-testid="external-link-indicator"
             aria-hidden="true"
-            className="ml-0.5 opacity-0 transition-opacity group-hover/card:opacity-100"
+            className="ml-0.5 opacity-70 transition-opacity group-hover/card:opacity-100 group-focus-visible/card:opacity-100"
           >
             ↗
           </span>


### PR DESCRIPTION
## Summary

- Add ↗ external link indicator next to issue number on `IssueCard` component
- Indicator is hidden by default, appears on card hover via Tailwind `group-hover`
- Uses existing unicode convention (consistent with `ActivityItem.tsx`)

## Changes

- `src/components/Issues/IssueCard.tsx` — added `group/card` scope and `↗` span with hover transition
- `src/components/Issues/IssueCard.test.tsx` — 2 new tests for indicator rendering and aria-hidden

## Testing

- All 23 IssueCard + Issues tests pass
- TypeScript compilation clean
- oxlint: 0 warnings, 0 errors

Closes #156

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a visible ↗ indicator next to the issue number on `IssueCard` to show it opens the GitHub issue. It’s visible by default and becomes fully opaque on hover or keyboard focus for better accessibility.

- **New Features**
  - Shows ↗ beside the issue number using Tailwind `group/card`; visible by default and fully opaque on hover/focus.
  - Marks the icon `aria-hidden` and adds tests for render and accessibility.

<sup>Written for commit 35f06b4b087b540d0f1bab8a217989a46c3c917e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Issue cards now show a subtle external link indicator (↗) when hovered or focused, making external links easier to identify.

* **Tests**
  * Added tests to ensure the external link indicator is rendered and includes the correct accessibility attributes for assistive technologies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->