### PR TITLE
fix(workspace): defer terminal rendering to avoid tauri-pilot timeouts

### DIFF
--- a/src/components/Workspace/Terminal.test.tsx
+++ b/src/components/Workspace/Terminal.test.tsx
@@ -67,15 +67,38 @@ import { ptyWrite, ptyResize, onEvent } from "../../lib/tauri";
 
 describe("Terminal", () => {
   let unlistenStdout: Mock;
+  let idleCallback: IdleRequestCallback | null;
+  let cancelIdleCallbackMock: Mock;
 
   beforeEach(() => {
     vi.clearAllMocks();
     unlistenStdout = vi.fn();
     (onEvent as Mock).mockResolvedValue(unlistenStdout);
+    idleCallback = null;
+    cancelIdleCallbackMock = vi.fn();
+    vi.stubGlobal(
+      "requestIdleCallback",
+      vi.fn((callback: IdleRequestCallback) => {
+        idleCallback = callback;
+        return 1;
+      }),
+    );
+    vi.stubGlobal("cancelIdleCallback", cancelIdleCallbackMock);
   });
+
+  function flushIdleCallback() {
+    expect(idleCallback).not.toBeNull();
+    act(() => {
+      idleCallback?.({
+        didTimeout: false,
+        timeRemaining: () => 50,
+      } as IdleDeadline);
+    });
+  }
 
   it("should initialize xterm on mount", () => {
     render(<Terminal ptyId="ws-1" />);
+    flushIdleCallback();
 
     expect(MockTerminal).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -95,6 +118,7 @@ describe("Terminal", () => {
 
   it("should write data from stdout event", async () => {
     render(<Terminal ptyId="ws-1" />);
+    flushIdleCallback();
 
     await vi.waitFor(() => {
       expect(onEvent).toHaveBeenCalledWith(
@@ -118,6 +142,7 @@ describe("Terminal", () => {
 
   it("should not write stdout for different ptyId", async () => {
     render(<Terminal ptyId="ws-1" />);
+    flushIdleCallback();
 
     await vi.waitFor(() => {
       expect(onEvent).toHaveBeenCalledWith(
@@ -141,6 +166,7 @@ describe("Terminal", () => {
 
   it("should call pty_write on keypress", () => {
     render(<Terminal ptyId="ws-1" />);
+    flushIdleCallback();
 
     expect(mockOnData).toHaveBeenCalledOnce();
     const calls = (mockOnData as Mock).mock.calls;
@@ -173,6 +199,7 @@ describe("Terminal", () => {
     vi.stubGlobal("ResizeObserver", MockResizeObserver);
 
     render(<Terminal ptyId="ws-1" />);
+    flushIdleCallback();
 
     expect(mockObserve).toHaveBeenCalledOnce();
 
@@ -192,6 +219,7 @@ describe("Terminal", () => {
 
   it("should cleanup on unmount", async () => {
     const { unmount } = render(<Terminal ptyId="ws-1" />);
+    flushIdleCallback();
 
     await vi.waitFor(() => {
       expect(onEvent).toHaveBeenCalledOnce();
@@ -206,4 +234,12 @@ describe("Terminal", () => {
     });
   });
 
+  it("should cancel deferred initialization on unmount before idle callback", () => {
+    const { unmount } = render(<Terminal ptyId="ws-1" />);
+
+    unmount();
+
+    expect(cancelIdleCallbackMock).toHaveBeenCalledWith(1);
+    expect(MockTerminal).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/Workspace/Terminal.test.tsx
+++ b/src/components/Workspace/Terminal.test.tsx
@@ -98,6 +98,11 @@ describe("Terminal", () => {
 
   it("should initialize xterm on mount", () => {
     render(<Terminal ptyId="ws-1" />);
+
+    expect(onEvent).toHaveBeenCalledWith(
+      "workspace:stdout",
+      expect.any(Function),
+    );
     flushIdleCallback();
 
     expect(MockTerminal).toHaveBeenCalledWith(
@@ -114,6 +119,33 @@ describe("Terminal", () => {
     expect(mockLoadAddon).toHaveBeenCalledTimes(2); // FitAddon + WebLinksAddon
     expect(mockFit).toHaveBeenCalledOnce();
     expect(screen.getByTestId("terminal-ws-1")).toBeInTheDocument();
+  });
+
+  it("should buffer stdout received before terminal initialization", async () => {
+    render(<Terminal ptyId="ws-1" />);
+
+    await vi.waitFor(() => {
+      expect(onEvent).toHaveBeenCalledWith(
+        "workspace:stdout",
+        expect.any(Function),
+      );
+    });
+
+    const call = (onEvent as Mock).mock.calls.find(
+      (c: unknown[]) => c[0] === "workspace:stdout",
+    );
+    expect(call).toBeDefined();
+    const handler = call![1] as (payload: { workspaceId: string; data: string }) => void;
+
+    act(() => {
+      handler({ workspaceId: "ws-1", data: "boot output" });
+    });
+
+    expect(mockWrite).not.toHaveBeenCalled();
+
+    flushIdleCallback();
+
+    expect(mockWrite).toHaveBeenCalledWith("boot output");
   });
 
   it("should write data from stdout event", async () => {
@@ -241,5 +273,15 @@ describe("Terminal", () => {
 
     expect(cancelIdleCallbackMock).toHaveBeenCalledWith(1);
     expect(MockTerminal).not.toHaveBeenCalled();
+  });
+
+  it("should unlisten stdout on unmount before idle callback", async () => {
+    const { unmount } = render(<Terminal ptyId="ws-1" />);
+
+    unmount();
+
+    await vi.waitFor(() => {
+      expect(unlistenStdout).toHaveBeenCalledOnce();
+    });
   });
 });

--- a/src/components/Workspace/Terminal.tsx
+++ b/src/components/Workspace/Terminal.tsx
@@ -33,55 +33,86 @@ export function Terminal({ ptyId }: TerminalProps) {
     const container = containerRef.current;
     if (!container) return;
 
-    const term = new XTerm({
-      cursorBlink: true,
-      fontSize: 14,
-      fontFamily: "'JetBrains Mono', 'Fira Code', monospace",
-      theme: PRISM_THEME,
-    });
+    const idleScheduler = globalThis as typeof globalThis & {
+      requestIdleCallback?: (
+        callback: IdleRequestCallback,
+        options?: IdleRequestOptions,
+      ) => number;
+      cancelIdleCallback?: (handle: number) => void;
+    };
 
-    const fitAddon = new FitAddon();
-    const webLinksAddon = new WebLinksAddon();
+    let disposed = false;
+    let cleanupTerminal: (() => void) | undefined;
 
-    term.loadAddon(fitAddon);
-    term.loadAddon(webLinksAddon);
-    term.open(container);
-    fitAddon.fit();
+    const initializeTerminal = () => {
+      if (disposed || !containerRef.current) return;
 
-    // stdin: forward user keystrokes to PTY
-    term.onData((data) => {
-      ptyWrite({ workspaceId: ptyId, data }).catch((err: unknown) => {
-        console.error("[Terminal] ptyWrite failed:", err);
+      const term = new XTerm({
+        cursorBlink: true,
+        fontSize: 14,
+        fontFamily: "'JetBrains Mono', 'Fira Code', monospace",
+        theme: PRISM_THEME,
       });
-    });
 
-    // stdout: listen for PTY output events
-    const unlistenPromise = onEvent<PtyOutput>("workspace:stdout", (payload) => {
-      if (payload.workspaceId === ptyId) {
-        term.write(payload.data);
-      }
-    });
+      const fitAddon = new FitAddon();
+      const webLinksAddon = new WebLinksAddon();
 
-    // resize: observe container and notify PTY
-    const resizeObserver = new ResizeObserver(() => {
+      term.loadAddon(fitAddon);
+      term.loadAddon(webLinksAddon);
+      term.open(containerRef.current);
       fitAddon.fit();
-      const dims = fitAddon.proposeDimensions();
-      if (dims) {
-        ptyResize({ workspaceId: ptyId, cols: dims.cols, rows: dims.rows }).catch(
-          (err: unknown) => {
-            console.error("[Terminal] ptyResize failed:", err);
-          },
-        );
-      }
-    });
-    resizeObserver.observe(container);
+
+      // stdin: forward user keystrokes to PTY
+      term.onData((data) => {
+        ptyWrite({ workspaceId: ptyId, data }).catch((err: unknown) => {
+          console.error("[Terminal] ptyWrite failed:", err);
+        });
+      });
+
+      // stdout: listen for PTY output events
+      const unlistenPromise = onEvent<PtyOutput>("workspace:stdout", (payload) => {
+        if (payload.workspaceId === ptyId) {
+          term.write(payload.data);
+        }
+      });
+
+      // resize: observe container and notify PTY
+      const resizeObserver = new ResizeObserver(() => {
+        fitAddon.fit();
+        const dims = fitAddon.proposeDimensions();
+        if (dims) {
+          ptyResize({ workspaceId: ptyId, cols: dims.cols, rows: dims.rows }).catch(
+            (err: unknown) => {
+              console.error("[Terminal] ptyResize failed:", err);
+            },
+          );
+        }
+      });
+      resizeObserver.observe(containerRef.current);
+
+      cleanupTerminal = () => {
+        resizeObserver.disconnect();
+        unlistenPromise
+          .then((unlisten) => unlisten())
+          .catch(() => {});
+        term.dispose();
+      };
+    };
+
+    const cancelInitialization = idleScheduler.requestIdleCallback
+      ? (() => {
+          const handle = idleScheduler.requestIdleCallback(initializeTerminal, { timeout: 200 });
+          return () => idleScheduler.cancelIdleCallback?.(handle);
+        })()
+      : (() => {
+          const handle = window.setTimeout(initializeTerminal, 0);
+          return () => window.clearTimeout(handle);
+        })();
 
     return () => {
-      resizeObserver.disconnect();
-      unlistenPromise
-        .then((unlisten) => unlisten())
-        .catch(() => {});
-      term.dispose();
+      disposed = true;
+      cancelInitialization();
+      cleanupTerminal?.();
     };
   }, [ptyId]);
 

--- a/src/components/Workspace/Terminal.tsx
+++ b/src/components/Workspace/Terminal.tsx
@@ -43,11 +43,24 @@ export function Terminal({ ptyId }: TerminalProps) {
 
     let disposed = false;
     let cleanupTerminal: (() => void) | undefined;
+    const bufferedStdout: string[] = [];
+    let term: XTerm | undefined;
+
+    const unlistenPromise = onEvent<PtyOutput>("workspace:stdout", (payload) => {
+      if (payload.workspaceId !== ptyId) return;
+
+      if (!term) {
+        bufferedStdout.push(payload.data);
+        return;
+      }
+
+      term.write(payload.data);
+    });
 
     const initializeTerminal = () => {
       if (disposed || !containerRef.current) return;
 
-      const term = new XTerm({
+      term = new XTerm({
         cursorBlink: true,
         fontSize: 14,
         fontFamily: "'JetBrains Mono', 'Fira Code', monospace",
@@ -69,12 +82,10 @@ export function Terminal({ ptyId }: TerminalProps) {
         });
       });
 
-      // stdout: listen for PTY output events
-      const unlistenPromise = onEvent<PtyOutput>("workspace:stdout", (payload) => {
-        if (payload.workspaceId === ptyId) {
-          term.write(payload.data);
-        }
-      });
+      for (const chunk of bufferedStdout) {
+        term.write(chunk);
+      }
+      bufferedStdout.length = 0;
 
       // resize: observe container and notify PTY
       const resizeObserver = new ResizeObserver(() => {
@@ -95,7 +106,8 @@ export function Terminal({ ptyId }: TerminalProps) {
         unlistenPromise
           .then((unlisten) => unlisten())
           .catch(() => {});
-        term.dispose();
+        term?.dispose();
+        term = undefined;
       };
     };
 
@@ -113,6 +125,11 @@ export function Terminal({ ptyId }: TerminalProps) {
       disposed = true;
       cancelInitialization();
       cleanupTerminal?.();
+      if (!cleanupTerminal) {
+        unlistenPromise
+          .then((unlisten) => unlisten())
+          .catch(() => {});
+      }
     };
   }, [ptyId]);
 

--- a/src/components/Workspace/WorkspaceView.test.tsx
+++ b/src/components/Workspace/WorkspaceView.test.tsx
@@ -167,11 +167,11 @@ describe("WorkspaceView", () => {
     );
 
     expect(screen.getByTestId("workspace-switcher")).toBeInTheDocument();
-    expect(screen.getByTestId("terminal-ws-1")).toBeInTheDocument();
     expect(screen.getByTestId("workspace-statusbar")).toBeInTheDocument();
+    expect(screen.getByTestId("workspace-terminal-loading")).toBeInTheDocument();
   });
 
-  it("should switch terminal on workspace change", () => {
+  it("should render the terminal after the chunk loads", async () => {
     renderWithQuery(
       <WorkspaceView
         workspaces={WORKSPACES}
@@ -181,7 +181,20 @@ describe("WorkspaceView", () => {
       />,
     );
 
-    expect(screen.getByTestId("terminal-ws-1")).toBeInTheDocument();
+    expect(await screen.findByTestId("terminal-ws-1")).toBeInTheDocument();
+  });
+
+  it("should switch terminal on workspace change", async () => {
+    renderWithQuery(
+      <WorkspaceView
+        workspaces={WORKSPACES}
+        statusInfo={STATUS_INFO}
+        entries={[]}
+        onBackToDashboard={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByTestId("terminal-ws-1")).toBeInTheDocument();
 
     act(() => {
       useWorkspacesStore.setState({ activeWorkspaceId: "ws-2" });
@@ -191,7 +204,7 @@ describe("WorkspaceView", () => {
     expect(screen.queryByTestId("terminal-ws-1")).not.toBeInTheDocument();
   });
 
-  it("should render terminal without status bar when status info is missing", () => {
+  it("should render terminal without status bar when status info is missing", async () => {
     renderWithQuery(
       <WorkspaceView
         workspaces={WORKSPACES}
@@ -202,7 +215,7 @@ describe("WorkspaceView", () => {
     );
 
     expect(screen.getByTestId("workspace-switcher")).toBeInTheDocument();
-    expect(screen.getByTestId("terminal-ws-1")).toBeInTheDocument();
+    expect(await screen.findByTestId("terminal-ws-1")).toBeInTheDocument();
     expect(screen.queryByTestId("workspace-statusbar")).not.toBeInTheDocument();
   });
 

--- a/src/components/Workspace/WorkspaceView.tsx
+++ b/src/components/Workspace/WorkspaceView.tsx
@@ -1,12 +1,28 @@
-import { useCallback, useState, type ReactElement } from "react";
+import { lazy, Suspense, useCallback, useState, type ReactElement } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import type { Workspace, WorkspaceListEntry, WorkspaceStatusInfo } from "../../lib/types";
 import { resumeWorkspace } from "../../lib/tauri";
 import { useWorkspacesStore } from "../../stores/workspaces";
 import { WorkspaceSwitcher } from "./WorkspaceSwitcher";
-import { Terminal } from "./Terminal";
 import { WorkspaceStatusBar } from "./WorkspaceStatusBar";
 import { WorkspaceListPage } from "./WorkspaceListPage";
+
+const Terminal = lazy(() =>
+  import("./Terminal").then((module) => ({ default: module.Terminal })),
+);
+
+function TerminalLoadingFallback(): ReactElement {
+  return (
+    <div
+      data-testid="workspace-terminal-loading"
+      role="status"
+      aria-live="polite"
+      className="flex h-full items-center justify-center bg-[#0a0a09] text-sm text-neutral-400"
+    >
+      Loading terminal…
+    </div>
+  );
+}
 
 interface WorkspaceViewProps {
   readonly workspaces: readonly Workspace[];
@@ -92,7 +108,9 @@ export function WorkspaceView({
       ) : active ? (
         <>
           <div className="min-h-0 flex-1">
-            <Terminal ptyId={active.id} />
+            <Suspense fallback={<TerminalLoadingFallback />}>
+              <Terminal ptyId={active.id} />
+            </Suspense>
           </div>
           {info && (
             <WorkspaceStatusBar


### PR DESCRIPTION
## Summary
- lazy-load the workspace terminal behind `Suspense` so xterm is not mounted during initial Workspaces view render
- defer xterm initialization with `requestIdleCallback` and cancel setup cleanly if the component unmounts first
- update workspace tests to cover the loading fallback and deferred terminal initialization path

## Validation
- `npm test -- src/components/Workspace/WorkspaceView.test.tsx src/components/Workspace/Terminal.test.tsx`
- `npm run build`

Closes #179

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers terminal rendering and `xterm` initialization to prevent tauri-pilot timeouts when opening Workspaces. Fixes #179 by lazy-loading the terminal, initializing on idle, and safely handling early unmounts.

- **Bug Fixes**
  - Lazy-load `Terminal` via `React.lazy` and `Suspense` with a small loading fallback to avoid mounting `xterm` during initial render.
  - Defer `xterm` setup using `requestIdleCallback` (fallback to `setTimeout`), buffer stdout until the terminal is ready, and cancel initialization on unmount; clean up listeners, `ResizeObserver`, and the terminal.
  - Update tests to cover the loading fallback, stdout buffering before init, idle-based initialization, and early unmount cleanup/cancellation.

<sup>Written for commit 981e2dcb6bc8f4a8e764aee4cd77e9ae17ce5f34. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal is loaded lazily with a visible "Loading terminal…" fallback while initialization is deferred.

* **Bug Fixes**
  * Deferred initialization with cancellation prevents work after unmount and avoids unnecessary resource allocation.
  * Stdout events are buffered until the terminal is ready; cleanup now reliably unsubscribes even if initialization was cancelled.

* **Tests**
  * Tests updated to cover deferred initialization, stdout buffering before init, and unmount-before-initialization cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->