### PR TITLE
refactor(ui): replace toast emojis with lucide icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@xterm/addon-web-links": "^0.12.0",
         "@xterm/xterm": "^6.0.0",
         "cmdk": "^1.1.1",
+        "lucide-react": "^1.8.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "zustand": "^5.0.12"
@@ -3774,6 +3775,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.8.0.tgz",
+      "integrity": "sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",
     "cmdk": "^1.1.1",
+    "lucide-react": "^1.8.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "zustand": "^5.0.12"

--- a/src/components/Toast/Toast.test.tsx
+++ b/src/components/Toast/Toast.test.tsx
@@ -54,6 +54,7 @@ describe("Toast", () => {
     render(<Toast />);
 
     expect(screen.getByText("Review Request")).toBeInTheDocument();
+    expect(screen.getByTestId("toast-icon-review_request")).toBeInTheDocument();
   });
 
   it("should show toast on ci_failure event", () => {
@@ -71,6 +72,7 @@ describe("Toast", () => {
     render(<Toast />);
 
     expect(screen.getByText("CI Failure")).toBeInTheDocument();
+    expect(screen.getByTestId("toast-icon-ci_failure")).toBeInTheDocument();
   });
 
   it("should show toast on pr_approved event", () => {
@@ -88,6 +90,7 @@ describe("Toast", () => {
     render(<Toast />);
 
     expect(screen.getByText("PR Approved")).toBeInTheDocument();
+    expect(screen.getByTestId("toast-icon-pr_approved")).toBeInTheDocument();
   });
 
   it("should auto-dismiss after 5s", () => {

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -1,3 +1,4 @@
+import { CircleCheck, CircleX, Eye, type LucideIcon } from "lucide-react";
 import { useCallback, useEffect, useRef, type ReactElement } from "react";
 import { useNotifications } from "../../hooks/useNotifications";
 import type { Notification } from "../../hooks/useNotifications";
@@ -8,11 +9,11 @@ const AUTO_DISMISS_MS = 5_000;
 
 const NOTIFICATION_META: Record<
   Notification["type"],
-  { label: string; icon: string; view: DashboardView }
+  { label: string; Icon: LucideIcon; view: DashboardView }
 > = {
-  review_request: { label: "Review Request", icon: "👀", view: "reviews" },
-  ci_failure: { label: "CI Failure", icon: "❌", view: "mine" },
-  pr_approved: { label: "PR Approved", icon: "✅", view: "mine" },
+  review_request: { label: "Review Request", Icon: Eye, view: "reviews" },
+  ci_failure: { label: "CI Failure", Icon: CircleX, view: "mine" },
+  pr_approved: { label: "PR Approved", Icon: CircleCheck, view: "mine" },
 };
 
 interface ToastItemProps {
@@ -41,6 +42,7 @@ function extractPayloadSummary(payload: unknown): string | undefined {
 function ToastItem({ notification, onDismiss, onNavigate }: ToastItemProps): ReactElement {
   const timerRef = useRef<ReturnType<typeof setTimeout>>(null);
   const meta = NOTIFICATION_META[notification.type];
+  const Icon = meta.Icon;
   const summary = extractPayloadSummary(notification.payload);
 
   useEffect(() => {
@@ -70,7 +72,16 @@ function ToastItem({ notification, onDismiss, onNavigate }: ToastItemProps): Rea
       onClick={handleClick}
       className="flex w-72 items-center gap-3 rounded-lg border border-border bg-bg-secondary p-3 shadow-lg transition-opacity hover:opacity-80"
     >
-      <span className="text-lg" aria-hidden="true">{meta.icon}</span>
+      <span
+        className="flex h-5 w-5 items-center justify-center text-fg"
+        aria-hidden="true"
+      >
+        <Icon
+          data-testid={`toast-icon-${notification.type}`}
+          className="h-5 w-5"
+          strokeWidth={1.9}
+        />
+      </span>
       <div className="flex flex-col items-start">
         <span className="text-sm font-medium text-fg">{meta.label}</span>
         {summary !== undefined && (


### PR DESCRIPTION
## Summary
- replace toast notification emoji glyphs with `lucide-react` SVG icons
- keep the existing notification labels, navigation targets, and payload summary behavior
- add targeted test assertions for the rendered icons

## Validation
- `npm test -- src/components/Toast/Toast.test.tsx`
- `npm run lint -- src/components/Toast/Toast.tsx src/components/Toast/Toast.test.tsx`
- `npm run build`

Closes #176

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced toast emojis with `lucide-react` SVG icons for a more consistent UI. Labels, navigation targets, and payload summaries remain unchanged.

- **Refactors**
  - Map `Notification` types to Lucide components (`Eye`, `CircleX`, `CircleCheck`) using `LucideIcon`.
  - Render icons with `data-testid="toast-icon-{type}"` and add tests to assert icon presence.

- **Dependencies**
  - Add `lucide-react` ^1.8.0.

<sup>Written for commit 6c0f7918948edda93b8b2a8ffca071a97e651d0a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced toast notifications with improved icon components for better visual presentation across review requests, CI failures, and approval notifications

* **Tests**
  * Updated test cases to verify proper rendering of toast notification icons

* **Chores**
  * Added new icon library dependency to support component-based UI elements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->