### PR TITLE
fix(github): use involves: instead of assignee: for issues query

### DIFF
--- a/src-tauri/src/cache/sync.rs
+++ b/src-tauri/src/cache/sync.rs
@@ -261,10 +261,10 @@ fn build_query_variables(
         review_query: format!("type:pr {repo_filter} review-requested:{username} state:open"),
         my_prs_query: format!("type:pr {repo_filter} author:{username} sort:updated"),
         open_issues_query: format!(
-            "type:issue {repo_filter} assignee:{username} state:open sort:updated"
+            "type:issue {repo_filter} involves:{username} state:open sort:updated"
         ),
         closed_issues_query: format!(
-            "type:issue {repo_filter} assignee:{username} state:closed sort:updated"
+            "type:issue {repo_filter} involves:{username} state:closed sort:updated"
         ),
         first: 100,
     })
@@ -888,8 +888,8 @@ mod tests {
         assert!(vars.review_query.contains("review-requested:octocat"));
         assert!(vars.review_query.contains("repo:org/repo"));
         assert!(vars.my_prs_query.contains("author:octocat"));
-        assert!(vars.open_issues_query.contains("assignee:octocat"));
-        assert!(vars.closed_issues_query.contains("assignee:octocat"));
+        assert!(vars.open_issues_query.contains("involves:octocat"));
+        assert!(vars.closed_issues_query.contains("involves:octocat"));
         assert_eq!(vars.first, 100);
 
         // review_query keeps state:open (only review open PRs)


### PR DESCRIPTION
## Summary

Follow-up fix for #163 — the first PR (#164) split the query into open/closed but the real root cause was the `assignee:` qualifier missing authored-but-unassigned issues.

- Replace `assignee:{username}` with `involves:{username}` in both open and closed issue search queries
- `involves:` covers author, assignee, mentioned, and commenter — matching expected dashboard behavior

## Root cause

The user creates issues without self-assigning them. `assignee:mpiton state:open` returns 0 results, while `involves:mpiton state:open` returns 72. The 28 closed issues appeared because they happened to have `mpiton` as explicit assignee.

## Test plan

- [x] `cargo test cache::sync` — 32 passed
- [x] Verified via `gh api graphql` that `involves:` returns open issues
- [ ] Manual: run `npm run tauri dev`, verify open issues tab shows correct count

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the dashboard’s open issues count by switching GitHub issue searches from `assignee:{username}` to `involves:{username}` so authored and mentioned issues are included.

- **Bug Fixes**
  - Use `involves:{username}` for open/closed issue queries to include author, assignee, mentioned, and commenter.
  - Update tests to expect `involves:` in issue queries.

<sup>Written for commit c060d9cb5e96a56a3c10c3119492a47f2a639a56. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved issue search to include all issues involving the user, not just those assigned directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->