### PR TITLE
add dashboard skeleton loading states

### DIFF
--- a/src/components/ActivityFeed/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed/ActivityFeed.test.tsx
@@ -87,6 +87,15 @@ describe("ActivityFeed", () => {
     expect(screen.getByText(/no activity/i)).toBeInTheDocument();
   });
 
+  it("should render list skeletons while loading", () => {
+    render(<ActivityFeed activities={[]} isLoading onMarkAllRead={onMarkAllRead} />);
+
+    expect(screen.getByTestId("activity-feed")).toHaveAttribute("aria-busy", "true");
+    expect(screen.getAllByTestId("activity-item-skeleton")).toHaveLength(4);
+    expect(screen.queryByText(/no activity/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("group", { name: /filter by type/i })).not.toBeInTheDocument();
+  });
+
   it("should render SectionHead with filtered count when activities are provided", () => {
     render(<ActivityFeed activities={allActivities} onMarkAllRead={onMarkAllRead} />);
 

--- a/src/components/ActivityFeed/ActivityFeed.tsx
+++ b/src/components/ActivityFeed/ActivityFeed.tsx
@@ -2,10 +2,12 @@ import { type ReactElement, useState } from "react";
 import type { Activity, ActivityType } from "../../lib/types";
 import { EmptyState } from "../atoms/EmptyState";
 import { SectionHead } from "../atoms/SectionHead";
+import { ListItemSkeleton, Skeleton } from "../atoms/Skeleton";
 import { ActivityItem } from "./ActivityItem";
 
 interface ActivityFeedProps {
   readonly activities: readonly Activity[];
+  readonly isLoading?: boolean;
   readonly onMarkAllRead: () => void;
 }
 
@@ -30,51 +32,83 @@ function matchesFilter(activity: Activity, filter: FilterType): boolean {
   return FILTER_MATCH[filter].includes(activity.activityType);
 }
 
-export function ActivityFeed({ activities, onMarkAllRead }: ActivityFeedProps): ReactElement {
+export function ActivityFeed({
+  activities,
+  isLoading = false,
+  onMarkAllRead,
+}: ActivityFeedProps): ReactElement {
   const [filter, setFilter] = useState<FilterType>("all");
 
   const visible = activities.filter((a) => matchesFilter(a, filter));
 
   return (
-    <section data-testid="activity-feed" className="flex flex-col gap-2">
-      <SectionHead title="Activity" count={visible.length} />
+    <section
+      data-testid="activity-feed"
+      aria-busy={isLoading ? "true" : undefined}
+      className="flex flex-col gap-2"
+    >
+      <SectionHead title="Activity" count={isLoading ? undefined : visible.length} />
 
-      <div className="flex min-w-0 flex-wrap items-center gap-1">
-        <div className="flex flex-wrap gap-1" role="group" aria-label="Filter by type">
-          {FILTER_LABELS.map((f) => (
-            <button
-              key={f}
-              type="button"
-              aria-pressed={filter === f}
-              onClick={() => setFilter(f)}
-              className={`rounded px-2 py-2 text-xs capitalize transition-colors ${
-                filter === f
-                  ? "bg-accent text-bg font-semibold hover:bg-accent/80"
-                  : "text-dim hover:bg-surface-hover hover:text-foreground"
-              }`}
-            >
-              {f}
-            </button>
-          ))}
-        </div>
+      {isLoading ? (
+        <>
+          <div className="flex min-w-0 flex-wrap items-center gap-1">
+            <Skeleton className="h-8 w-11" />
+            <Skeleton className="h-8 w-16" />
+            <Skeleton className="h-8 w-12" />
+            <Skeleton className="ml-auto h-8 w-24" />
+          </div>
 
-        <button
-          type="button"
-          onClick={onMarkAllRead}
-          className="ml-auto rounded px-2 py-2 text-xs text-dim hover:text-foreground"
-        >
-          Mark all read
-        </button>
-      </div>
-
-      {visible.length === 0 ? (
-        <EmptyState icon="◌" message="No activity to display" />
+          <div data-testid="activity-feed-loading" className="flex flex-col gap-1">
+            {Array.from({ length: 4 }, (_, index) => (
+              <ListItemSkeleton
+                key={`activity-skeleton-${index}`}
+                testId="activity-item-skeleton"
+                showBodyLine
+                showPill={false}
+              />
+            ))}
+          </div>
+        </>
       ) : (
-        <div className="flex flex-col gap-1">
-          {visible.map((activity) => (
-            <ActivityItem key={activity.id} activity={activity} />
-          ))}
-        </div>
+        <>
+          <div className="flex min-w-0 flex-wrap items-center gap-1">
+            <div className="flex flex-wrap gap-1" role="group" aria-label="Filter by type">
+              {FILTER_LABELS.map((f) => (
+                <button
+                  key={f}
+                  type="button"
+                  aria-pressed={filter === f}
+                  onClick={() => setFilter(f)}
+                  className={`rounded px-2 py-2 text-xs capitalize transition-colors ${
+                    filter === f
+                      ? "bg-accent text-bg font-semibold hover:bg-accent/80"
+                      : "text-dim hover:bg-surface-hover hover:text-foreground"
+                  }`}
+                >
+                  {f}
+                </button>
+              ))}
+            </div>
+
+            <button
+              type="button"
+              onClick={onMarkAllRead}
+              className="ml-auto rounded px-2 py-2 text-xs text-dim hover:text-foreground"
+            >
+              Mark all read
+            </button>
+          </div>
+
+          {visible.length === 0 ? (
+            <EmptyState icon="◌" message="No activity to display" />
+          ) : (
+            <div className="flex flex-col gap-1">
+              {visible.map((activity) => (
+                <ActivityItem key={activity.id} activity={activity} />
+              ))}
+            </div>
+          )}
+        </>
       )}
     </section>
   );

--- a/src/components/Issues/Issues.test.tsx
+++ b/src/components/Issues/Issues.test.tsx
@@ -112,6 +112,15 @@ describe("Issues", () => {
     expect(screen.getByText(/no issues/i)).toBeInTheDocument();
   });
 
+  it("should render list skeletons while loading", () => {
+    render(<Issues issues={[]} isLoading onOpen={onOpen} />);
+
+    expect(screen.getByTestId("issues")).toHaveAttribute("aria-busy", "true");
+    expect(screen.getAllByTestId("issue-card-skeleton")).toHaveLength(4);
+    expect(screen.queryByText(/no issues/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("group", { name: /filter by state/i })).not.toBeInTheDocument();
+  });
+
   it("should show empty state on closed tab when no closed issues", async () => {
     const user = userEvent.setup();
     render(<Issues issues={[openIssue1]} onOpen={onOpen} />);

--- a/src/components/Issues/Issues.tsx
+++ b/src/components/Issues/Issues.tsx
@@ -6,10 +6,12 @@ import type { Issue } from "../../lib/types";
 import { useRegisterNavigableItems } from "../../hooks/useRegisterNavigableItems";
 import { EmptyState } from "../atoms/EmptyState";
 import { SectionHead } from "../atoms/SectionHead";
+import { ListItemSkeleton, Skeleton } from "../atoms/Skeleton";
 import { IssueCard } from "./IssueCard";
 
 interface IssuesProps {
   readonly issues: readonly Issue[];
+  readonly isLoading?: boolean;
   readonly onOpen: (url: string) => void;
 }
 
@@ -23,7 +25,11 @@ function isClosed(issue: Issue): boolean {
   return issue.state === "closed";
 }
 
-export function Issues({ issues, onOpen }: IssuesProps): ReactElement {
+export function Issues({
+  issues,
+  isLoading = false,
+  onOpen,
+}: IssuesProps): ReactElement {
   const [tab, setTab] = useState<Tab>("open");
   const parentRef = useRef<HTMLDivElement>(null);
 
@@ -62,69 +68,94 @@ export function Issues({ issues, onOpen }: IssuesProps): ReactElement {
   useRegisterNavigableItems(navItems);
 
   return (
-    <section data-testid="issues" className="flex flex-col gap-2">
-      <SectionHead title="Issues" count={issues.length} />
+    <section
+      data-testid="issues"
+      aria-busy={isLoading ? "true" : undefined}
+      className="flex flex-col gap-2"
+    >
+      <SectionHead title="Issues" count={isLoading ? undefined : issues.length} />
 
-      <div className="flex gap-1" role="group" aria-label="Filter by state">
-        <button
-          type="button"
-          aria-pressed={tab === "open"}
-          onClick={() => setTab("open")}
-          className={`rounded px-2 py-2 text-xs transition-colors ${
-            tab === "open"
-              ? "bg-accent text-bg font-semibold hover:bg-accent/80"
-              : "text-dim hover:bg-surface-hover hover:text-foreground"
-          }`}
-        >
-          Open {openIssues.length}
-        </button>
-        <button
-          type="button"
-          aria-pressed={tab === "closed"}
-          onClick={() => setTab("closed")}
-          className={`rounded px-2 py-2 text-xs transition-colors ${
-            tab === "closed"
-              ? "bg-accent text-bg font-semibold hover:bg-accent/80"
-              : "text-dim hover:bg-surface-hover hover:text-foreground"
-          }`}
-        >
-          Closed {closedIssues.length}
-        </button>
-      </div>
-
-      {visible.length === 0 ? (
-        <EmptyState icon="◎" message="No issues to display" />
-      ) : (
-        <div
-          ref={parentRef}
-          className="max-h-[600px] overflow-y-auto"
-        >
-          <div
-            className="relative w-full"
-            style={{ height: `${virtualizer.getTotalSize()}px` }}
-          >
-            {virtualizer.getVirtualItems().map((virtualItem) => {
-              const issue = visible[virtualItem.index];
-              if (!issue) return <div key={virtualItem.key} style={{ height: `${virtualItem.size}px` }} />;
-              return (
-                <div
-                  key={virtualItem.key}
-                  className="absolute left-0 top-0 w-full"
-                  style={{
-                    height: `${virtualItem.size}px`,
-                    transform: `translateY(${virtualItem.start}px)`,
-                  }}
-                >
-                  <IssueCard
-                    issue={issue}
-                    repoName={repoMap.get(issue.repoId) ?? issue.repoId}
-                    onOpen={onOpen}
-                  />
-                </div>
-              );
-            })}
+      {isLoading ? (
+        <>
+          <div className="flex gap-1">
+            <Skeleton className="h-8 w-16" />
+            <Skeleton className="h-8 w-[4.5rem]" />
           </div>
-        </div>
+
+          <div data-testid="issues-loading" className="flex flex-col gap-1">
+            {Array.from({ length: 4 }, (_, index) => (
+              <ListItemSkeleton
+                key={`issue-skeleton-${index}`}
+                testId="issue-card-skeleton"
+                showPill
+              />
+            ))}
+          </div>
+        </>
+      ) : (
+        <>
+          <div className="flex gap-1" role="group" aria-label="Filter by state">
+            <button
+              type="button"
+              aria-pressed={tab === "open"}
+              onClick={() => setTab("open")}
+              className={`rounded px-2 py-2 text-xs transition-colors ${
+                tab === "open"
+                  ? "bg-accent text-bg font-semibold hover:bg-accent/80"
+                  : "text-dim hover:bg-surface-hover hover:text-foreground"
+              }`}
+            >
+              Open {openIssues.length}
+            </button>
+            <button
+              type="button"
+              aria-pressed={tab === "closed"}
+              onClick={() => setTab("closed")}
+              className={`rounded px-2 py-2 text-xs transition-colors ${
+                tab === "closed"
+                  ? "bg-accent text-bg font-semibold hover:bg-accent/80"
+                  : "text-dim hover:bg-surface-hover hover:text-foreground"
+              }`}
+            >
+              Closed {closedIssues.length}
+            </button>
+          </div>
+
+          {visible.length === 0 ? (
+            <EmptyState icon="◎" message="No issues to display" />
+          ) : (
+            <div
+              ref={parentRef}
+              className="max-h-[600px] overflow-y-auto"
+            >
+              <div
+                className="relative w-full"
+                style={{ height: `${virtualizer.getTotalSize()}px` }}
+              >
+                {virtualizer.getVirtualItems().map((virtualItem) => {
+                  const issue = visible[virtualItem.index];
+                  if (!issue) return <div key={virtualItem.key} style={{ height: `${virtualItem.size}px` }} />;
+                  return (
+                    <div
+                      key={virtualItem.key}
+                      className="absolute left-0 top-0 w-full"
+                      style={{
+                        height: `${virtualItem.size}px`,
+                        transform: `translateY(${virtualItem.start}px)`,
+                      }}
+                    >
+                      <IssueCard
+                        issue={issue}
+                        repoName={repoMap.get(issue.repoId) ?? issue.repoId}
+                        onOpen={onOpen}
+                      />
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </>
       )}
     </section>
   );

--- a/src/components/MyPRs/MyPRs.test.tsx
+++ b/src/components/MyPRs/MyPRs.test.tsx
@@ -92,6 +92,15 @@ describe("MyPRs", () => {
     expect(screen.getByText(/no pull requests/i)).toBeInTheDocument();
   });
 
+  it("should render card skeletons while loading", () => {
+    render(<MyPRs prs={[]} isLoading onOpen={onOpen} />);
+
+    expect(screen.getByTestId("my-prs")).toHaveAttribute("aria-busy", "true");
+    expect(screen.getAllByTestId("my-pr-card-skeleton")).toHaveLength(3);
+    expect(screen.queryByText(/no pull requests/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("group", { name: /filter by state/i })).not.toBeInTheDocument();
+  });
+
   it("should render SectionHead with title and total count", () => {
     render(<MyPRs prs={allPrs} onOpen={onOpen} />);
 

--- a/src/components/MyPRs/MyPRs.tsx
+++ b/src/components/MyPRs/MyPRs.tsx
@@ -3,6 +3,7 @@ import type { PullRequestWithReview } from "../../lib/types";
 import { useRegisterNavigableItems } from "../../hooks/useRegisterNavigableItems";
 import { EmptyState } from "../atoms/EmptyState";
 import { SectionHead } from "../atoms/SectionHead";
+import { CardSkeleton, Skeleton } from "../atoms/Skeleton";
 import { MyPrCard } from "./MyPrCard";
 
 interface WorkspaceActionParams {
@@ -15,6 +16,7 @@ interface WorkspaceActionParams {
 
 interface MyPRsProps {
   readonly prs: readonly PullRequestWithReview[];
+  readonly isLoading?: boolean;
   readonly onOpen: (url: string) => void;
   readonly onWorkspaceAction?: (params: WorkspaceActionParams) => void;
 }
@@ -32,6 +34,7 @@ function isMerged(pr: PullRequestWithReview): boolean {
 
 export function MyPRs({
   prs,
+  isLoading = false,
   onOpen,
   onWorkspaceAction,
 }: MyPRsProps): ReactElement {
@@ -51,49 +54,77 @@ export function MyPRs({
   useRegisterNavigableItems(navItems);
 
   return (
-    <section data-testid="my-prs" className="flex flex-col gap-2">
-      <SectionHead title="My PRs" count={openPrs.length + mergedPrs.length} />
+    <section
+      data-testid="my-prs"
+      aria-busy={isLoading ? "true" : undefined}
+      className="flex flex-col gap-2"
+    >
+      <SectionHead
+        title="My PRs"
+        count={isLoading ? undefined : openPrs.length + mergedPrs.length}
+      />
 
-      <div className="flex gap-1" role="group" aria-label="Filter by state">
-        <button
-          type="button"
-          aria-pressed={tab === "open"}
-          onClick={() => setTab("open")}
-          className={`rounded px-2 py-2 text-xs transition-colors ${
-            tab === "open"
-              ? "bg-accent text-bg font-semibold hover:bg-accent/80"
-              : "text-dim hover:bg-surface-hover hover:text-foreground"
-          }`}
-        >
-          Open {openPrs.length}
-        </button>
-        <button
-          type="button"
-          aria-pressed={tab === "merged"}
-          onClick={() => setTab("merged")}
-          className={`rounded px-2 py-2 text-xs transition-colors ${
-            tab === "merged"
-              ? "bg-accent text-bg font-semibold hover:bg-accent/80"
-              : "text-dim hover:bg-surface-hover hover:text-foreground"
-          }`}
-        >
-          Merged {mergedPrs.length}
-        </button>
-      </div>
+      {isLoading ? (
+        <>
+          <div className="flex gap-1">
+            <Skeleton className="h-8 w-16" />
+            <Skeleton className="h-8 w-20" />
+          </div>
 
-      {visible.length === 0 ? (
-        <EmptyState icon="↗" message="No pull requests to display" />
+          <div data-testid="my-prs-loading" className="flex flex-col gap-1">
+            {Array.from({ length: 3 }, (_, index) => (
+              <CardSkeleton
+                key={`my-pr-skeleton-${index}`}
+                testId="my-pr-card-skeleton"
+                showTrailingBadge
+              />
+            ))}
+          </div>
+        </>
       ) : (
-        <div className="flex flex-col gap-1">
-          {visible.map((pr) => (
-            <MyPrCard
-              key={pr.pullRequest.id}
-              data={pr}
-              onOpen={onOpen}
-              onWorkspaceAction={onWorkspaceAction}
-            />
-          ))}
-        </div>
+        <>
+          <div className="flex gap-1" role="group" aria-label="Filter by state">
+            <button
+              type="button"
+              aria-pressed={tab === "open"}
+              onClick={() => setTab("open")}
+              className={`rounded px-2 py-2 text-xs transition-colors ${
+                tab === "open"
+                  ? "bg-accent text-bg font-semibold hover:bg-accent/80"
+                  : "text-dim hover:bg-surface-hover hover:text-foreground"
+              }`}
+            >
+              Open {openPrs.length}
+            </button>
+            <button
+              type="button"
+              aria-pressed={tab === "merged"}
+              onClick={() => setTab("merged")}
+              className={`rounded px-2 py-2 text-xs transition-colors ${
+                tab === "merged"
+                  ? "bg-accent text-bg font-semibold hover:bg-accent/80"
+                  : "text-dim hover:bg-surface-hover hover:text-foreground"
+              }`}
+            >
+              Merged {mergedPrs.length}
+            </button>
+          </div>
+
+          {visible.length === 0 ? (
+            <EmptyState icon="↗" message="No pull requests to display" />
+          ) : (
+            <div className="flex flex-col gap-1">
+              {visible.map((pr) => (
+                <MyPrCard
+                  key={pr.pullRequest.id}
+                  data={pr}
+                  onOpen={onOpen}
+                  onWorkspaceAction={onWorkspaceAction}
+                />
+              ))}
+            </div>
+          )}
+        </>
       )}
     </section>
   );

--- a/src/components/Overview/Overview.test.tsx
+++ b/src/components/Overview/Overview.test.tsx
@@ -253,7 +253,12 @@ describe("Overview", () => {
 
     renderWithProviders(<Overview />);
 
-    expect(screen.getByText(/loading/i)).toBeInTheDocument();
+    expect(screen.getByTestId("overview")).toHaveAttribute("aria-busy", "true");
+    expect(screen.getByTestId("review-queue")).toHaveAttribute("aria-busy", "true");
+    expect(screen.getByTestId("my-prs")).toHaveAttribute("aria-busy", "true");
+    expect(screen.getByTestId("issues")).toHaveAttribute("aria-busy", "true");
+    expect(screen.getByTestId("activity-feed")).toHaveAttribute("aria-busy", "true");
+    expect(screen.queryByText(/loading/i)).not.toBeInTheDocument();
   });
 
   it("should show error state when dashboard is absent and error exists", () => {

--- a/src/components/Overview/Overview.tsx
+++ b/src/components/Overview/Overview.tsx
@@ -15,7 +15,7 @@ const MAX_PRS = 5;
 const MAX_ACTIVITIES = 5;
 
 export function Overview(): ReactElement {
-  const { dashboard, error } = useGitHubData();
+  const { dashboard, error, isLoading } = useGitHubData();
   const queryClient = useQueryClient();
 
   const markAllRead = useMutation({
@@ -84,29 +84,41 @@ export function Overview(): ReactElement {
     );
   }
 
-  if (!dashboard) {
-    return (
-      <div className="flex h-full items-center justify-center text-dim">
-        Loading...
-      </div>
-    );
-  }
+  const showLoadingState = !dashboard && !error;
 
-  const reviews = dashboard.reviewRequests.slice(0, MAX_REVIEWS);
-  const prs = dashboard.myPullRequests.slice(0, MAX_PRS);
-  const issues = dashboard.assignedIssues;
-  const activities = dashboard.recentActivity.slice(0, MAX_ACTIVITIES);
+  const reviews = dashboard?.reviewRequests.slice(0, MAX_REVIEWS) ?? [];
+  const prs = dashboard?.myPullRequests.slice(0, MAX_PRS) ?? [];
+  const issues = dashboard?.assignedIssues ?? [];
+  const activities = dashboard?.recentActivity.slice(0, MAX_ACTIVITIES) ?? [];
 
   return (
-    <div data-testid="overview" className="flex h-full gap-6 overflow-y-auto p-4">
+    <div
+      data-testid="overview"
+      aria-busy={showLoadingState || isLoading ? "true" : undefined}
+      className="flex h-full gap-6 overflow-y-auto p-4"
+    >
       <div className="flex min-w-0 flex-1 flex-col gap-6">
-        <ReviewQueue reviews={reviews} onOpen={openUrl} onWorkspaceAction={handleWorkspaceAction} />
-        <MyPRs prs={prs} onOpen={openUrl} onWorkspaceAction={handleWorkspaceAction} />
+        <ReviewQueue
+          reviews={reviews}
+          isLoading={showLoadingState}
+          onOpen={openUrl}
+          onWorkspaceAction={handleWorkspaceAction}
+        />
+        <MyPRs
+          prs={prs}
+          isLoading={showLoadingState}
+          onOpen={openUrl}
+          onWorkspaceAction={handleWorkspaceAction}
+        />
       </div>
 
       <div className="flex w-[300px] min-w-0 flex-col gap-6">
-        <Issues issues={issues} onOpen={openUrl} />
-        <ActivityFeed activities={activities} onMarkAllRead={() => markAllRead.mutate()} />
+        <Issues issues={issues} isLoading={showLoadingState} onOpen={openUrl} />
+        <ActivityFeed
+          activities={activities}
+          isLoading={showLoadingState}
+          onMarkAllRead={() => markAllRead.mutate()}
+        />
       </div>
     </div>
   );

--- a/src/components/ReviewQueue/ReviewQueue.test.tsx
+++ b/src/components/ReviewQueue/ReviewQueue.test.tsx
@@ -131,6 +131,16 @@ describe("ReviewQueue", () => {
     expect(screen.queryByRole("group", { name: /filter by priority/i })).not.toBeInTheDocument();
   });
 
+  it("should suppress navigable review content while loading with reviews present", () => {
+    render(<ReviewQueue reviews={[highPr]} isLoading onOpen={vi.fn()} />);
+
+    expect(screen.getByTestId("review-queue")).toHaveAttribute("aria-busy", "true");
+    expect(screen.getAllByTestId("review-card-skeleton")).toHaveLength(3);
+    expect(screen.queryByText("High feature")).not.toBeInTheDocument();
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    expect(screen.queryByRole("group", { name: /filter by priority/i })).not.toBeInTheDocument();
+  });
+
   it("should show section header with count", () => {
     render(<ReviewQueue reviews={allReviews} onOpen={vi.fn()} />);
 

--- a/src/components/ReviewQueue/ReviewQueue.test.tsx
+++ b/src/components/ReviewQueue/ReviewQueue.test.tsx
@@ -122,6 +122,15 @@ describe("ReviewQueue", () => {
     expect(screen.queryAllByRole("link")).toHaveLength(0);
   });
 
+  it("should render card skeletons while loading", () => {
+    render(<ReviewQueue reviews={[]} isLoading onOpen={vi.fn()} />);
+
+    expect(screen.getByTestId("review-queue")).toHaveAttribute("aria-busy", "true");
+    expect(screen.getAllByTestId("review-card-skeleton")).toHaveLength(3);
+    expect(screen.queryByText(/no.*review/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("group", { name: /filter by priority/i })).not.toBeInTheDocument();
+  });
+
   it("should show section header with count", () => {
     render(<ReviewQueue reviews={allReviews} onOpen={vi.fn()} />);
 

--- a/src/components/ReviewQueue/ReviewQueue.tsx
+++ b/src/components/ReviewQueue/ReviewQueue.tsx
@@ -99,8 +99,8 @@ export function ReviewQueue({
   }, [reviews, focusMode, priorityFilter, repoFilter]);
 
   const navItems = useMemo(
-    () => sorted.map((r) => ({ url: r.pullRequest.url })),
-    [sorted],
+    () => (isLoading ? [] : sorted.map((r) => ({ url: r.pullRequest.url }))),
+    [isLoading, sorted],
   );
   useRegisterNavigableItems(navItems);
 
@@ -115,10 +115,22 @@ export function ReviewQueue({
       {isLoading ? (
         <>
           <div className="flex items-center gap-3">
-            <Skeleton className="h-8 w-11" />
-            <Skeleton className="h-8 w-16" />
-            <Skeleton className="h-8 w-14" />
-            <Skeleton className="h-8 w-12" />
+            {PRIORITY_FILTERS.map((filter) => (
+              <Skeleton
+                key={`priority-filter-skeleton-${filter}`}
+                className={`h-8 ${
+                  filter === "all"
+                    ? "w-11"
+                    : filter === "critical"
+                      ? "w-16"
+                      : filter === "high"
+                        ? "w-12"
+                        : filter === "medium"
+                          ? "w-14"
+                          : "w-10"
+                }`}
+              />
+            ))}
           </div>
 
           <div

--- a/src/components/ReviewQueue/ReviewQueue.tsx
+++ b/src/components/ReviewQueue/ReviewQueue.tsx
@@ -2,6 +2,7 @@ import { type ReactElement, useEffect, useMemo } from "react";
 import type { Priority, PullRequestWithReview } from "../../lib/types";
 import { useRegisterNavigableItems } from "../../hooks/useRegisterNavigableItems";
 import { useDashboardStore } from "../../stores/dashboard";
+import { CardSkeleton, Skeleton } from "../atoms/Skeleton";
 import { EmptyState } from "../atoms/EmptyState";
 import { SectionHead } from "../atoms/SectionHead";
 import { ReviewCard } from "./ReviewCard";
@@ -16,6 +17,7 @@ interface WorkspaceActionParams {
 
 interface ReviewQueueProps {
   readonly reviews: readonly PullRequestWithReview[];
+  readonly isLoading?: boolean;
   readonly onOpen: (url: string) => void;
   readonly onWorkspaceAction?: (params: WorkspaceActionParams) => void;
 }
@@ -58,6 +60,7 @@ function getUniqueRepos(
 
 export function ReviewQueue({
   reviews,
+  isLoading = false,
   onOpen,
   onWorkspaceAction,
 }: ReviewQueueProps): ReactElement {
@@ -102,62 +105,93 @@ export function ReviewQueue({
   useRegisterNavigableItems(navItems);
 
   return (
-    <section data-testid="review-queue" className="flex flex-col gap-2">
-      <SectionHead title="Reviews" count={sorted.length} />
+    <section
+      data-testid="review-queue"
+      aria-busy={isLoading ? "true" : undefined}
+      className="flex flex-col gap-2"
+    >
+      <SectionHead title="Reviews" count={isLoading ? undefined : sorted.length} />
 
-      <div className="flex items-center gap-3">
-        <div className="flex gap-1" role="group" aria-label="Filter by priority">
-          {PRIORITY_FILTERS.map((f) => (
-            <button
-              key={f}
-              type="button"
-              aria-pressed={priorityFilter === f}
-              onClick={() =>
-                setFilter({ priority: f === "all" ? undefined : f })
-              }
-              className={`rounded px-2 py-2 text-xs transition-colors ${
-                priorityFilter === f
-                  ? "bg-accent text-bg font-semibold hover:bg-accent/80"
-                  : "text-dim hover:bg-surface-hover hover:text-foreground"
-              }`}
-            >
-              {f}
-            </button>
-          ))}
-        </div>
+      {isLoading ? (
+        <>
+          <div className="flex items-center gap-3">
+            <Skeleton className="h-8 w-11" />
+            <Skeleton className="h-8 w-16" />
+            <Skeleton className="h-8 w-14" />
+            <Skeleton className="h-8 w-12" />
+          </div>
 
-        {repos.length > 1 && (
-          <select
-            aria-label="Filter by repo"
-            value={repoFilter}
-            onChange={(e) =>
-              setFilter({ repo: e.target.value || undefined })
-            }
-            className="cursor-pointer rounded border border-border bg-surface px-2 py-2 text-xs text-foreground transition-colors hover:border-foreground"
+          <div
+            data-testid="review-queue-loading"
+            className="flex flex-col gap-1"
           >
-            <option value="">All repos</option>
-            {repos.map((id) => (
-              <option key={id} value={id}>
-                {id}
-              </option>
+            {Array.from({ length: 3 }, (_, index) => (
+              <CardSkeleton
+                key={`review-skeleton-${index}`}
+                testId="review-card-skeleton"
+                showPriorityBar
+                showTrailingBadge
+              />
             ))}
-          </select>
-        )}
-      </div>
-
-      {sorted.length === 0 ? (
-        <EmptyState icon="✓" message="No pending reviews — you're all caught up!" />
+          </div>
+        </>
       ) : (
-        <div className="flex flex-col gap-1">
-          {sorted.map((review) => (
-            <ReviewCard
-              key={review.pullRequest.id}
-              data={review}
-              onOpen={onOpen}
-              onWorkspaceAction={onWorkspaceAction}
-            />
-          ))}
-        </div>
+        <>
+          <div className="flex items-center gap-3">
+            <div className="flex gap-1" role="group" aria-label="Filter by priority">
+              {PRIORITY_FILTERS.map((f) => (
+                <button
+                  key={f}
+                  type="button"
+                  aria-pressed={priorityFilter === f}
+                  onClick={() =>
+                    setFilter({ priority: f === "all" ? undefined : f })
+                  }
+                  className={`rounded px-2 py-2 text-xs transition-colors ${
+                    priorityFilter === f
+                      ? "bg-accent text-bg font-semibold hover:bg-accent/80"
+                      : "text-dim hover:bg-surface-hover hover:text-foreground"
+                  }`}
+                >
+                  {f}
+                </button>
+              ))}
+            </div>
+
+            {repos.length > 1 && (
+              <select
+                aria-label="Filter by repo"
+                value={repoFilter}
+                onChange={(e) =>
+                  setFilter({ repo: e.target.value || undefined })
+                }
+                className="cursor-pointer rounded border border-border bg-surface px-2 py-2 text-xs text-foreground transition-colors hover:border-foreground"
+              >
+                <option value="">All repos</option>
+                {repos.map((id) => (
+                  <option key={id} value={id}>
+                    {id}
+                  </option>
+                ))}
+              </select>
+            )}
+          </div>
+
+          {sorted.length === 0 ? (
+            <EmptyState icon="✓" message="No pending reviews — you're all caught up!" />
+          ) : (
+            <div className="flex flex-col gap-1">
+              {sorted.map((review) => (
+                <ReviewCard
+                  key={review.pullRequest.id}
+                  data={review}
+                  onOpen={onOpen}
+                  onWorkspaceAction={onWorkspaceAction}
+                />
+              ))}
+            </div>
+          )}
+        </>
       )}
     </section>
   );

--- a/src/components/StatsBar/StatsBar.test.tsx
+++ b/src/components/StatsBar/StatsBar.test.tsx
@@ -87,7 +87,7 @@ describe("StatsBar", () => {
     expect(pendingValue).toHaveClass("text-accent");
   });
 
-  it("should show placeholder when stats are null", () => {
+  it("should render stats skeletons while loading", () => {
     (useGitHubData as Mock).mockReturnValue({
       stats: null,
       dashboard: null,
@@ -98,8 +98,12 @@ describe("StatsBar", () => {
 
     render(<StatsBar />, { wrapper: createWrapper() });
 
-    const values = screen.getAllByText("—");
-    expect(values.length).toBe(4);
+    expect(screen.getByTestId("stats-bar")).toHaveAttribute("aria-busy", "true");
+    expect(screen.getByTestId("stat-pending-reviews-skeleton")).toBeInTheDocument();
+    expect(screen.getByTestId("stat-open-prs-skeleton")).toBeInTheDocument();
+    expect(screen.getByTestId("stat-issues-skeleton")).toBeInTheDocument();
+    expect(screen.getByTestId("stat-workspaces-skeleton")).toBeInTheDocument();
+    expect(screen.getByTestId("stats-bar-sync-skeleton")).toBeInTheDocument();
   });
 
   it("should show minutes format when synced over 60s ago", () => {

--- a/src/components/StatsBar/StatsBar.tsx
+++ b/src/components/StatsBar/StatsBar.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, type ReactElement } from "react";
 import { useGitHubData } from "../../hooks/useGitHubData";
 import { useDashboardStore } from "../../stores/dashboard";
+import { StatsBarSkeleton } from "../atoms/Skeleton";
 
 const TICK_INTERVAL = 10_000;
 
@@ -42,7 +43,7 @@ function StatItem({ label, value, testId, highlight }: StatItemProps): ReactElem
 }
 
 export function StatsBar(): ReactElement {
-  const { stats, dashboard, isSyncing } = useGitHubData();
+  const { stats, dashboard, isLoading, isSyncing } = useGitHubData();
   const focusMode = useDashboardStore((s) => s.focusMode);
   const [now, setNow] = useState(() => Date.now());
 
@@ -53,11 +54,16 @@ export function StatsBar(): ReactElement {
 
   const syncedAt = dashboard?.syncedAt ?? null;
 
+  if (isLoading && !stats) {
+    return <StatsBarSkeleton focusMode={focusMode} />;
+  }
+
   return (
     <div
       data-testid="stats-bar"
       role="region"
       aria-label="Statistics"
+      aria-busy={isLoading ? "true" : undefined}
       className="flex items-center justify-between border-b border-border px-4 py-2"
     >
       <div className="flex items-center gap-6">

--- a/src/components/atoms/SectionHead.test.tsx
+++ b/src/components/atoms/SectionHead.test.tsx
@@ -13,6 +13,13 @@ describe("SectionHead", () => {
     expect(screen.getByText("5")).toBeInTheDocument();
   });
 
+  it("should omit count when it is not provided", () => {
+    render(<SectionHead title="Reviews" />);
+
+    expect(screen.getByText("Reviews")).toBeInTheDocument();
+    expect(screen.queryByText("5")).not.toBeInTheDocument();
+  });
+
   it("should render separator", () => {
     const { container } = render(<SectionHead title="Reviews" count={0} />);
     expect(container.querySelector("hr, [role='separator']")).toBeInTheDocument();

--- a/src/components/atoms/SectionHead.tsx
+++ b/src/components/atoms/SectionHead.tsx
@@ -2,7 +2,7 @@ import type { ReactElement } from "react";
 
 interface SectionHeadProps {
   readonly title: string;
-  readonly count: number;
+  readonly count?: number;
 }
 
 export function SectionHead({ title, count }: SectionHeadProps): ReactElement {
@@ -10,7 +10,7 @@ export function SectionHead({ title, count }: SectionHeadProps): ReactElement {
     <div>
       <div className="flex items-center gap-2">
         <h2 className="text-sm font-semibold text-white">{title}</h2>
-        <span className="text-xs text-dim">{count}</span>
+        {typeof count === "number" && <span className="text-xs text-dim">{count}</span>}
       </div>
       <hr className="mt-1 border-border" role="separator" />
     </div>

--- a/src/components/atoms/Skeleton.tsx
+++ b/src/components/atoms/Skeleton.tsx
@@ -102,7 +102,7 @@ export function ListItemSkeleton({
 
 function StatSkeleton({ testId }: { readonly testId: string }): ReactElement {
   return (
-    <div data-testid={testId} className="flex flex-col gap-1">
+    <div aria-hidden="true" data-testid={testId} className="flex flex-col gap-1">
       <Skeleton className="h-6 w-10" />
       <Skeleton className="h-3 w-16" />
     </div>

--- a/src/components/atoms/Skeleton.tsx
+++ b/src/components/atoms/Skeleton.tsx
@@ -1,0 +1,140 @@
+import type { ReactElement } from "react";
+
+interface SkeletonProps {
+  readonly className?: string;
+  readonly testId?: string;
+}
+
+interface CardSkeletonProps {
+  readonly testId?: string;
+  readonly showPriorityBar?: boolean;
+  readonly showTrailingBadge?: boolean;
+}
+
+interface ListItemSkeletonProps {
+  readonly testId?: string;
+  readonly showBodyLine?: boolean;
+  readonly showPill?: boolean;
+}
+
+interface StatsBarSkeletonProps {
+  readonly focusMode?: boolean;
+}
+
+export function Skeleton({
+  className = "",
+  testId,
+}: SkeletonProps): ReactElement {
+  return (
+    <div
+      aria-hidden="true"
+      data-testid={testId}
+      className={`animate-pulse rounded bg-surface ${className}`.trim()}
+    />
+  );
+}
+
+export function CardSkeleton({
+  testId,
+  showPriorityBar = false,
+  showTrailingBadge = false,
+}: CardSkeletonProps): ReactElement {
+  return (
+    <div
+      aria-hidden="true"
+      data-testid={testId}
+      className="flex items-center gap-3 rounded border border-border px-3 py-2"
+    >
+      {showPriorityBar ? (
+        <Skeleton className="h-10 w-1 rounded-full" />
+      ) : (
+        <Skeleton className="h-2.5 w-2.5 rounded-full" />
+      )}
+
+      <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-4 max-w-[220px] flex-1" />
+          <Skeleton className="h-3 w-10" />
+          {showTrailingBadge && <Skeleton className="h-5 w-20 rounded-full" />}
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-3 w-16" />
+          <Skeleton className="h-3 w-12" />
+          <Skeleton className="h-3 w-14" />
+          <Skeleton className="ml-auto h-3 w-14" />
+        </div>
+      </div>
+
+      {showTrailingBadge && <Skeleton className="h-8 w-16 rounded" />}
+    </div>
+  );
+}
+
+export function ListItemSkeleton({
+  testId,
+  showBodyLine = false,
+  showPill = true,
+}: ListItemSkeletonProps): ReactElement {
+  return (
+    <div
+      aria-hidden="true"
+      data-testid={testId}
+      className="flex flex-col gap-2 rounded border border-border px-3 py-2"
+    >
+      <div className="flex min-w-0 items-center gap-2">
+        <Skeleton className="h-2.5 w-2.5 rounded-full" />
+        <Skeleton className="h-3 w-10" />
+        <Skeleton className="h-4 max-w-[200px] flex-1" />
+      </div>
+
+      <div className="flex min-w-0 flex-col gap-2 pl-[18px]">
+        {showBodyLine && <Skeleton className="h-3 w-full max-w-[240px]" />}
+        <div className="flex min-w-0 items-center gap-2">
+          <Skeleton className="h-5 w-20 rounded-full" />
+          {showPill && <Skeleton className="h-5 w-16 rounded-full" />}
+          <Skeleton className="ml-auto h-3 w-12" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function StatSkeleton({ testId }: { readonly testId: string }): ReactElement {
+  return (
+    <div data-testid={testId} className="flex flex-col gap-1">
+      <Skeleton className="h-6 w-10" />
+      <Skeleton className="h-3 w-16" />
+    </div>
+  );
+}
+
+export function StatsBarSkeleton({
+  focusMode = false,
+}: StatsBarSkeletonProps): ReactElement {
+  return (
+    <div
+      data-testid="stats-bar"
+      role="region"
+      aria-label="Statistics"
+      aria-busy="true"
+      className="flex items-center justify-between border-b border-border px-4 py-2"
+    >
+      <div className="flex items-center gap-6">
+        <StatSkeleton testId="stat-pending-reviews-skeleton" />
+        <StatSkeleton testId="stat-open-prs-skeleton" />
+        <StatSkeleton testId="stat-issues-skeleton" />
+        <StatSkeleton testId="stat-workspaces-skeleton" />
+      </div>
+
+      <div className="flex items-center gap-3">
+        {focusMode && (
+          <span className="rounded bg-accent px-2 py-0.5 text-xs font-bold text-bg">
+            FOCUS MODE
+          </span>
+        )}
+        <Skeleton testId="stats-bar-sync-skeleton" className="h-4 w-24" />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Close #170 
## What changed
- added reusable skeleton loading components for dashboard sections
- replaced the top-level loading text with section-specific placeholders
- added aria-busy on loading containers and updated focused tests

## Why
The dashboard had no meaningful loading feedback during initial data fetches, which caused abrupt content pop-in and unclear app state.

## Validation
- npx vitest run src/components/Overview/Overview.test.tsx src/components/ReviewQueue/ReviewQueue.test.tsx src/components/MyPRs/MyPRs.test.tsx src/components/Issues/Issues.test.tsx src/components/ActivityFeed/ActivityFeed.test.tsx src/components/StatsBar/StatsBar.test.tsx
- npm run lint
- npm run build


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds reusable skeleton loading states across the dashboard and replaces the global “Loading…” screen with per-section placeholders to reduce flicker and clarify app state. Implements Linear issue 170 with consistent, accessible loading UI.

- **New Features**
  - Added shared skeleton atoms: `Skeleton`, `CardSkeleton`, `ListItemSkeleton`, `StatsBarSkeleton`.
  - Wired `isLoading` + skeletons into `ReviewQueue`, `MyPRs`, `Issues`, `ActivityFeed`, `StatsBar`; `Overview` now sets `aria-busy` and passes loading flags instead of rendering a loading screen.
  - Updated `SectionHead` to accept an optional count and omit it while loading.
  - Hid filters and interactive controls while loading; suppressed navigable item registration; showed card/list skeletons instead.
  - Set `aria-busy` on loading containers and updated tests to assert skeletons and accessibility.

<sup>Written for commit f5d55cac9b05f38fab99151728ae1d88860c8c9b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard sections now show animated skeleton placeholders and expose loading state (aria-busy) while fetching.
  * Reusable skeleton/loading visuals added for cards, list items and the stats bar.
  * Section headers hide counts during loading to avoid misleading numbers.

* **Tests**
  * Added tests covering loading-state behavior across Overview, Review Queue, My PRs, Issues, Activity Feed and StatsBar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->