### PR TITLE
feat(settings): add grouped repository controls

### DIFF
--- a/src/components/Settings/Settings.test.tsx
+++ b/src/components/Settings/Settings.test.tsx
@@ -39,9 +39,7 @@ function renderWithProviders(ui: ReactElement) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
-  return render(
-    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
-  );
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
 }
 
 function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
@@ -163,11 +161,7 @@ describe("Settings", () => {
   });
 
   it("should display auth status when connected", async () => {
-    setupMocks(
-      makeConfig(),
-      [],
-      makeAuthStatus({ connected: true, username: "alice" }),
-    );
+    setupMocks(makeConfig(), [], makeAuthStatus({ connected: true, username: "alice" }));
 
     renderWithProviders(<Settings />);
 
@@ -258,9 +252,14 @@ describe("Settings", () => {
 
     const reposSection = screen.getByTestId("settings-repos");
     const toggles = within(reposSection).getAllByRole("checkbox");
+    const frontendRow = screen.getByText("frontend").closest("label");
+    const backendRow = screen.getByText("backend").closest("label");
+
     expect(toggles).toHaveLength(2);
-    expect(toggles[0]).toBeChecked();
-    expect(toggles[1]).not.toBeChecked();
+    expect(frontendRow).not.toBeNull();
+    expect(backendRow).not.toBeNull();
+    expect(within(frontendRow as HTMLElement).getByRole("checkbox")).toBeChecked();
+    expect(within(backendRow as HTMLElement).getByRole("checkbox")).not.toBeChecked();
   });
 
   it("should call setRepoEnabled when repo toggle is clicked", async () => {
@@ -427,40 +426,103 @@ describe("Settings", () => {
     expect(screen.queryByText("mobile")).not.toBeInTheDocument();
   });
 
-  it("should show only first 10 repos when more than 10 exist", async () => {
-    const repos = Array.from({ length: 15 }, (_, i) => makeRepo(i + 1));
-    setupMocks(makeConfig(), repos);
+  it("should show enabled repositories count", async () => {
+    setupMocks(makeConfig(), [
+      makeRepo(1, { enabled: true }),
+      makeRepo(2, { enabled: false }),
+      makeRepo(3, { enabled: true }),
+    ]);
 
     renderWithProviders(<Settings />);
 
-    await screen.findByText("repo-1");
-
-    const reposSection = screen.getByTestId("settings-repos");
-    const checkboxes = within(reposSection).getAllByRole("checkbox");
-    expect(checkboxes).toHaveLength(10);
-    expect(screen.getByText("Show 5 more")).toBeInTheDocument();
+    expect(await screen.findByText("2 of 3 repositories enabled")).toBeInTheDocument();
   });
 
-  it("should show all repos when 'Show N more' button is clicked", async () => {
-    const user = userEvent.setup();
-    const repos = Array.from({ length: 15 }, (_, i) => makeRepo(i + 1));
-    setupMocks(makeConfig(), repos);
+  it("should group repositories by organization", async () => {
+    setupMocks(makeConfig(), [
+      makeRepo(1, { org: "zeta", name: "api", fullName: "zeta/api" }),
+      makeRepo(2, { org: "alpha", name: "web", fullName: "alpha/web" }),
+      makeRepo(3, { org: "alpha", name: "cli", fullName: "alpha/cli", enabled: false }),
+    ]);
 
     renderWithProviders(<Settings />);
 
-    await screen.findByText("Show 5 more");
-    await user.click(screen.getByText("Show 5 more"));
+    expect(await screen.findByText("alpha/")).toBeInTheDocument();
+    expect(screen.getByText("zeta/")).toBeInTheDocument();
+    expect(screen.getByText("1/2 enabled")).toBeInTheDocument();
+    expect(screen.getByText("1/1 enabled")).toBeInTheDocument();
+  });
 
-    const reposSection = screen.getByTestId("settings-repos");
-    const checkboxes = within(reposSection).getAllByRole("checkbox");
-    expect(checkboxes).toHaveLength(15);
-    expect(screen.queryByText("Show 5 more")).not.toBeInTheDocument();
+  it("should batch enable repositories matching the current filter", async () => {
+    const repos = [
+      makeRepo(1, { org: "org", name: "frontend", fullName: "org/frontend", enabled: false }),
+      makeRepo(2, {
+        org: "org",
+        name: "frontend-docs",
+        fullName: "org/frontend-docs",
+        enabled: true,
+      }),
+      makeRepo(3, { org: "org", name: "backend", fullName: "org/backend", enabled: false }),
+    ];
+    setupMocks(makeConfig(), repos);
+    mockedSetRepoEnabled.mockImplementation(async (repoId, enabled) => {
+      const repo = repos.find((candidate) => candidate.id === repoId);
+      return { ...(repo ?? makeRepo(99)), id: repoId, enabled };
+    });
+
+    renderWithProviders(<Settings />);
+
+    await screen.findByText("frontend");
+    vi.useFakeTimers();
+
+    const input = screen.getByPlaceholderText("Filter repositories...");
+    act(() => {
+      fireEvent.change(input, { target: { value: "front" } });
+      vi.advanceTimersByTime(200);
+    });
+    vi.useRealTimers();
+
+    fireEvent.click(screen.getByRole("button", { name: "Select all" }));
+
+    await waitFor(() => expect(mockedSetRepoEnabled).toHaveBeenCalledTimes(1));
+    expect(mockedSetRepoEnabled).toHaveBeenCalledWith("repo-1", true);
+    expect(mockedSetRepoEnabled).not.toHaveBeenCalledWith("repo-3", true);
+    expect(screen.getByText("2 matching current filter")).toBeInTheDocument();
+  });
+
+  it("should invert the current filtered selection", async () => {
+    const repos = [
+      makeRepo(1, { name: "frontend", fullName: "org/frontend", enabled: true }),
+      makeRepo(2, { name: "frontend-api", fullName: "org/frontend-api", enabled: false }),
+      makeRepo(3, { name: "backend", fullName: "org/backend", enabled: true }),
+    ];
+    setupMocks(makeConfig(), repos);
+    mockedSetRepoEnabled.mockImplementation(async (repoId, enabled) => {
+      const repo = repos.find((candidate) => candidate.id === repoId);
+      return { ...(repo ?? makeRepo(99)), id: repoId, enabled };
+    });
+
+    renderWithProviders(<Settings />);
+
+    await screen.findByText("frontend");
+    vi.useFakeTimers();
+
+    const input = screen.getByPlaceholderText("Filter repositories...");
+    act(() => {
+      fireEvent.change(input, { target: { value: "front" } });
+      vi.advanceTimersByTime(200);
+    });
+    vi.useRealTimers();
+
+    fireEvent.click(screen.getByRole("button", { name: "Invert selection" }));
+
+    await waitFor(() => expect(mockedSetRepoEnabled).toHaveBeenCalledTimes(2));
+    expect(mockedSetRepoEnabled).toHaveBeenCalledWith("repo-1", false);
+    expect(mockedSetRepoEnabled).toHaveBeenCalledWith("repo-2", true);
   });
 
   it("should show no-match message when search returns empty", async () => {
-    setupMocks(makeConfig(), [
-      makeRepo(1, { name: "frontend", fullName: "org/frontend" }),
-    ]);
+    setupMocks(makeConfig(), [makeRepo(1, { name: "frontend", fullName: "org/frontend" })]);
 
     renderWithProviders(<Settings />);
 
@@ -476,5 +538,4 @@ describe("Settings", () => {
 
     expect(screen.getByText("No repos match")).toBeInTheDocument();
   });
-
 });

--- a/src/components/Settings/Settings.test.tsx
+++ b/src/components/Settings/Settings.test.tsx
@@ -426,6 +426,32 @@ describe("Settings", () => {
     expect(screen.queryByText("mobile")).not.toBeInTheDocument();
   });
 
+  it("should wait for the debounced search before showing the match count label", async () => {
+    setupMocks(makeConfig(), [
+      makeRepo(1, { name: "frontend", fullName: "org/frontend" }),
+      makeRepo(2, { name: "frontend-api", fullName: "org/frontend-api" }),
+      makeRepo(3, { name: "backend", fullName: "org/backend" }),
+    ]);
+
+    renderWithProviders(<Settings />);
+
+    await screen.findByText("frontend");
+    vi.useFakeTimers();
+
+    const input = screen.getByPlaceholderText("Filter repositories...");
+    act(() => {
+      fireEvent.change(input, { target: { value: "front" } });
+    });
+
+    expect(screen.queryByText(/matching current filter/i)).not.toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(screen.getByText("2 matching current filter")).toBeInTheDocument();
+  });
+
   it("should show enabled repositories count", async () => {
     setupMocks(makeConfig(), [
       makeRepo(1, { enabled: true }),
@@ -519,6 +545,64 @@ describe("Settings", () => {
     await waitFor(() => expect(mockedSetRepoEnabled).toHaveBeenCalledTimes(2));
     expect(mockedSetRepoEnabled).toHaveBeenCalledWith("repo-1", false);
     expect(mockedSetRepoEnabled).toHaveBeenCalledWith("repo-2", true);
+  });
+
+  it("should refetch repos and show failed repo ids after a partial batch failure", async () => {
+    const initialRepos = [
+      makeRepo(1, { name: "frontend", fullName: "org/frontend", enabled: false }),
+      makeRepo(2, { name: "frontend-api", fullName: "org/frontend-api", enabled: false }),
+    ];
+    const refetchedRepos = [
+      makeRepo(1, { name: "frontend", fullName: "org/frontend", enabled: true }),
+      makeRepo(2, { name: "frontend-api", fullName: "org/frontend-api", enabled: false }),
+    ];
+
+    mockedGetConfig.mockResolvedValue(makeConfig());
+    mockedAuthGetStatus.mockResolvedValue(makeAuthStatus());
+    mockedSetConfig.mockResolvedValue(makeConfig());
+    mockedGetPersonalStats.mockResolvedValue(makePersonalStats());
+    mockedGetMemoryUsage.mockResolvedValue({
+      rssBytes: 50_000_000,
+      dbSizeBytes: 1_048_576,
+    });
+    mockedListRepos.mockResolvedValueOnce(initialRepos).mockResolvedValueOnce(refetchedRepos);
+    mockedSetRepoEnabled.mockImplementation(async (repoId, enabled) => {
+      if (repoId === "repo-2") {
+        throw new Error("toggle failed");
+      }
+
+      return (
+        refetchedRepos.find((repo) => repo.id === repoId) ??
+        makeRepo(99, { id: repoId, enabled, name: "fallback", fullName: `org/${repoId}` })
+      );
+    });
+
+    renderWithProviders(<Settings />);
+
+    await screen.findByText("frontend");
+    vi.useFakeTimers();
+
+    const input = screen.getByPlaceholderText("Filter repositories...");
+    act(() => {
+      fireEvent.change(input, { target: { value: "front" } });
+      vi.advanceTimersByTime(200);
+    });
+    vi.useRealTimers();
+
+    fireEvent.click(screen.getByRole("button", { name: "Select all" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Failed to update repositories: repo-2",
+    );
+    await waitFor(() => expect(mockedListRepos).toHaveBeenCalledTimes(2));
+
+    const frontendRow = screen.getByText("frontend").closest("label");
+    const frontendApiRow = screen.getByText("frontend-api").closest("label");
+
+    expect(frontendRow).not.toBeNull();
+    expect(frontendApiRow).not.toBeNull();
+    expect(within(frontendRow as HTMLElement).getByRole("checkbox")).toBeChecked();
+    expect(within(frontendApiRow as HTMLElement).getByRole("checkbox")).not.toBeChecked();
   });
 
   it("should show no-match message when search returns empty", async () => {

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -1,11 +1,6 @@
 import { useEffect, useState, type ReactElement } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import {
-  getConfig,
-  setConfig,
-  listRepos,
-  setRepoEnabled,
-} from "../../lib/tauri";
+import { getConfig, setConfig, listRepos, setRepoEnabled } from "../../lib/tauri";
 import type { PartialAppConfig, Repo } from "../../lib/types";
 import { AuthSetup } from "../AuthSetup/AuthSetup";
 import { Stats } from "./Stats";
@@ -20,6 +15,15 @@ function useReposQuery() {
   return useQuery({ queryKey: ["repos"], queryFn: listRepos });
 }
 
+interface RepoUpdate {
+  readonly repoId: string;
+  readonly enabled: boolean;
+}
+
+interface RepoGroup {
+  readonly org: string;
+  readonly repos: readonly Repo[];
+}
 
 interface NumberFieldProps {
   readonly label: string;
@@ -29,7 +33,13 @@ interface NumberFieldProps {
   readonly onCommit: (value: number) => void;
 }
 
-function NumberField({ label, value, min = 1, resetKey, onCommit }: NumberFieldProps): ReactElement {
+function NumberField({
+  label,
+  value,
+  min = 1,
+  resetKey,
+  onCommit,
+}: NumberFieldProps): ReactElement {
   const [draft, setDraft] = useState(String(value));
 
   useEffect(() => {
@@ -70,7 +80,9 @@ interface RepoRowProps {
 function RepoRow({ repo, disabled, onToggle }: RepoRowProps): ReactElement {
   return (
     <label className="flex items-center justify-between gap-3 py-1">
-      <span className="min-w-0 truncate font-mono text-sm text-white" title={repo.name}>{repo.name}</span>
+      <span className="min-w-0 truncate font-mono text-sm text-white" title={repo.name}>
+        {repo.name}
+      </span>
       <input
         type="checkbox"
         checked={repo.enabled}
@@ -82,7 +94,43 @@ function RepoRow({ repo, disabled, onToggle }: RepoRowProps): ReactElement {
   );
 }
 
+function groupReposByOrg(repos: readonly Repo[]): readonly RepoGroup[] {
+  const groups = new Map<string, Repo[]>();
+
+  for (const repo of repos) {
+    const existing = groups.get(repo.org);
+    if (existing) {
+      existing.push(repo);
+    } else {
+      groups.set(repo.org, [repo]);
+    }
+  }
+
+  return Array.from(groups.entries())
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([org, orgRepos]) => ({
+      org,
+      repos: [...orgRepos].sort((left, right) => left.name.localeCompare(right.name)),
+    }));
+}
+
+function buildRepoUpdates(
+  repos: readonly Repo[],
+  getNextEnabled: (repo: Repo) => boolean,
+): readonly RepoUpdate[] {
+  return repos
+    .map((repo) => ({
+      repoId: repo.id,
+      enabled: getNextEnabled(repo),
+      currentEnabled: repo.enabled,
+    }))
+    .filter((update) => update.enabled !== update.currentEnabled)
+    .map(({ repoId, enabled }) => ({ repoId, enabled }));
+}
+
 const sectionClass = "flex flex-col gap-3 border-b border-border pb-4";
+const controlButtonClass =
+  "rounded border border-border px-2 py-1 text-xs font-medium text-dim transition-colors hover:border-accent hover:text-white disabled:cursor-not-allowed disabled:opacity-50";
 
 export function Settings(): ReactElement {
   const queryClient = useQueryClient();
@@ -91,12 +139,7 @@ export function Settings(): ReactElement {
   const [saveError, setSaveError] = useState<string | null>(null);
   const [resetKey, setResetKey] = useState(0);
   const [repoSearch, setRepoSearch] = useState("");
-  const [showAllRepos, setShowAllRepos] = useState(false);
   const debouncedRepoSearch = useDebounce(repoSearch, 150);
-
-  useEffect(() => {
-    setShowAllRepos(false);
-  }, [debouncedRepoSearch]);
 
   const configMutation = useMutation({
     mutationFn: (partial: PartialAppConfig) => setConfig(partial),
@@ -114,15 +157,16 @@ export function Settings(): ReactElement {
   });
 
   const repoToggleMutation = useMutation({
-    mutationFn: ({ repoId, enabled }: { repoId: string; enabled: boolean }) =>
-      setRepoEnabled(repoId, enabled),
+    mutationFn: async (updates: readonly RepoUpdate[]) => {
+      await Promise.all(updates.map(({ repoId, enabled }) => setRepoEnabled(repoId, enabled)));
+    },
     onSuccess: () => {
       setSaveError(null);
       queryClient.invalidateQueries({ queryKey: ["repos"] });
     },
     onError: (err: unknown) => {
       console.error("[Settings] repo toggle failed:", err);
-      setSaveError("Failed to toggle repository. Please retry.");
+      setSaveError("Failed to update repositories. Please retry.");
     },
   });
 
@@ -147,19 +191,27 @@ export function Settings(): ReactElement {
   const searchLower = debouncedRepoSearch.toLowerCase();
   const filteredSettingsRepos = allRepos.filter(
     (r) =>
-      r.name.toLowerCase().includes(searchLower) ||
-      r.fullName.toLowerCase().includes(searchLower),
+      r.name.toLowerCase().includes(searchLower) || r.fullName.toLowerCase().includes(searchLower),
   );
-  const visibleSettingsRepos = showAllRepos
-    ? filteredSettingsRepos
-    : filteredSettingsRepos.slice(0, 10);
+  const groupedSettingsRepos = groupReposByOrg(filteredSettingsRepos);
+  const enabledReposCount = allRepos.filter((repo) => repo.enabled).length;
+
+  function mutateRepoUpdates(updates: readonly RepoUpdate[]): void {
+    if (updates.length === 0) {
+      return;
+    }
+
+    repoToggleMutation.mutate(updates);
+  }
 
   return (
     <section data-testid="settings" className="flex h-full flex-col gap-6 overflow-y-auto p-4">
       <h1 className="text-lg font-semibold text-white">Settings</h1>
 
       {saveError ? (
-        <p role="alert" className="text-sm text-red-400">{saveError}</p>
+        <p role="alert" className="text-sm text-red-400">
+          {saveError}
+        </p>
       ) : null}
 
       <div data-testid="settings-github" className={sectionClass}>
@@ -184,7 +236,14 @@ export function Settings(): ReactElement {
       </div>
 
       <div data-testid="settings-repos" className="flex flex-col gap-3">
-        <h2 className="text-accent text-sm font-semibold uppercase tracking-wider">Repositories</h2>
+        <div className="flex flex-col gap-1">
+          <h2 className="text-accent text-sm font-semibold uppercase tracking-wider">
+            Repositories
+          </h2>
+          <p className="text-dim text-sm">
+            {enabledReposCount} of {allRepos.length} repositories enabled
+          </p>
+        </div>
         <input
           type="search"
           placeholder="Filter repositories..."
@@ -192,6 +251,39 @@ export function Settings(): ReactElement {
           onChange={(e) => setRepoSearch(e.target.value)}
           className="bg-surface border-border rounded border px-2 py-1 text-sm text-white placeholder:text-muted outline-none"
         />
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={() => mutateRepoUpdates(buildRepoUpdates(filteredSettingsRepos, () => true))}
+            disabled={repoToggleMutation.isPending || filteredSettingsRepos.length === 0}
+            className={controlButtonClass}
+          >
+            Select all
+          </button>
+          <button
+            type="button"
+            onClick={() => mutateRepoUpdates(buildRepoUpdates(filteredSettingsRepos, () => false))}
+            disabled={repoToggleMutation.isPending || filteredSettingsRepos.length === 0}
+            className={controlButtonClass}
+          >
+            Deselect all
+          </button>
+          <button
+            type="button"
+            onClick={() =>
+              mutateRepoUpdates(buildRepoUpdates(filteredSettingsRepos, (repo) => !repo.enabled))
+            }
+            disabled={repoToggleMutation.isPending || filteredSettingsRepos.length === 0}
+            className={controlButtonClass}
+          >
+            Invert selection
+          </button>
+          {repoSearch.trim() ? (
+            <span className="text-dim text-xs">
+              {filteredSettingsRepos.length} matching current filter
+            </span>
+          ) : null}
+        </div>
         {reposQuery.isLoading ? (
           <span className="text-dim text-sm">Loading repositories...</span>
         ) : reposQuery.error ? (
@@ -201,26 +293,27 @@ export function Settings(): ReactElement {
         ) : filteredSettingsRepos.length === 0 ? (
           <span className="text-dim text-sm">No repos match</span>
         ) : (
-          <div className="flex flex-col gap-1">
-            {visibleSettingsRepos.map((repo) => (
-              <RepoRow
-                key={repo.id}
-                repo={repo}
-                disabled={repoToggleMutation.isPending}
-                onToggle={(repoId, enabled) =>
-                  repoToggleMutation.mutate({ repoId, enabled })
-                }
-              />
+          <div className="flex flex-col gap-4">
+            {groupedSettingsRepos.map((group) => (
+              <div key={group.org} className="flex flex-col gap-1">
+                <div className="flex items-center justify-between gap-3">
+                  <h3 className="font-mono text-xs uppercase tracking-wide text-dim">
+                    {group.org}/
+                  </h3>
+                  <span className="text-dim text-xs">
+                    {group.repos.filter((repo) => repo.enabled).length}/{group.repos.length} enabled
+                  </span>
+                </div>
+                {group.repos.map((repo) => (
+                  <RepoRow
+                    key={repo.id}
+                    repo={repo}
+                    disabled={repoToggleMutation.isPending}
+                    onToggle={(repoId, enabled) => mutateRepoUpdates([{ repoId, enabled }])}
+                  />
+                ))}
+              </div>
             ))}
-            {!showAllRepos && filteredSettingsRepos.length > 10 && (
-              <button
-                type="button"
-                onClick={() => setShowAllRepos(true)}
-                className="text-xs text-muted hover:text-foreground transition-colors"
-              >
-                Show {filteredSettingsRepos.length - 10} more
-              </button>
-            )}
           </div>
         )}
       </div>

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -25,6 +25,10 @@ interface RepoGroup {
   readonly repos: readonly Repo[];
 }
 
+interface RepoBatchUpdateError extends Error {
+  failedRepoIds: readonly string[];
+}
+
 interface NumberFieldProps {
   readonly label: string;
   readonly value: number;
@@ -118,14 +122,36 @@ function buildRepoUpdates(
   repos: readonly Repo[],
   getNextEnabled: (repo: Repo) => boolean,
 ): readonly RepoUpdate[] {
-  return repos
-    .map((repo) => ({
-      repoId: repo.id,
-      enabled: getNextEnabled(repo),
-      currentEnabled: repo.enabled,
-    }))
-    .filter((update) => update.enabled !== update.currentEnabled)
-    .map(({ repoId, enabled }) => ({ repoId, enabled }));
+  const updates: RepoUpdate[] = [];
+
+  for (const repo of repos) {
+    const enabled = getNextEnabled(repo);
+    if (enabled !== repo.enabled) {
+      updates.push({ repoId: repo.id, enabled });
+    }
+  }
+
+  return updates;
+}
+
+function createRepoBatchUpdateError(failedRepoIds: readonly string[]): RepoBatchUpdateError {
+  const error = new Error("Failed to update some repositories.") as RepoBatchUpdateError;
+  error.failedRepoIds = failedRepoIds;
+  return error;
+}
+
+function getRepoBatchUpdateErrorMessage(err: unknown): string {
+  if (
+    typeof err === "object" &&
+    err !== null &&
+    "failedRepoIds" in err &&
+    Array.isArray(err.failedRepoIds) &&
+    err.failedRepoIds.length > 0
+  ) {
+    return `Failed to update repositories: ${err.failedRepoIds.join(", ")}`;
+  }
+
+  return "Failed to update repositories. Please retry.";
 }
 
 const sectionClass = "flex flex-col gap-3 border-b border-border pb-4";
@@ -158,15 +184,31 @@ export function Settings(): ReactElement {
 
   const repoToggleMutation = useMutation({
     mutationFn: async (updates: readonly RepoUpdate[]) => {
-      await Promise.all(updates.map(({ repoId, enabled }) => setRepoEnabled(repoId, enabled)));
+      const results = await Promise.allSettled(
+        updates.map(({ repoId, enabled }) => setRepoEnabled(repoId, enabled)),
+      );
+      const failedRepoIds: string[] = [];
+
+      for (const [index, result] of results.entries()) {
+        const update = updates[index];
+        if (result.status === "rejected" && update) {
+          failedRepoIds.push(update.repoId);
+        }
+      }
+
+      if (failedRepoIds.length > 0) {
+        throw createRepoBatchUpdateError(failedRepoIds);
+      }
     },
     onSuccess: () => {
       setSaveError(null);
-      queryClient.invalidateQueries({ queryKey: ["repos"] });
     },
     onError: (err: unknown) => {
       console.error("[Settings] repo toggle failed:", err);
-      setSaveError("Failed to update repositories. Please retry.");
+      setSaveError(getRepoBatchUpdateErrorMessage(err));
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["repos"] });
     },
   });
 
@@ -278,7 +320,7 @@ export function Settings(): ReactElement {
           >
             Invert selection
           </button>
-          {repoSearch.trim() ? (
+          {debouncedRepoSearch.trim() ? (
             <span className="text-dim text-xs">
               {filteredSettingsRepos.length} matching current filter
             </span>


### PR DESCRIPTION
## Summary
- add repository enablement counts and group settings repos by organization
- add select all, deselect all, and invert selection actions scoped to the current filter
- update Settings tests to cover grouping, counts, and filtered batch actions

## Validation
- `npm run test -- src/components/Settings/Settings.test.tsx`
- `npx tsc --noEmit`
- `npm run lint -- src/components/Settings/Settings.tsx src/components/Settings/Settings.test.tsx`
- `npx oxfmt --check src/components/Settings/Settings.tsx src/components/Settings/Settings.test.tsx`

Closes #173

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Groups repositories by organization in Settings and adds batch enable/disable controls scoped to the current filter to make repo management faster. Implements the grouped repository controls requested in #173.

- **New Features**
  - Group repos by organization with per-group enabled counts and a global “N of M enabled”.
  - Add Select all, Deselect all, and Invert selection scoped to the current filter, with a debounced “matching current filter” count; remove pagination so all repos are shown.
  - Batch updates with clear errors that list failed repo IDs and auto-refetch to sync state.

<sup>Written for commit 9c4e04402d90b422a1da832d5bfe9b7f198f5deb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repository list now groups by organization with per-group enabled counts.
  * Added bulk selection controls: "Select all," "Deselect all," and "Invert selection."
  * Shows total enabled repositories and a "matching current filter" count when searching.

* **Bug Fixes**
  * Removed pagination/show-more behavior so all repositories are visible.

* **Tests**
  * Improved tests for toggles, debounced filtering and match-count display, bulk actions, and partial-batch failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->