### PR TITLE
fix(ui): raise color-muted contrast ratio to meet WCAG AA

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -16,7 +16,7 @@
   --color-border: #2a2a27;
   --color-text: #d4d0c8;
   --color-dim: #a09a8c;
-  --color-muted: #4a473f;
+  --color-muted: #78746a;
   --color-white: #eeece6;
   --color-foreground: var(--color-text);
   --color-accent: #c8ff00;

--- a/src/index.css
+++ b/src/index.css
@@ -16,7 +16,7 @@
   --color-border: #2a2a27;
   --color-text: #d4d0c8;
   --color-dim: #a09a8c;
-  --color-muted: #78746a;
+  --color-muted: #838077;
   --color-white: #eeece6;
   --color-foreground: var(--color-text);
   --color-accent: #c8ff00;


### PR DESCRIPTION
## Summary

- Change `--color-muted` from `#4a473f` (contrast ratio 1.67:1) to `#78746a` (4.6:1) against `--color-bg: #111110`
- The previous value was ~3x below the WCAG 2.1 AA minimum of 4.5:1 for normal text
- Affects all `text-muted` usage across 8 components plus scrollbar and selection styling

Closes #168

## Test plan

- [x] All 493 frontend tests pass
- [x] oxlint — 0 warnings, 0 errors
- [ ] Visual check: open any PRism page and verify muted text is readable but still visually subdued
- [ ] Verify scrollbar thumb color is acceptable with the new value

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved readability by increasing the contrast of muted text to meet WCAG 2.1 AA. Fixes #168.

- **Bug Fixes**
  - Updated `--color-muted` from `#4a473f` (1.67:1) to `#838077` (~4.83:1) against `--color-bg` `#111110`.
  - Affects all `text-muted` across 8 components, plus scrollbar thumb and selection.

<sup>Written for commit 28d231455e469daa1de521a12cd634478bfa06ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the theme's muted color to a lighter shade, refreshing scrollbar thumb and related interface element colors for improved visual consistency; hover interactions continue to use the existing dim color.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->