### PR TITLE
fix(ui): replace window.open with Tauri plugin-opener for issue links

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -4,8 +4,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import App from "./App";
 import { useDashboardStore } from "./stores/dashboard";
 
-vi.mock("@tauri-apps/plugin-opener", () => ({
-  openUrl: vi.fn().mockResolvedValue(undefined),
+vi.mock("./lib/open", () => ({
+  openUrl: vi.fn(),
 }));
 
 vi.mock("./lib/tauri", async (importOriginal) => {
@@ -149,8 +149,8 @@ describe("App keyboard shortcuts", () => {
       selectedIndex: -1,
       navigableItems: items,
     });
-    const opener = await import("@tauri-apps/plugin-opener");
-    mockedOpenUrl = vi.mocked(opener.openUrl);
+    const { openUrl } = await import("./lib/open");
+    mockedOpenUrl = vi.mocked(openUrl);
     mockedOpenUrl.mockClear();
   });
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
 import { act, render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import App from "./App";

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -4,6 +4,10 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import App from "./App";
 import { useDashboardStore } from "./stores/dashboard";
 
+vi.mock("@tauri-apps/plugin-opener", () => ({
+  openUrl: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock("./lib/tauri", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./lib/tauri")>();
   return {
@@ -134,9 +138,9 @@ describe("App keyboard shortcuts", () => {
     { url: "https://github.com/org/repo/pull/3" },
   ];
 
-  let openSpy: ReturnType<typeof vi.spyOn>;
+  let mockedOpenUrl: ReturnType<typeof vi.fn>;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     // Use "feed" view — it has no useRegisterNavigableItems hook,
     // so pre-seeded navigableItems are preserved for keyboard tests.
     useDashboardStore.setState({
@@ -145,11 +149,9 @@ describe("App keyboard shortcuts", () => {
       selectedIndex: -1,
       navigableItems: items,
     });
-    openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
-  });
-
-  afterEach(() => {
-    openSpy.mockRestore();
+    const opener = await import("@tauri-apps/plugin-opener");
+    mockedOpenUrl = vi.mocked(opener.openUrl);
+    mockedOpenUrl.mockClear();
   });
 
   it("should navigate list with j/k", async () => {
@@ -172,10 +174,8 @@ describe("App keyboard shortcuts", () => {
     await screen.findByTestId("activity-feed");
 
     act(() => fireKey("Enter"));
-    expect(openSpy).toHaveBeenCalledWith(
+    expect(mockedOpenUrl).toHaveBeenCalledWith(
       "https://github.com/org/repo/pull/2",
-      "_blank",
-      "noopener,noreferrer",
     );
   });
 
@@ -184,7 +184,7 @@ describe("App keyboard shortcuts", () => {
     await screen.findByTestId("activity-feed");
 
     act(() => fireKey("Enter"));
-    expect(openSpy).not.toHaveBeenCalled();
+    expect(mockedOpenUrl).not.toHaveBeenCalled();
   });
 
   it("should return to overview on Escape", async () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import { useKeyboard } from "./hooks/useKeyboard";
 import { useDashboardStore } from "./stores/dashboard";
 import { useWorkspaceEnriched } from "./hooks/useWorkspaceEnriched";
 import { useWorkspacesStore } from "./stores/workspaces";
+import { openUrl as tauriOpen } from "@tauri-apps/plugin-opener";
 import type { DashboardView } from "./stores/dashboard";
 
 const WorkspaceView = lazy(() =>
@@ -35,7 +36,9 @@ const Settings = lazy(() =>
 );
 
 function openUrl(url: string): void {
-  window.open(url, "_blank", "noopener,noreferrer");
+  tauriOpen(url).catch((err: unknown) => {
+    console.warn("[openUrl] failed to open", url, err);
+  });
 }
 
 function LazyFallback(): ReactElement {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,7 +25,7 @@ import { useKeyboard } from "./hooks/useKeyboard";
 import { useDashboardStore } from "./stores/dashboard";
 import { useWorkspaceEnriched } from "./hooks/useWorkspaceEnriched";
 import { useWorkspacesStore } from "./stores/workspaces";
-import { openUrl as tauriOpen } from "@tauri-apps/plugin-opener";
+import { openUrl } from "./lib/open";
 import type { DashboardView } from "./stores/dashboard";
 
 const WorkspaceView = lazy(() =>
@@ -34,12 +34,6 @@ const WorkspaceView = lazy(() =>
 const Settings = lazy(() =>
   import("./components/Settings").then((m) => ({ default: m.Settings })),
 );
-
-function openUrl(url: string): void {
-  tauriOpen(url).catch((err: unknown) => {
-    console.warn("[openUrl] failed to open", url, err);
-  });
-}
 
 function LazyFallback(): ReactElement {
   return (

--- a/src/components/CommandPalette/CommandPalette.test.tsx
+++ b/src/components/CommandPalette/CommandPalette.test.tsx
@@ -4,8 +4,8 @@ import { userEvent } from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { CommandPalette } from "./CommandPalette";
 
-vi.mock("@tauri-apps/plugin-opener", () => ({
-  openUrl: vi.fn().mockResolvedValue(undefined),
+vi.mock("../../lib/open", () => ({
+  openUrl: vi.fn(),
 }));
 
 vi.mock("../../hooks/useGitHubData", () => ({
@@ -283,7 +283,7 @@ describe("CommandPalette", () => {
   });
 
   it("should open selected item in browser on Cmd+Enter", async () => {
-    const { openUrl: mockedOpenUrl } = await import("@tauri-apps/plugin-opener");
+    const { openUrl: mockedOpenUrl } = await import("../../lib/open");
     vi.mocked(mockedOpenUrl).mockClear();
     const pr = makePr();
 
@@ -308,6 +308,33 @@ describe("CommandPalette", () => {
       "https://github.com/org/repo/pull/42",
     );
     expect(mockSetView).not.toHaveBeenCalled();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("should open selected item in browser on Ctrl+Enter", async () => {
+    const { openUrl: mockedOpenUrl } = await import("../../lib/open");
+    vi.mocked(mockedOpenUrl).mockClear();
+    const pr = makePr();
+
+    (useGitHubData as Mock).mockReturnValue({
+      dashboard: makeDashboard({ reviewRequests: [pr] }),
+      stats: null,
+      isLoading: false,
+      error: null,
+      forceSync: vi.fn(),
+      isSyncing: false,
+    });
+
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    renderPalette({ open: true, onOpenChange });
+
+    await user.keyboard("{ArrowDown}");
+    await user.keyboard("{Control>}{Enter}{/Control}");
+
+    expect(mockedOpenUrl).toHaveBeenCalledWith(
+      "https://github.com/org/repo/pull/42",
+    );
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 

--- a/src/components/CommandPalette/CommandPalette.test.tsx
+++ b/src/components/CommandPalette/CommandPalette.test.tsx
@@ -4,6 +4,10 @@ import { userEvent } from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { CommandPalette } from "./CommandPalette";
 
+vi.mock("@tauri-apps/plugin-opener", () => ({
+  openUrl: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock("../../hooks/useGitHubData", () => ({
   useGitHubData: vi.fn(),
 }));
@@ -279,7 +283,8 @@ describe("CommandPalette", () => {
   });
 
   it("should open selected item in browser on Cmd+Enter", async () => {
-    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+    const { openUrl: mockedOpenUrl } = await import("@tauri-apps/plugin-opener");
+    vi.mocked(mockedOpenUrl).mockClear();
     const pr = makePr();
 
     (useGitHubData as Mock).mockReturnValue({
@@ -299,15 +304,11 @@ describe("CommandPalette", () => {
     await user.keyboard("{ArrowDown}");
     await user.keyboard("{Meta>}{Enter}{/Meta}");
 
-    expect(openSpy).toHaveBeenCalledWith(
+    expect(mockedOpenUrl).toHaveBeenCalledWith(
       "https://github.com/org/repo/pull/42",
-      "_blank",
-      "noopener,noreferrer",
     );
     expect(mockSetView).not.toHaveBeenCalled();
     expect(onOpenChange).toHaveBeenCalledWith(false);
-
-    openSpy.mockRestore();
   });
 
   it("should show empty state when no results match", async () => {

--- a/src/components/CommandPalette/CommandPalette.tsx
+++ b/src/components/CommandPalette/CommandPalette.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useGitHubData } from "../../hooks/useGitHubData";
 import { listRepos } from "../../lib/tauri";
 import { useDashboardStore } from "../../stores/dashboard";
+import { openUrl } from "@tauri-apps/plugin-opener";
 import type { DashboardView } from "../../stores/dashboard";
 import type { PullRequestWithReview, Issue } from "../../lib/types";
 
@@ -133,7 +134,9 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
       e.preventDefault();
       const item = findSelectedItem();
       if (item) {
-        window.open(item.url, "_blank", "noopener,noreferrer");
+        openUrl(item.url).catch((err: unknown) => {
+          console.warn("[openUrl] failed to open", item.url, err);
+        });
         onOpenChange(false);
       }
     }

--- a/src/components/CommandPalette/CommandPalette.tsx
+++ b/src/components/CommandPalette/CommandPalette.tsx
@@ -4,7 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useGitHubData } from "../../hooks/useGitHubData";
 import { listRepos } from "../../lib/tauri";
 import { useDashboardStore } from "../../stores/dashboard";
-import { openUrl } from "@tauri-apps/plugin-opener";
+import { openUrl } from "../../lib/open";
 import type { DashboardView } from "../../stores/dashboard";
 import type { PullRequestWithReview, Issue } from "../../lib/types";
 
@@ -134,9 +134,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
       e.preventDefault();
       const item = findSelectedItem();
       if (item) {
-        openUrl(item.url).catch((err: unknown) => {
-          console.warn("[openUrl] failed to open", item.url, err);
-        });
+        openUrl(item.url);
         onOpenChange(false);
       }
     }

--- a/src/components/Overview/Overview.test.tsx
+++ b/src/components/Overview/Overview.test.tsx
@@ -11,8 +11,8 @@ import type {
 } from "../../lib/types";
 import { Overview } from "./Overview";
 
-vi.mock("@tauri-apps/plugin-opener", () => ({
-  openUrl: vi.fn().mockResolvedValue(undefined),
+vi.mock("../../lib/open", () => ({
+  openUrl: vi.fn(),
 }));
 
 vi.mock("@tanstack/react-virtual", () => ({
@@ -324,7 +324,7 @@ describe("Overview", () => {
   });
 
   it("should open URL when a PR card is clicked", async () => {
-    const { openUrl: mockedOpenUrl } = await import("@tauri-apps/plugin-opener");
+    const { openUrl: mockedOpenUrl } = await import("../../lib/open");
     vi.mocked(mockedOpenUrl).mockClear();
     const user = userEvent.setup();
     setupMock(

--- a/src/components/Overview/Overview.test.tsx
+++ b/src/components/Overview/Overview.test.tsx
@@ -11,6 +11,10 @@ import type {
 } from "../../lib/types";
 import { Overview } from "./Overview";
 
+vi.mock("@tauri-apps/plugin-opener", () => ({
+  openUrl: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock("@tanstack/react-virtual", () => ({
   useVirtualizer: (opts: { count: number; estimateSize: (i: number) => number }) => ({
     getVirtualItems: () =>
@@ -320,7 +324,8 @@ describe("Overview", () => {
   });
 
   it("should open URL when a PR card is clicked", async () => {
-    const windowOpenSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+    const { openUrl: mockedOpenUrl } = await import("@tauri-apps/plugin-opener");
+    vi.mocked(mockedOpenUrl).mockClear();
     const user = userEvent.setup();
     setupMock(
       makeDashboard({
@@ -332,12 +337,8 @@ describe("Overview", () => {
 
     await user.click(screen.getByRole("link"));
 
-    expect(windowOpenSpy).toHaveBeenCalledWith(
+    expect(mockedOpenUrl).toHaveBeenCalledWith(
       "https://github.com/org/repo/pull/1",
-      "_blank",
-      "noopener,noreferrer",
     );
-
-    windowOpenSpy.mockRestore();
   });
 });

--- a/src/components/Overview/Overview.tsx
+++ b/src/components/Overview/Overview.tsx
@@ -8,17 +8,11 @@ import { ReviewQueue } from "../ReviewQueue";
 import { MyPRs } from "../MyPRs";
 import { Issues } from "../Issues";
 import { ActivityFeed } from "../ActivityFeed";
-import { openUrl as tauriOpen } from "@tauri-apps/plugin-opener";
+import { openUrl } from "../../lib/open";
 
 const MAX_REVIEWS = 5;
 const MAX_PRS = 5;
 const MAX_ACTIVITIES = 5;
-
-function openUrl(url: string): void {
-  tauriOpen(url).catch((err: unknown) => {
-    console.warn("[openUrl] failed to open", url, err);
-  });
-}
 
 export function Overview(): ReactElement {
   const { dashboard, error } = useGitHubData();

--- a/src/components/Overview/Overview.tsx
+++ b/src/components/Overview/Overview.tsx
@@ -8,13 +8,16 @@ import { ReviewQueue } from "../ReviewQueue";
 import { MyPRs } from "../MyPRs";
 import { Issues } from "../Issues";
 import { ActivityFeed } from "../ActivityFeed";
+import { openUrl as tauriOpen } from "@tauri-apps/plugin-opener";
 
 const MAX_REVIEWS = 5;
 const MAX_PRS = 5;
 const MAX_ACTIVITIES = 5;
 
 function openUrl(url: string): void {
-  window.open(url, "_blank", "noopener,noreferrer");
+  tauriOpen(url).catch((err: unknown) => {
+    console.warn("[openUrl] failed to open", url, err);
+  });
 }
 
 export function Overview(): ReactElement {

--- a/src/lib/open.ts
+++ b/src/lib/open.ts
@@ -1,0 +1,7 @@
+import { openUrl as tauriOpen } from "@tauri-apps/plugin-opener";
+
+export function openUrl(url: string): void {
+  tauriOpen(url).catch((err: unknown) => {
+    console.warn("[openUrl] failed to open", url, err);
+  });
+}


### PR DESCRIPTION
## Summary

- Replaced `window.open()` with `openUrl` from `@tauri-apps/plugin-opener` in `App.tsx`, `Overview.tsx`, and `CommandPalette.tsx`
- Added `console.warn` error logging on failed URL opens
- Updated 3 test files to mock `@tauri-apps/plugin-opener` instead of `window.open`

Closes #161

## Test plan

- [x] 489/489 tests pass (0 failures)
- [x] TypeScript compilation passes
- [x] No remaining `window.open` calls in `src/`
- [ ] Manual: click an issue/PR link in the dashboard — should open in default browser
- [ ] Manual: Cmd+Enter in command palette — should open selected item in browser

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes issue and PR links not opening in the Tauri app by routing all opens through a shared `openUrl` wrapper over `@tauri-apps/plugin-opener`. Clicking links and using Cmd+Enter or Ctrl+Enter now open in the default browser.

- **Bug Fixes**
  - Replaced `window.open()` with `openUrl` in `App.tsx`, `Overview.tsx`, and `CommandPalette.tsx`.
  - Added `console.warn` when a URL fails to open.

- **Refactors**
  - Added `src/lib/open.ts` to centralize `openUrl`; removed duplicate helpers.
  - Updated components to import from the shared module.
  - Updated tests to mock `lib/open`, added a Ctrl+Enter case, and removed an unused import in `App.test.tsx`.

<sup>Written for commit e6c6f6920104f9f3390cd30504d7a2fd0005d7b7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Links now open via the platform’s native handler instead of directly opening a browser tab.
  * Failures to open links are now logged for better visibility.

* **Bug Fixes**
  * Keyboard shortcuts (Enter / Ctrl/Cmd+Enter) reliably open the selected item’s URL and close the command palette as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->