### PR TITLE
fix(ui): expose is_read field and add read/unread visual distinction (#166)

### DIFF
--- a/src-tauri/src/cache/activity.rs
+++ b/src-tauri/src/cache/activity.rs
@@ -87,7 +87,7 @@ pub async fn insert_activity(pool: &SqlitePool, activity: &Activity) -> Result<A
         .bind(&activity.pull_request_id)
         .bind(&activity.issue_id)
         .bind(&activity.message)
-        .bind(if activity.is_read { 1_i64 } else { 0 })
+        .bind(i64::from(activity.is_read))
         .bind(&activity.created_at)
         .fetch_one(pool)
         .await?;
@@ -150,7 +150,7 @@ where
     .bind(&activity.pull_request_id)
     .bind(&activity.issue_id)
     .bind(&activity.message)
-    .bind(if activity.is_read { 1_i64 } else { 0 })
+    .bind(i64::from(activity.is_read))
     .bind(&activity.created_at)
     .execute(executor)
     .await?;

--- a/src-tauri/src/cache/activity.rs
+++ b/src-tauri/src/cache/activity.rs
@@ -65,7 +65,7 @@ impl TryFrom<ActivityRow> for Activity {
 }
 
 /// Explicit column list for all queries on `activity`.
-/// `is_read` is populated by `ActivityRow` (DB DEFAULT 0 on INSERT) and
+/// `is_read` is selected via `ActivityRow` and
 /// mapped to `Activity.is_read` via `TryFrom`.
 const ACTIVITY_COLS: &str =
     "id, activity_type, actor, repo_id, pull_request_id, issue_id, message, is_read, created_at";
@@ -74,8 +74,8 @@ const ACTIVITY_COLS: &str =
 #[allow(dead_code)]
 pub async fn insert_activity(pool: &SqlitePool, activity: &Activity) -> Result<Activity, AppError> {
     let sql = format!(
-        "INSERT INTO activity (id, activity_type, actor, repo_id, pull_request_id, issue_id, message, created_at)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+        "INSERT INTO activity (id, activity_type, actor, repo_id, pull_request_id, issue_id, message, is_read, created_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
          RETURNING {ACTIVITY_COLS}"
     );
 
@@ -87,6 +87,7 @@ pub async fn insert_activity(pool: &SqlitePool, activity: &Activity) -> Result<A
         .bind(&activity.pull_request_id)
         .bind(&activity.issue_id)
         .bind(&activity.message)
+        .bind(if activity.is_read { 1_i64 } else { 0 })
         .bind(&activity.created_at)
         .fetch_one(pool)
         .await?;
@@ -139,8 +140,8 @@ where
     E: sqlx::Executor<'e, Database = sqlx::Sqlite>,
 {
     let result = sqlx::query(
-        "INSERT OR IGNORE INTO activity (id, activity_type, actor, repo_id, pull_request_id, issue_id, message, created_at) \
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+        "INSERT OR IGNORE INTO activity (id, activity_type, actor, repo_id, pull_request_id, issue_id, message, is_read, created_at) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
     )
     .bind(&activity.id)
     .bind(activity_type_to_str(&activity.activity_type))
@@ -149,6 +150,7 @@ where
     .bind(&activity.pull_request_id)
     .bind(&activity.issue_id)
     .bind(&activity.message)
+    .bind(if activity.is_read { 1_i64 } else { 0 })
     .bind(&activity.created_at)
     .execute(executor)
     .await?;

--- a/src-tauri/src/cache/activity.rs
+++ b/src-tauri/src/cache/activity.rs
@@ -58,15 +58,15 @@ impl TryFrom<ActivityRow> for Activity {
             pull_request_id: row.pull_request_id,
             issue_id: row.issue_id,
             message: row.message,
+            is_read: row.is_read != 0,
             created_at: row.created_at,
         })
     }
 }
 
 /// Explicit column list for all queries on `activity`.
-/// `is_read` is populated by `ActivityRow` (DB DEFAULT 0 on INSERT) but
-/// discarded by `TryFrom<Activity>` — it is a DB-internal flag, not part
-/// of the domain struct.
+/// `is_read` is populated by `ActivityRow` (DB DEFAULT 0 on INSERT) and
+/// mapped to `Activity.is_read` via `TryFrom`.
 const ACTIVITY_COLS: &str =
     "id, activity_type, actor, repo_id, pull_request_id, issue_id, message, is_read, created_at";
 
@@ -220,6 +220,7 @@ mod tests {
             pull_request_id: None,
             issue_id: None,
             message: message.to_string(),
+            is_read: false,
             created_at: "2026-03-20T10:00:00Z".to_string(),
         }
     }
@@ -239,6 +240,7 @@ mod tests {
         assert_eq!(result.pull_request_id, None);
         assert_eq!(result.issue_id, None);
         assert_eq!(result.message, "Opened PR #42");
+        assert!(!result.is_read);
         assert_eq!(result.created_at, "2026-03-20T10:00:00Z");
 
         // Duplicate insert should fail (PRIMARY KEY constraint)
@@ -340,6 +342,52 @@ mod tests {
         // Mark all again — none should be updated
         let count = mark_all_read(&pool).await.unwrap();
         assert_eq!(count, 0);
+
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_is_read_roundtrip_after_mark_read() {
+        let (pool, _tmp) = test_pool().await;
+        upsert_repo(&pool, &sample_repo()).await.unwrap();
+
+        let activity = sample_activity("act-1", ActivityType::CommentAdded, "Comment");
+        insert_activity(&pool, &activity).await.unwrap();
+
+        // Freshly inserted → is_read should be false
+        let before = get_activity_by_id(&pool, "act-1").await.unwrap().unwrap();
+        assert!(!before.is_read);
+
+        // Mark as read
+        mark_read(&pool, "act-1").await.unwrap();
+
+        // Fetched again → is_read should be true
+        let after = get_activity_by_id(&pool, "act-1").await.unwrap().unwrap();
+        assert!(after.is_read);
+
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_is_read_roundtrip_after_mark_all_read() {
+        let (pool, _tmp) = test_pool().await;
+        upsert_repo(&pool, &sample_repo()).await.unwrap();
+
+        let a1 = sample_activity("act-1", ActivityType::PrOpened, "PR");
+        let a2 = sample_activity("act-2", ActivityType::PrMerged, "Merge");
+        insert_activity(&pool, &a1).await.unwrap();
+        insert_activity(&pool, &a2).await.unwrap();
+
+        // Both unread
+        let all = get_recent_activity(&pool, 10, 0).await.unwrap();
+        assert!(all.iter().all(|a| !a.is_read));
+
+        // Mark all read
+        mark_all_read(&pool).await.unwrap();
+
+        // Both should now be read
+        let all = get_recent_activity(&pool, 10, 0).await.unwrap();
+        assert!(all.iter().all(|a| a.is_read));
 
         pool.close().await;
     }

--- a/src-tauri/src/cache/dashboard.rs
+++ b/src-tauri/src/cache/dashboard.rs
@@ -661,6 +661,7 @@ mod tests {
             pull_request_id: Some("pr-4".to_string()),
             issue_id: None,
             message: "Bob opened PR".to_string(),
+            is_read: false,
             created_at: "2026-03-20T10:00:00Z".to_string(),
         };
         insert_activity(&pool, &act1).await.unwrap();
@@ -672,6 +673,7 @@ mod tests {
             pull_request_id: None,
             issue_id: Some("issue-1".to_string()),
             message: "Charlie commented".to_string(),
+            is_read: false,
             created_at: "2026-03-20T11:00:00Z".to_string(),
         };
         insert_activity(&pool, &act2).await.unwrap();

--- a/src-tauri/src/cache/sync.rs
+++ b/src-tauri/src/cache/sync.rs
@@ -558,6 +558,7 @@ fn map_activity_nodes(data: &recent_activity::ResponseData) -> Vec<Activity> {
                     pull_request_id: None,
                     issue_id: None,
                     message: format!("PR #{}: {}", pr.number, pr.title),
+                    is_read: false,
                     created_at: pr.updated_at.clone(),
                 });
             }
@@ -579,6 +580,7 @@ fn map_activity_nodes(data: &recent_activity::ResponseData) -> Vec<Activity> {
                     pull_request_id: None,
                     issue_id: None,
                     message: format!("Issue #{}: {}", issue.number, issue.title),
+                    is_read: false,
                     created_at: issue.updated_at.clone(),
                 });
             }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2073,6 +2073,7 @@ mod tests {
             pull_request_id: None,
             issue_id: None,
             message: "Opened PR #42".into(),
+            is_read: false,
             created_at: "2026-03-27T10:00:00Z".into(),
         };
         crate::cache::activity::insert_activity(&pool, &activity)
@@ -2125,6 +2126,7 @@ mod tests {
             pull_request_id: None,
             issue_id: None,
             message: "First".into(),
+            is_read: false,
             created_at: "2026-03-27T10:00:00Z".into(),
         };
         let a2 = crate::types::Activity {
@@ -2135,6 +2137,7 @@ mod tests {
             pull_request_id: None,
             issue_id: None,
             message: "Second".into(),
+            is_read: false,
             created_at: "2026-03-27T11:00:00Z".into(),
         };
         crate::cache::activity::insert_activity(&pool, &a1)

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -190,6 +190,7 @@ pub struct Activity {
     pub pull_request_id: Option<String>,
     pub issue_id: Option<String>,
     pub message: String,
+    pub is_read: bool,
     pub created_at: String,
 }
 
@@ -835,6 +836,7 @@ mod tests {
             pull_request_id: Some("pr-1".to_string()),
             issue_id: None,
             message: "Opened PR #42".to_string(),
+            is_read: false,
             created_at: "2026-03-24T10:00:00Z".to_string(),
         };
         let json = serde_json::to_string(&activity).unwrap();

--- a/src/components/ActivityFeed/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed/ActivityFeed.test.tsx
@@ -13,6 +13,7 @@ function makeActivity(overrides: Partial<Activity> = {}): Activity {
     pullRequestId: "pr-1",
     issueId: null,
     message: "Some comment",
+    isRead: false,
     createdAt: "2026-03-28T10:00:00Z",
     ...overrides,
   };

--- a/src/components/ActivityFeed/ActivityItem.test.tsx
+++ b/src/components/ActivityFeed/ActivityItem.test.tsx
@@ -12,6 +12,7 @@ function makeActivity(overrides: Partial<Activity> = {}): Activity {
     pullRequestId: "pr-42",
     issueId: null,
     message: "Looks good, just one small nit on the error handling path",
+    isRead: false,
     createdAt: "2026-03-28T10:00:00Z",
     ...overrides,
   };
@@ -71,5 +72,23 @@ describe("ActivityItem", () => {
     render(<ActivityItem activity={makeActivity({ activityType: "pr_merged" })} />);
 
     expect(screen.getByTestId("activity-action")).toHaveTextContent(/merged/i);
+  });
+
+  it("should show unread dot when activity is not read", () => {
+    render(<ActivityItem activity={makeActivity({ isRead: false })} />);
+
+    expect(screen.getByTestId("unread-dot")).toBeInTheDocument();
+  });
+
+  it("should not show unread dot when activity is read", () => {
+    render(<ActivityItem activity={makeActivity({ isRead: true })} />);
+
+    expect(screen.queryByTestId("unread-dot")).not.toBeInTheDocument();
+  });
+
+  it("should apply reduced opacity when activity is read", () => {
+    render(<ActivityItem activity={makeActivity({ isRead: true })} />);
+
+    expect(screen.getByTestId("activity-item").className).toContain("opacity-50");
   });
 });

--- a/src/components/ActivityFeed/ActivityItem.tsx
+++ b/src/components/ActivityFeed/ActivityItem.tsx
@@ -38,7 +38,12 @@ function truncate(text: string, max: number): string {
 
 export function ActivityItem({ activity }: ActivityItemProps): ReactElement {
   return (
-    <div data-testid="activity-item" className="flex items-start gap-2 rounded border border-border px-3 py-2">
+    <div data-testid="activity-item" className={`flex items-start gap-2 rounded border border-border px-3 py-2${activity.isRead ? " opacity-50" : ""}`}>
+      {activity.isRead ? (
+        <span aria-hidden="true" className="mt-1.5 h-2 w-2 shrink-0" />
+      ) : (
+        <span data-testid="unread-dot" className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-blue-500" />
+      )}
       <span data-testid="activity-icon" aria-hidden="true" className="shrink-0 text-sm text-dim">
         {ACTIVITY_ICON[activity.activityType]}
       </span>

--- a/src/components/Overview/Overview.test.tsx
+++ b/src/components/Overview/Overview.test.tsx
@@ -107,6 +107,7 @@ function makeActivity(n: number): Activity {
     pullRequestId: `pr-${n}`,
     issueId: null,
     message: `Comment on PR #${n}`,
+    isRead: false,
     createdAt: "2026-03-26T10:00:00Z",
   };
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -95,6 +95,7 @@ export interface Activity {
   readonly pullRequestId: string | null;
   readonly issueId: string | null;
   readonly message: string;
+  readonly isRead: boolean;
   readonly createdAt: string;
 }
 


### PR DESCRIPTION
## Summary

- Expose `is_read` boolean from SQLite through the Rust `Activity` struct to the React frontend
- Add visual read/unread distinction in `ActivityItem`: blue unread dot + reduced opacity for read items
- The existing `mark_all_read` mutation and TanStack Query invalidation flow now produces visible UI feedback

## Changes

**Backend (Rust):**
- `types.rs` — added `pub is_read: bool` to `Activity` struct (serializes as `isRead`)
- `cache/activity.rs` — updated `TryFrom<ActivityRow>` to map `row.is_read != 0`
- `cache/sync.rs`, `cache/dashboard.rs`, `commands.rs` — set `is_read: false` on all Activity constructions

**Frontend (TypeScript/React):**
- `lib/types.ts` — added `readonly isRead: boolean` to `Activity` interface
- `ActivityItem.tsx` — conditional blue dot (unread) + `opacity-50` (read) + `aria-hidden` spacer

**Tests:**
- 2 new Rust tests: `is_read` round-trip after `mark_read` and `mark_all_read`
- 3 new TS tests: unread dot visible, hidden when read, opacity-50 when read
- Updated all mock Activity data in existing tests

## Test plan

- [x] `cargo check` passes
- [x] `cargo test cache::activity` — 9 tests pass (including 2 new round-trip tests)
- [x] `npx vitest run` — 493 tests pass
- [x] `oxlint` — 0 warnings, 0 errors

Closes #166

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Activities now include a read/unread state that is persisted, a blue dot marks unread items, and read items are visually faded.

* **Tests**
  * Tests added and updated to verify read/unread persistence and the UI indicators/visual state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->