### PR TITLE
fix(ui): add spacing between section labels and counts

### DIFF
--- a/src/components/Sidebar/Sidebar.test.tsx
+++ b/src/components/Sidebar/Sidebar.test.tsx
@@ -201,6 +201,7 @@ describe("Sidebar", () => {
     renderSidebar();
     const section = await screen.findByRole("region", { name: /repos/i });
     expect(section).toBeInTheDocument();
+    expect(section).toHaveAccessibleName("Repos 1");
   });
 
   it("should show repos section collapsed by default", async () => {

--- a/src/components/Sidebar/Sidebar.test.tsx
+++ b/src/components/Sidebar/Sidebar.test.tsx
@@ -233,6 +233,7 @@ describe("Sidebar", () => {
     const reposHeader = await screen.findByRole("button", { name: /repos/i });
     expect(reposHeader).toBeInTheDocument();
     // The mock provides 1 enabled repo — exact match to avoid false positives
-    expect(reposHeader).toHaveTextContent(/^Repos\s*1\s*▸$/);
+    expect(reposHeader).toHaveAccessibleName("Repos 1");
+    expect(reposHeader).toHaveTextContent(/^Repos 1\s*▸$/);
   });
 });

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -145,12 +145,17 @@ export function Sidebar(): ReactElement {
           <button
             type="button"
             aria-expanded={isReposExpanded}
+            aria-label={`Repos ${enabledRepos.length}`}
             onClick={() => setIsReposExpanded((prev) => !prev)}
             className="flex w-full items-center justify-between px-2 text-[10px] font-semibold uppercase tracking-wider text-dim hover:text-foreground"
           >
-            <span id="sidebar-repos-heading">
-              Repos
-              <span className="ml-1 text-dim/60">{enabledRepos.length}</span>
+            <span
+              id="sidebar-repos-heading"
+              aria-label={`Repos ${enabledRepos.length}`}
+              className="inline-flex items-baseline"
+            >
+              <span>Repos</span>
+              <span className="text-dim/60"> {enabledRepos.length}</span>
             </span>
             <span aria-hidden="true">{isReposExpanded ? "▾" : "▸"}</span>
           </button>

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -141,7 +141,11 @@ export function Sidebar(): ReactElement {
 
       {/* Repos section — collapsible; full management in Settings */}
       {repos.length > 0 && (
-        <div role="region" aria-labelledby="sidebar-repos-heading" className="flex min-h-0 flex-col gap-1">
+        <div
+          role="region"
+          aria-label={`Repos ${enabledRepos.length}`}
+          className="flex min-h-0 flex-col gap-1"
+        >
           <button
             type="button"
             aria-expanded={isReposExpanded}
@@ -149,11 +153,7 @@ export function Sidebar(): ReactElement {
             onClick={() => setIsReposExpanded((prev) => !prev)}
             className="flex w-full items-center justify-between px-2 text-[10px] font-semibold uppercase tracking-wider text-dim hover:text-foreground"
           >
-            <span
-              id="sidebar-repos-heading"
-              aria-label={`Repos ${enabledRepos.length}`}
-              className="inline-flex items-baseline"
-            >
+            <span id="sidebar-repos-heading" className="inline-flex items-baseline">
               <span>Repos</span>
               <span className="text-dim/60"> {enabledRepos.length}</span>
             </span>

--- a/src/components/atoms/SectionHead.test.tsx
+++ b/src/components/atoms/SectionHead.test.tsx
@@ -11,6 +11,7 @@ describe("SectionHead", () => {
   it("should render count", () => {
     render(<SectionHead title="Reviews" count={5} />);
     expect(screen.getByText("5")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Reviews 5" })).toBeInTheDocument();
   });
 
   it("should omit count when it is not provided", () => {

--- a/src/components/atoms/SectionHead.tsx
+++ b/src/components/atoms/SectionHead.tsx
@@ -6,12 +6,14 @@ interface SectionHeadProps {
 }
 
 export function SectionHead({ title, count }: SectionHeadProps): ReactElement {
+  const accessibleTitle = typeof count === "number" ? `${title} ${count}` : title;
+
   return (
     <div>
-      <div className="flex items-center gap-2">
-        <h2 className="text-sm font-semibold text-white">{title}</h2>
-        {typeof count === "number" && <span className="text-xs text-dim">{count}</span>}
-      </div>
+      <h2 className="text-sm font-semibold text-white" aria-label={accessibleTitle}>
+        {title}
+        {typeof count === "number" && <span className="text-xs font-normal text-dim"> {count}</span>}
+      </h2>
       <hr className="mt-1 border-border" role="separator" />
     </div>
   );


### PR DESCRIPTION
## Summary

This fixes the missing spacing between section labels and their counts in the UI, including the sidebar repositories heading reported in issue #175.

## Root Cause

The label text and numeric count were rendered as adjacent nodes without a reliable textual separator for rendered text and accessible names, which produced output like `Repos1`.

## Changes

- render an explicit space between the `Repos` label and its count in the sidebar heading
- add explicit accessible labels so assistive technologies read `Repos 1` and `Reviews 5` instead of concatenated text
- align the shared `SectionHead` component with the same spacing behavior
- update targeted tests to assert the corrected accessible names and visible text

## Impact

Users now see and hear section headings with proper separation between labels and counts. This removes the `Repos73` style regression and prevents the same issue in shared section headers.

## Validation

- `npm run test -- src/components/Sidebar/Sidebar.test.tsx src/components/atoms/SectionHead.test.tsx`
- `npm run lint -- src/components/Sidebar/Sidebar.tsx src/components/atoms/SectionHead.tsx src/components/Sidebar/Sidebar.test.tsx src/components/atoms/SectionHead.test.tsx`

Closes #175

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix spacing between section labels and counts so headings show and read as “Repos 1” and “Reviews 5” instead of “Repos1”. Improves accessibility across the sidebar and shared section headers. Closes #175.

- **Bug Fixes**
  - Sidebar Repos: add `aria-label` "Repos N" on the region and button; render a visible space before the count.
  - `SectionHead`: render the count inside the `<h2>` with a leading space and set `aria-label` to "Title N" for a correct accessible name.
  - Tests: assert accessible names ("Repos 1", "Reviews 5") and visible text.

<sup>Written for commit e802b66e16ae7d9c5001713af548b410422efa1e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added descriptive accessible labels to repository and section headers so counts are announced as part of their headings and controls.
* **Tests**
  * Tightened tests to assert exact accessible names and visible formatting for repo and section count labels, ensuring accessibility and visual output are aligned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->