### PR TITLE
fix(ui): sidebar arrow navigation

### DIFF
--- a/src/components/Sidebar/NavItem.test.tsx
+++ b/src/components/Sidebar/NavItem.test.tsx
@@ -73,4 +73,28 @@ describe("NavItem", () => {
     const button = screen.getByRole("button");
     expect(button).not.toHaveAttribute("aria-label");
   });
+
+  it("should pass through keyboard and focus props", async () => {
+    const handleFocus = vi.fn();
+    const handleKeyDown = vi.fn();
+    render(
+      <NavItem
+        label="Overview"
+        view="overview"
+        isActive={false}
+        onClick={vi.fn()}
+        tabIndex={-1}
+        onFocus={handleFocus}
+        onKeyDown={handleKeyDown}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: /overview/i });
+    button.focus();
+    await userEvent.keyboard("{ArrowDown}");
+
+    expect(button).toHaveAttribute("tabindex", "-1");
+    expect(handleFocus).toHaveBeenCalledTimes(1);
+    expect(handleKeyDown).toHaveBeenCalled();
+  });
 });

--- a/src/components/Sidebar/NavItem.tsx
+++ b/src/components/Sidebar/NavItem.tsx
@@ -1,4 +1,9 @@
-import type { ReactElement } from "react";
+import type {
+  FocusEventHandler,
+  KeyboardEventHandler,
+  ReactElement,
+  Ref,
+} from "react";
 import type { DashboardView } from "../../stores/dashboard";
 
 interface NavItemProps {
@@ -7,6 +12,10 @@ interface NavItemProps {
   readonly count?: number;
   readonly isActive: boolean;
   readonly onClick: (view: DashboardView) => void;
+  readonly tabIndex?: number;
+  readonly onFocus?: FocusEventHandler<HTMLButtonElement>;
+  readonly onKeyDown?: KeyboardEventHandler<HTMLButtonElement>;
+  readonly buttonRef?: Ref<HTMLButtonElement>;
 }
 
 export function NavItem({
@@ -15,13 +24,21 @@ export function NavItem({
   count,
   isActive,
   onClick,
+  tabIndex,
+  onFocus,
+  onKeyDown,
+  buttonRef,
 }: NavItemProps): ReactElement {
   return (
     <button
+      ref={buttonRef}
       type="button"
       onClick={() => onClick(view)}
+      onFocus={onFocus}
+      onKeyDown={onKeyDown}
       aria-current={isActive ? "page" : undefined}
       aria-label={count !== undefined && count > 0 ? `${label} (${count})` : undefined}
+      tabIndex={tabIndex}
       className={`flex w-full items-center justify-between rounded px-2 py-1.5 text-left text-sm ${
         isActive
           ? "bg-surface text-white hover:bg-surface-hover"

--- a/src/components/Sidebar/Sidebar.test.tsx
+++ b/src/components/Sidebar/Sidebar.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Sidebar } from "./Sidebar";
@@ -292,5 +292,23 @@ describe("Sidebar", () => {
     expect(overviewButton).toHaveFocus();
     expect(overviewButton).toHaveAttribute("tabindex", "0");
     expect(settingsButton).toHaveAttribute("tabindex", "-1");
+  });
+
+  it("should preserve the roving target while a nav item still has focus", () => {
+    renderSidebar();
+
+    const reviewButton = screen.getByRole("button", { name: /to review \(3\)/i });
+    const settingsButton = screen.getByRole("button", { name: /settings/i });
+
+    reviewButton.focus();
+
+    act(() => {
+      useDashboardStore.setState({ currentView: "settings" });
+    });
+
+    expect(reviewButton).toHaveFocus();
+    expect(reviewButton).toHaveAttribute("tabindex", "0");
+    expect(settingsButton).toHaveAttribute("tabindex", "-1");
+    expect(settingsButton).toHaveAttribute("aria-current", "page");
   });
 });

--- a/src/components/Sidebar/Sidebar.test.tsx
+++ b/src/components/Sidebar/Sidebar.test.tsx
@@ -237,4 +237,60 @@ describe("Sidebar", () => {
     expect(reposHeader).toHaveAccessibleName("Repos 1");
     expect(reposHeader).toHaveTextContent(/^Repos 1\s*▸$/);
   });
+
+  it("should use roving tab index for sidebar navigation", () => {
+    renderSidebar();
+
+    expect(screen.getByRole("button", { name: /overview/i })).toHaveAttribute("tabindex", "0");
+    expect(screen.getByRole("button", { name: /to review \(3\)/i })).toHaveAttribute("tabindex", "-1");
+    expect(screen.getByRole("button", { name: /my prs \(7\)/i })).toHaveAttribute("tabindex", "-1");
+  });
+
+  it("should move focus to the next nav item on ArrowDown", async () => {
+    const user = userEvent.setup();
+    renderSidebar();
+
+    const overviewButton = screen.getByRole("button", { name: /overview/i });
+    const reviewButton = screen.getByRole("button", { name: /to review \(3\)/i });
+
+    overviewButton.focus();
+    await user.keyboard("{ArrowDown}");
+
+    expect(reviewButton).toHaveFocus();
+    expect(reviewButton).toHaveAttribute("tabindex", "0");
+    expect(overviewButton).toHaveAttribute("tabindex", "-1");
+    expect(useDashboardStore.getState().currentView).toBe("overview");
+  });
+
+  it("should move focus to the previous nav item on ArrowUp", async () => {
+    const user = userEvent.setup();
+    renderSidebar();
+
+    const overviewButton = screen.getByRole("button", { name: /overview/i });
+    const settingsButton = screen.getByRole("button", { name: /settings/i });
+
+    overviewButton.focus();
+    await user.keyboard("{ArrowUp}");
+
+    expect(settingsButton).toHaveFocus();
+    expect(settingsButton).toHaveAttribute("tabindex", "0");
+  });
+
+  it("should move focus to the first and last nav item with Home and End", async () => {
+    const user = userEvent.setup();
+    renderSidebar();
+
+    const overviewButton = screen.getByRole("button", { name: /overview/i });
+    const activityButton = screen.getByRole("button", { name: /activity \(4\)/i });
+    const settingsButton = screen.getByRole("button", { name: /settings/i });
+
+    activityButton.focus();
+    await user.keyboard("{End}");
+    expect(settingsButton).toHaveFocus();
+
+    await user.keyboard("{Home}");
+    expect(overviewButton).toHaveFocus();
+    expect(overviewButton).toHaveAttribute("tabindex", "0");
+    expect(settingsButton).toHaveAttribute("tabindex", "-1");
+  });
 });

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -113,7 +113,6 @@ export function Sidebar(): ReactElement {
   function focusNavItem(index: number) {
     const item = NAV_ITEMS[index];
     if (!item) return;
-    setFocusedView(item.view);
     navItemRefs.current[index]?.focus();
   }
 
@@ -151,7 +150,7 @@ export function Sidebar(): ReactElement {
       </div>
 
       {/* Navigation */}
-      <div className="flex flex-col gap-0.5" role="toolbar" aria-label="Primary views" aria-orientation="vertical">
+      <div className="flex flex-col gap-0.5" role="group" aria-label="Primary views">
         {NAV_ITEMS.map((item, index) => (
           <NavItem
             key={item.view}

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -73,6 +73,7 @@ export function Sidebar(): ReactElement {
 
   const [isReposExpanded, setIsReposExpanded] = useState(false);
   const [focusedView, setFocusedView] = useState<DashboardView>(currentView);
+  const navGroupRef = useRef<HTMLDivElement | null>(null);
   const navItemRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
   const workspaces = (dashboard?.workspaces ?? []).filter(
@@ -83,6 +84,9 @@ export function Sidebar(): ReactElement {
   const username = authQuery.data?.username ?? null;
 
   useEffect(() => {
+    if (typeof document !== "undefined" && navGroupRef.current?.contains(document.activeElement)) {
+      return;
+    }
     setFocusedView(currentView);
   }, [currentView]);
 
@@ -150,7 +154,7 @@ export function Sidebar(): ReactElement {
       </div>
 
       {/* Navigation */}
-      <div className="flex flex-col gap-0.5" role="group" aria-label="Primary views">
+      <div ref={navGroupRef} className="flex flex-col gap-0.5" role="group" aria-label="Primary views">
         {NAV_ITEMS.map((item, index) => (
           <NavItem
             key={item.view}

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { ReactElement } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useDashboardStore } from "../../stores/dashboard";
@@ -72,6 +72,8 @@ export function Sidebar(): ReactElement {
   }
 
   const [isReposExpanded, setIsReposExpanded] = useState(false);
+  const [focusedView, setFocusedView] = useState<DashboardView>(currentView);
+  const navItemRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
   const workspaces = (dashboard?.workspaces ?? []).filter(
     (ws) => ws.state !== "archived",
@@ -79,6 +81,10 @@ export function Sidebar(): ReactElement {
   const repos = reposQuery.data ?? [];
   const enabledRepos = repos.filter((r) => r.enabled);
   const username = authQuery.data?.username ?? null;
+
+  useEffect(() => {
+    setFocusedView(currentView);
+  }, [currentView]);
 
   async function handleSelectAll() {
     const toEnable = repos.filter((r) => !r.enabled);
@@ -104,6 +110,38 @@ export function Sidebar(): ReactElement {
     }
   }
 
+  function focusNavItem(index: number) {
+    const item = NAV_ITEMS[index];
+    if (!item) return;
+    setFocusedView(item.view);
+    navItemRefs.current[index]?.focus();
+  }
+
+  function handleNavKeyDown(event: React.KeyboardEvent<HTMLButtonElement>, index: number) {
+    const count = NAV_ITEMS.length;
+    let nextIndex: number | null = null;
+
+    switch (event.key) {
+      case "ArrowDown":
+        nextIndex = (index + 1) % count;
+        break;
+      case "ArrowUp":
+        nextIndex = (index - 1 + count) % count;
+        break;
+      case "Home":
+        nextIndex = 0;
+        break;
+      case "End":
+        nextIndex = count - 1;
+        break;
+      default:
+        return;
+    }
+
+    event.preventDefault();
+    focusNavItem(nextIndex);
+  }
+
   return (
     <nav data-testid="sidebar" aria-label="Main navigation" className="flex h-full flex-col gap-4 p-3">
       {/* Logo */}
@@ -113,15 +151,21 @@ export function Sidebar(): ReactElement {
       </div>
 
       {/* Navigation */}
-      <div className="flex flex-col gap-0.5">
-        {NAV_ITEMS.map((item) => (
+      <div className="flex flex-col gap-0.5" role="toolbar" aria-label="Primary views" aria-orientation="vertical">
+        {NAV_ITEMS.map((item, index) => (
           <NavItem
             key={item.view}
+            buttonRef={(element) => {
+              navItemRefs.current[index] = element;
+            }}
             label={item.label}
             view={item.view}
             count={item.countKey && stats ? stats[item.countKey] : undefined}
             isActive={currentView === item.view}
+            tabIndex={focusedView === item.view ? 0 : -1}
             onClick={handleNavClick}
+            onFocus={() => setFocusedView(item.view)}
+            onKeyDown={(event) => handleNavKeyDown(event, index)}
           />
         ))}
       </div>


### PR DESCRIPTION
## Summary
- implement roving tabindex for sidebar navigation items
- add ArrowUp/ArrowDown/Home/End keyboard handling without changing the active view on focus movement
- cover the new focus behavior with sidebar and nav item tests

## Why
Arrow key navigation in the sidebar did not move focus between items. Only Tab worked, which broke expected keyboard navigation for this control and left issue #178 unresolved.

## Root Cause
Sidebar navigation items were plain buttons without shared focus state, per-item `tabIndex` management, or arrow-key handling.

## Impact
Users can now move focus through the sidebar using arrow keys and jump to the first/last item with Home and End, matching the roving tabindex pattern expected for this kind of navigation.

## Validation
- `npm test -- src/components/Sidebar/Sidebar.test.tsx src/components/Sidebar/NavItem.test.tsx`
- `npm run build`
- `npm run lint -- src/components/Sidebar/Sidebar.tsx src/components/Sidebar/NavItem.tsx src/components/Sidebar/Sidebar.test.tsx src/components/Sidebar/NavItem.test.tsx`

Fixes #178

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds roving tabindex and ArrowUp/ArrowDown/Home/End navigation to the sidebar so users can move focus between items without changing the active view. Groups nav items as "Primary views" for better screen reader context. Fixes #178.

- **Bug Fixes**
  - Implemented roving tabindex with `focusedView` and refs; preserves focus when the view changes and resets to the active view if focus leaves the group.
  - Handled ArrowUp/ArrowDown/Home/End with wrap-around and `preventDefault` to avoid triggering navigation.
  - Exposed `tabIndex`, `onFocus`, `onKeyDown`, and `buttonRef` on `NavItem`; tests cover prop pass-through, roving behavior, and focus movement.

<sup>Written for commit c9c779a09471da2bd69461f74c78f73c8011a98e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Keyboard navigation for the sidebar: Up/Down arrows, Home, End to move focus; only the active/focused item is tabbable and the nav is exposed as a primary views group.

* **Tests**
  * Added tests validating sidebar roving tabindex, arrow/Home/End focus behavior, focus persistence when view changes, and per-item focus/key handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->