### PR TITLE
fix(ui): improve read/unread visual distinction in Activity feed

### DIFF
--- a/src/components/ActivityFeed/ActivityItem.test.tsx
+++ b/src/components/ActivityFeed/ActivityItem.test.tsx
@@ -80,15 +80,26 @@ describe("ActivityItem", () => {
     expect(screen.getByTestId("unread-dot")).toBeInTheDocument();
   });
 
+  it("should highlight unread activity with accent styling", () => {
+    render(<ActivityItem activity={makeActivity({ isRead: false })} />);
+
+    expect(screen.getByTestId("activity-item")).toHaveClass(
+      "border-accent/30",
+      "bg-surface",
+      "shadow-[inset_3px_0_0_var(--color-accent)]",
+    );
+    expect(screen.getByTestId("unread-dot")).toHaveClass("bg-accent");
+  });
+
   it("should not show unread dot when activity is read", () => {
     render(<ActivityItem activity={makeActivity({ isRead: true })} />);
 
     expect(screen.queryByTestId("unread-dot")).not.toBeInTheDocument();
   });
 
-  it("should apply reduced opacity when activity is read", () => {
+  it("should apply muted styling when activity is read", () => {
     render(<ActivityItem activity={makeActivity({ isRead: true })} />);
 
-    expect(screen.getByTestId("activity-item").className).toContain("opacity-50");
+    expect(screen.getByTestId("activity-item")).toHaveClass("bg-bg", "opacity-60");
   });
 });

--- a/src/components/ActivityFeed/ActivityItem.test.tsx
+++ b/src/components/ActivityFeed/ActivityItem.test.tsx
@@ -88,6 +88,7 @@ describe("ActivityItem", () => {
       "bg-surface",
       "shadow-[inset_3px_0_0_var(--color-accent)]",
     );
+    expect(screen.getByTestId("activity-item")).not.toHaveClass("opacity-60");
     expect(screen.getByTestId("unread-dot")).toHaveClass("bg-accent");
   });
 

--- a/src/components/ActivityFeed/ActivityItem.tsx
+++ b/src/components/ActivityFeed/ActivityItem.tsx
@@ -37,12 +37,22 @@ function truncate(text: string, max: number): string {
 }
 
 export function ActivityItem({ activity }: ActivityItemProps): ReactElement {
+  const itemClassName = [
+    "flex items-start gap-2 rounded border px-3 py-2 transition-colors",
+    activity.isRead
+      ? "border-border bg-bg opacity-60"
+      : "border-accent/30 bg-surface shadow-[inset_3px_0_0_var(--color-accent)]",
+  ].join(" ");
+
   return (
-    <div data-testid="activity-item" className={`flex items-start gap-2 rounded border border-border px-3 py-2${activity.isRead ? " opacity-50" : ""}`}>
+    <div data-testid="activity-item" className={itemClassName}>
       {activity.isRead ? (
         <span aria-hidden="true" className="mt-1.5 h-2 w-2 shrink-0" />
       ) : (
-        <span data-testid="unread-dot" className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-blue-500" />
+        <span
+          data-testid="unread-dot"
+          className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-accent shadow-[0_0_0_4px_rgba(200,255,0,0.16)]"
+        />
       )}
       <span data-testid="activity-icon" aria-hidden="true" className="shrink-0 text-sm text-dim">
         {ACTIVITY_ICON[activity.activityType]}

--- a/src/components/ActivityFeed/ActivityItem.tsx
+++ b/src/components/ActivityFeed/ActivityItem.tsx
@@ -51,7 +51,7 @@ export function ActivityItem({ activity }: ActivityItemProps): ReactElement {
       ) : (
         <span
           data-testid="unread-dot"
-          className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-accent shadow-[0_0_0_4px_rgba(200,255,0,0.16)]"
+          className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-accent shadow-[0_0_0_4px_var(--color-accent-glow)]"
         />
       )}
       <span data-testid="activity-icon" aria-hidden="true" className="shrink-0 text-sm text-dim">

--- a/src/index.css
+++ b/src/index.css
@@ -20,6 +20,7 @@
   --color-white: #eeece6;
   --color-foreground: var(--color-text);
   --color-accent: #c8ff00;
+  --color-accent-glow: color-mix(in srgb, var(--color-accent) 16%, transparent);
 
   /* ── Couleurs sémantiques ───────────────────── */
   --color-red: #ff4d4d;


### PR DESCRIPTION
## Summary
- make unread activity items stand out with accent styling and a stronger visual marker
- mute read activity items with a flatter background and reduced opacity
- add tests covering both read and unread presentation states

Closes #174

## Validation
- `npm run test -- src/components/ActivityFeed/ActivityItem.test.tsx src/components/ActivityFeed/ActivityFeed.test.tsx`
- `npm run lint -- src/components/ActivityFeed/ActivityItem.tsx src/components/ActivityFeed/ActivityItem.test.tsx`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve read/unread contrast in the Activity feed. Unread items are highlighted; read items are muted for easier scanning and better accessibility. Closes #174.

- **Bug Fixes**
  - Unread items: accent border, subtle left accent bar, and an accent unread dot with a soft glow.
  - Read items: neutral background and border with reduced opacity; tests cover both states.

<sup>Written for commit 6138b466ded15989f2d4555073f934962031ace7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved visual distinction between read and unread activity items, including accent-based highlights and a subtle glow for unread indicators.
  * Updated muted/read styling for clearer reduced-opacity appearance.

* **Tests**
  * Added and updated tests to validate read/unread visuals and accent-driven unread indicators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->