### PR TITLE
fix(ui): increase filter touch target sizes

### DIFF
--- a/src/components/ActivityFeed/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed/ActivityFeed.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Activity } from "../../lib/types";
@@ -101,6 +101,23 @@ describe("ActivityFeed", () => {
 
     expect(screen.getByText("Activity")).toBeInTheDocument();
     expect(screen.getByText("6")).toBeInTheDocument();
+  });
+
+  it("should keep filter buttons at the minimum touch target size", () => {
+    render(<ActivityFeed activities={allActivities} onMarkAllRead={onMarkAllRead} />);
+
+    const filterGroup = screen.getByRole("group", { name: /filter by type/i });
+    const buttons = within(filterGroup).getAllByRole("button");
+
+    for (const button of buttons) {
+      expect(button).toHaveClass("min-h-11", "min-w-11");
+    }
+  });
+
+  it("should keep the mark all read action at the minimum touch target height", () => {
+    render(<ActivityFeed activities={allActivities} onMarkAllRead={onMarkAllRead} />);
+
+    expect(screen.getByRole("button", { name: /mark all read/i })).toHaveClass("min-h-11");
   });
 
   it("should set aria-pressed correctly when filter button is clicked", async () => {

--- a/src/components/ActivityFeed/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed/ActivityFeed.test.tsx
@@ -120,6 +120,12 @@ describe("ActivityFeed", () => {
     expect(screen.getByRole("button", { name: /mark all read/i })).toHaveClass("min-h-11");
   });
 
+  it("should render the ci filter label in uppercase", () => {
+    render(<ActivityFeed activities={allActivities} onMarkAllRead={onMarkAllRead} />);
+
+    expect(screen.getByRole("button", { name: "CI" })).toBeInTheDocument();
+  });
+
   it("should set aria-pressed correctly when filter button is clicked", async () => {
     const user = userEvent.setup();
     render(<ActivityFeed activities={allActivities} onMarkAllRead={onMarkAllRead} />);

--- a/src/components/ActivityFeed/ActivityFeed.tsx
+++ b/src/components/ActivityFeed/ActivityFeed.tsx
@@ -24,8 +24,17 @@ const MENTION_PATTERN = /(^|\s)@\w+/;
 
 const FILTER_LABELS = ["all", "comment", "review", "ci", "mention", "other"] as const satisfies readonly FilterType[];
 
+const FILTER_LABEL: Record<FilterType, string> = {
+  all: "all",
+  comment: "comment",
+  review: "review",
+  ci: "CI",
+  mention: "mention",
+  other: "other",
+};
+
 const FILTER_BUTTON_CLASS =
-  "inline-flex min-h-11 min-w-11 items-center justify-center rounded px-3 text-xs capitalize leading-none transition-colors";
+  "inline-flex min-h-11 min-w-11 items-center justify-center rounded px-3 text-xs leading-none transition-colors";
 
 const ACTION_BUTTON_CLASS =
   "inline-flex min-h-11 items-center rounded px-3 text-xs transition-colors";
@@ -91,7 +100,7 @@ export function ActivityFeed({
                       : "text-dim hover:bg-surface-hover hover:text-foreground"
                   }`}
                 >
-                  {f}
+                  {FILTER_LABEL[f]}
                 </button>
               ))}
             </div>

--- a/src/components/ActivityFeed/ActivityFeed.tsx
+++ b/src/components/ActivityFeed/ActivityFeed.tsx
@@ -24,6 +24,12 @@ const MENTION_PATTERN = /(^|\s)@\w+/;
 
 const FILTER_LABELS = ["all", "comment", "review", "ci", "mention", "other"] as const satisfies readonly FilterType[];
 
+const FILTER_BUTTON_CLASS =
+  "inline-flex min-h-11 min-w-11 items-center justify-center rounded px-3 text-xs capitalize leading-none transition-colors";
+
+const ACTION_BUTTON_CLASS =
+  "inline-flex min-h-11 items-center rounded px-3 text-xs transition-colors";
+
 function matchesFilter(activity: Activity, filter: FilterType): boolean {
   if (filter === "all") return true;
   if (filter === "mention") {
@@ -52,10 +58,10 @@ export function ActivityFeed({
       {isLoading ? (
         <>
           <div className="flex min-w-0 flex-wrap items-center gap-1">
-            <Skeleton className="h-8 w-11" />
-            <Skeleton className="h-8 w-16" />
-            <Skeleton className="h-8 w-12" />
-            <Skeleton className="ml-auto h-8 w-24" />
+            <Skeleton className="h-11 w-11" />
+            <Skeleton className="h-11 w-16" />
+            <Skeleton className="h-11 w-12" />
+            <Skeleton className="ml-auto h-11 w-24" />
           </div>
 
           <div data-testid="activity-feed-loading" className="flex flex-col gap-1">
@@ -79,7 +85,7 @@ export function ActivityFeed({
                   type="button"
                   aria-pressed={filter === f}
                   onClick={() => setFilter(f)}
-                  className={`rounded px-2 py-2 text-xs capitalize transition-colors ${
+                  className={`${FILTER_BUTTON_CLASS} ${
                     filter === f
                       ? "bg-accent text-bg font-semibold hover:bg-accent/80"
                       : "text-dim hover:bg-surface-hover hover:text-foreground"
@@ -93,7 +99,7 @@ export function ActivityFeed({
             <button
               type="button"
               onClick={onMarkAllRead}
-              className="ml-auto rounded px-2 py-2 text-xs text-dim hover:text-foreground"
+              className={`ml-auto text-dim hover:text-foreground ${ACTION_BUTTON_CLASS}`}
             >
               Mark all read
             </button>

--- a/src/components/Issues/Issues.test.tsx
+++ b/src/components/Issues/Issues.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Issue, Repo } from "../../lib/types";
@@ -104,6 +104,17 @@ describe("Issues", () => {
 
     expect(openTab).toHaveTextContent("2");
     expect(closedTab).toHaveTextContent("2");
+  });
+
+  it("should keep state filters at the minimum touch target size", () => {
+    render(<Issues issues={allIssues} onOpen={onOpen} />);
+
+    const group = screen.getByRole("group", { name: /filter by state/i });
+    const buttons = within(group).getAllByRole("button");
+
+    for (const button of buttons) {
+      expect(button).toHaveClass("min-h-11", "min-w-11");
+    }
   });
 
   it("should show empty state when no open issues", () => {

--- a/src/components/Issues/Issues.tsx
+++ b/src/components/Issues/Issues.tsx
@@ -17,6 +17,9 @@ interface IssuesProps {
 
 type Tab = "open" | "closed";
 
+const FILTER_BUTTON_CLASS =
+  "inline-flex min-h-11 min-w-11 items-center justify-center rounded px-3 text-xs leading-none transition-colors";
+
 function isOpen(issue: Issue): boolean {
   return issue.state === "open";
 }
@@ -78,8 +81,8 @@ export function Issues({
       {isLoading ? (
         <>
           <div className="flex gap-1">
-            <Skeleton className="h-8 w-16" />
-            <Skeleton className="h-8 w-[4.5rem]" />
+            <Skeleton className="h-11 w-16" />
+            <Skeleton className="h-11 w-[4.5rem]" />
           </div>
 
           <div data-testid="issues-loading" className="flex flex-col gap-1">
@@ -99,7 +102,7 @@ export function Issues({
               type="button"
               aria-pressed={tab === "open"}
               onClick={() => setTab("open")}
-              className={`rounded px-2 py-2 text-xs transition-colors ${
+              className={`${FILTER_BUTTON_CLASS} ${
                 tab === "open"
                   ? "bg-accent text-bg font-semibold hover:bg-accent/80"
                   : "text-dim hover:bg-surface-hover hover:text-foreground"
@@ -111,7 +114,7 @@ export function Issues({
               type="button"
               aria-pressed={tab === "closed"}
               onClick={() => setTab("closed")}
-              className={`rounded px-2 py-2 text-xs transition-colors ${
+              className={`${FILTER_BUTTON_CLASS} ${
                 tab === "closed"
                   ? "bg-accent text-bg font-semibold hover:bg-accent/80"
                   : "text-dim hover:bg-surface-hover hover:text-foreground"

--- a/src/components/MyPRs/MyPRs.test.tsx
+++ b/src/components/MyPRs/MyPRs.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { PullRequestWithReview } from "../../lib/types";
-import { MyPRs } from "./index";
+import { MyPRs } from "./MyPRs";
 
 function makePr(
   overrides: Partial<PullRequestWithReview["pullRequest"]> = {},

--- a/src/components/MyPRs/MyPRs.test.tsx
+++ b/src/components/MyPRs/MyPRs.test.tsx
@@ -86,6 +86,17 @@ describe("MyPRs", () => {
     expect(mergedTab).toHaveTextContent("2"); // mergedPr1, mergedPr2
   });
 
+  it("should keep state filters at the minimum touch target size", () => {
+    render(<MyPRs prs={allPrs} onOpen={onOpen} />);
+
+    const group = screen.getByRole("group", { name: /filter by state/i });
+    const buttons = within(group).getAllByRole("button");
+
+    for (const button of buttons) {
+      expect(button).toHaveClass("min-h-11", "min-w-11");
+    }
+  });
+
   it("should show empty state when no PRs match current tab", () => {
     render(<MyPRs prs={[mergedPr1]} onOpen={onOpen} />);
 

--- a/src/components/MyPRs/MyPRs.tsx
+++ b/src/components/MyPRs/MyPRs.tsx
@@ -23,6 +23,9 @@ interface MyPRsProps {
 
 type Tab = "open" | "merged";
 
+const FILTER_BUTTON_CLASS =
+  "inline-flex min-h-11 min-w-11 items-center justify-center rounded px-3 text-xs leading-none transition-colors";
+
 function isOpen(pr: PullRequestWithReview): boolean {
   const { state } = pr.pullRequest;
   return state === "open" || state === "draft";
@@ -67,8 +70,8 @@ export function MyPRs({
       {isLoading ? (
         <>
           <div className="flex gap-1">
-            <Skeleton className="h-8 w-16" />
-            <Skeleton className="h-8 w-20" />
+            <Skeleton className="h-11 w-16" />
+            <Skeleton className="h-11 w-20" />
           </div>
 
           <div data-testid="my-prs-loading" className="flex flex-col gap-1">
@@ -88,7 +91,7 @@ export function MyPRs({
               type="button"
               aria-pressed={tab === "open"}
               onClick={() => setTab("open")}
-              className={`rounded px-2 py-2 text-xs transition-colors ${
+              className={`${FILTER_BUTTON_CLASS} ${
                 tab === "open"
                   ? "bg-accent text-bg font-semibold hover:bg-accent/80"
                   : "text-dim hover:bg-surface-hover hover:text-foreground"
@@ -100,7 +103,7 @@ export function MyPRs({
               type="button"
               aria-pressed={tab === "merged"}
               onClick={() => setTab("merged")}
-              className={`rounded px-2 py-2 text-xs transition-colors ${
+              className={`${FILTER_BUTTON_CLASS} ${
                 tab === "merged"
                   ? "bg-accent text-bg font-semibold hover:bg-accent/80"
                   : "text-dim hover:bg-surface-hover hover:text-foreground"

--- a/src/components/ReviewQueue/ReviewQueue.test.tsx
+++ b/src/components/ReviewQueue/ReviewQueue.test.tsx
@@ -170,6 +170,17 @@ describe("ReviewQueue", () => {
     expect(screen.getByText("1")).toBeInTheDocument();
   });
 
+  it("should keep priority filters at the minimum touch target size", () => {
+    render(<ReviewQueue reviews={allReviews} onOpen={vi.fn()} />);
+
+    const filterGroup = screen.getByRole("group", { name: /filter by priority/i });
+    const buttons = within(filterGroup).getAllByRole("button");
+
+    for (const button of buttons) {
+      expect(button).toHaveClass("min-h-11", "min-w-11");
+    }
+  });
+
   it("should show empty state when filter matches nothing", async () => {
     const user = userEvent.setup();
     const reviews = [highPr];
@@ -231,6 +242,12 @@ describe("ReviewQueue", () => {
     );
 
     expect(screen.getByText("4")).toBeInTheDocument();
+  });
+
+  it("should keep the repo filter select at the minimum touch target height", () => {
+    render(<ReviewQueue reviews={multiRepoReviews} onOpen={vi.fn()} />);
+
+    expect(screen.getByRole("combobox", { name: /filter by repo/i })).toHaveClass("min-h-11");
   });
 
   it("should clear stale repo filter when selected repo disappears from reviews", async () => {

--- a/src/components/ReviewQueue/ReviewQueue.tsx
+++ b/src/components/ReviewQueue/ReviewQueue.tsx
@@ -41,6 +41,12 @@ const PRIORITY_FILTERS: readonly PriorityFilter[] = [
   "low",
 ];
 
+const FILTER_BUTTON_CLASS =
+  "inline-flex min-h-11 min-w-11 items-center justify-center rounded px-3 text-xs leading-none transition-colors";
+
+const INLINE_CONTROL_CLASS =
+  "min-h-11 rounded px-3 text-xs transition-colors";
+
 function sortByPriority(
   reviews: readonly PullRequestWithReview[],
 ): readonly PullRequestWithReview[] {
@@ -118,7 +124,7 @@ export function ReviewQueue({
             {PRIORITY_FILTERS.map((filter) => (
               <Skeleton
                 key={`priority-filter-skeleton-${filter}`}
-                className={`h-8 ${
+                className={`h-11 ${
                   filter === "all"
                     ? "w-11"
                     : filter === "critical"
@@ -159,7 +165,7 @@ export function ReviewQueue({
                   onClick={() =>
                     setFilter({ priority: f === "all" ? undefined : f })
                   }
-                  className={`rounded px-2 py-2 text-xs transition-colors ${
+                  className={`${FILTER_BUTTON_CLASS} ${
                     priorityFilter === f
                       ? "bg-accent text-bg font-semibold hover:bg-accent/80"
                       : "text-dim hover:bg-surface-hover hover:text-foreground"
@@ -177,7 +183,7 @@ export function ReviewQueue({
                 onChange={(e) =>
                   setFilter({ repo: e.target.value || undefined })
                 }
-                className="cursor-pointer rounded border border-border bg-surface px-2 py-2 text-xs text-foreground transition-colors hover:border-foreground"
+                className={`cursor-pointer border border-border bg-surface text-foreground hover:border-foreground ${INLINE_CONTROL_CLASS}`}
               >
                 <option value="">All repos</option>
                 {repos.map((id) => (


### PR DESCRIPTION
## Summary
- raise filter and tab controls to a minimum 44x44 touch target across review, activity, PR, and issue panels
- increase adjacent inline controls and loading skeleton heights to match the updated interactive sizing
- add component tests to lock the minimum target-size classes in place

Closes #172

## Validation
- `npm test -- src/components/ReviewQueue/ReviewQueue.test.tsx src/components/ActivityFeed/ActivityFeed.test.tsx src/components/MyPRs/MyPRs.test.tsx src/components/Issues/Issues.test.tsx`
- `npm run build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase touch targets to 44×44 for filter, tab, and inline controls across ReviewQueue, ActivityFeed, MyPRs, and Issues for better mobile access (per #172). Updated skeletons to 44px, added tests to lock `min-h-11`/`min-w-11`, enforced 44px height for the repo select and “Mark all read”, uppercased the “CI” filter label, and introduced shared class constants.

<sup>Written for commit 8a0157fbcc861c7b306ce57a0aac841409c7f6c1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Filter labels standardized (e.g., “CI” displays uppercase) for clearer control names

* **Style**
  * Standardized filter and action control sizing/spacing for consistent appearance
  * Increased loading skeleton heights for visual alignment
  * Enlarged minimum touch targets for select/combobox controls

* **Tests**
  * Added tests asserting minimum touch-target sizing for filter buttons, select controls, and the “mark all read” action
<!-- end of auto-generated comment: release notes by coderabbit.ai -->