### PR TITLE
fix workspace resume black terminal

### DIFF
--- a/src/components/Workspace/Terminal.test.tsx
+++ b/src/components/Workspace/Terminal.test.tsx
@@ -294,6 +294,6 @@ describe("Terminal", () => {
       handler({ workspaceId: "ws-1", data: "late output" });
     });
 
-    expect(mockWrite).not.toHaveBeenCalledWith("late output");
+    expect(mockWrite).not.toHaveBeenCalled();
   });
 });

--- a/src/components/Workspace/Terminal.test.tsx
+++ b/src/components/Workspace/Terminal.test.tsx
@@ -10,6 +10,7 @@ const {
   mockLoadAddon,
   mockDispose,
   mockFit,
+  mockPropose,
   MockTerminal,
   MockFitAddon,
   MockWebLinksAddon,
@@ -97,6 +98,17 @@ describe("Terminal", () => {
     expect(screen.getByTestId("terminal-ws-1")).toBeInTheDocument();
   });
 
+  it("should send the initial terminal size to the PTY on mount", () => {
+    render(<Terminal ptyId="ws-1" />);
+
+    expect(mockPropose).toHaveBeenCalledOnce();
+    expect(ptyResize).toHaveBeenCalledWith({
+      workspaceId: "ws-1",
+      cols: 120,
+      rows: 40,
+    });
+  });
+
   it("should not defer initialization via requestIdleCallback", () => {
     const requestIdleCallbackMock = vi.fn();
     vi.stubGlobal("requestIdleCallback", requestIdleCallbackMock);
@@ -109,7 +121,15 @@ describe("Terminal", () => {
     vi.unstubAllGlobals();
   });
 
-  it("should write stdout received from the matching workspace", async () => {
+  it("should buffer stdout until the event subscription promise resolves", async () => {
+    let resolveUnlisten: ((value: Mock) => void) | undefined;
+    (onEvent as Mock).mockImplementation(
+      () =>
+        new Promise<Mock>((resolve) => {
+          resolveUnlisten = resolve;
+        }),
+    );
+
     render(<Terminal ptyId="ws-1" />);
 
     await vi.waitFor(() => {
@@ -129,10 +149,17 @@ describe("Terminal", () => {
       handler({ workspaceId: "ws-1", data: "boot output" });
     });
 
+    expect(mockWrite).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveUnlisten?.(unlistenStdout);
+      await Promise.resolve();
+    });
+
     expect(mockWrite).toHaveBeenCalledWith("boot output");
   });
 
-  it("should write data from stdout event", async () => {
+  it("should write stdout received from the matching workspace", async () => {
     render(<Terminal ptyId="ws-1" />);
 
     await vi.waitFor(() => {
@@ -213,6 +240,7 @@ describe("Terminal", () => {
 
     render(<Terminal ptyId="ws-1" />);
 
+    vi.mocked(ptyResize).mockClear();
     expect(mockObserve).toHaveBeenCalledOnce();
 
     act(() => {
@@ -242,5 +270,30 @@ describe("Terminal", () => {
     await vi.waitFor(() => {
       expect(unlistenStdout).toHaveBeenCalledOnce();
     });
+  });
+
+  it("should ignore stdout after unmount", async () => {
+    const { unmount } = render(<Terminal ptyId="ws-1" />);
+
+    await vi.waitFor(() => {
+      expect(onEvent).toHaveBeenCalledWith(
+        "workspace:stdout",
+        expect.any(Function),
+      );
+    });
+
+    const call = (onEvent as Mock).mock.calls.find(
+      (c: unknown[]) => c[0] === "workspace:stdout",
+    );
+    expect(call).toBeDefined();
+    const handler = call![1] as (payload: { workspaceId: string; data: string }) => void;
+
+    unmount();
+
+    act(() => {
+      handler({ workspaceId: "ws-1", data: "late output" });
+    });
+
+    expect(mockWrite).not.toHaveBeenCalledWith("late output");
   });
 });

--- a/src/components/Workspace/Terminal.test.tsx
+++ b/src/components/Workspace/Terminal.test.tsx
@@ -67,34 +67,12 @@ import { ptyWrite, ptyResize, onEvent } from "../../lib/tauri";
 
 describe("Terminal", () => {
   let unlistenStdout: Mock;
-  let idleCallback: IdleRequestCallback | null;
-  let cancelIdleCallbackMock: Mock;
 
   beforeEach(() => {
     vi.clearAllMocks();
     unlistenStdout = vi.fn();
     (onEvent as Mock).mockResolvedValue(unlistenStdout);
-    idleCallback = null;
-    cancelIdleCallbackMock = vi.fn();
-    vi.stubGlobal(
-      "requestIdleCallback",
-      vi.fn((callback: IdleRequestCallback) => {
-        idleCallback = callback;
-        return 1;
-      }),
-    );
-    vi.stubGlobal("cancelIdleCallback", cancelIdleCallbackMock);
   });
-
-  function flushIdleCallback() {
-    expect(idleCallback).not.toBeNull();
-    act(() => {
-      idleCallback?.({
-        didTimeout: false,
-        timeRemaining: () => 50,
-      } as IdleDeadline);
-    });
-  }
 
   it("should initialize xterm on mount", () => {
     render(<Terminal ptyId="ws-1" />);
@@ -103,8 +81,6 @@ describe("Terminal", () => {
       "workspace:stdout",
       expect.any(Function),
     );
-    flushIdleCallback();
-
     expect(MockTerminal).toHaveBeenCalledWith(
       expect.objectContaining({
         cursorBlink: true,
@@ -116,12 +92,24 @@ describe("Terminal", () => {
       }),
     );
     expect(mockOpen).toHaveBeenCalledOnce();
-    expect(mockLoadAddon).toHaveBeenCalledTimes(2); // FitAddon + WebLinksAddon
+    expect(mockLoadAddon).toHaveBeenCalledTimes(2);
     expect(mockFit).toHaveBeenCalledOnce();
     expect(screen.getByTestId("terminal-ws-1")).toBeInTheDocument();
   });
 
-  it("should buffer stdout received before terminal initialization", async () => {
+  it("should not defer initialization via requestIdleCallback", () => {
+    const requestIdleCallbackMock = vi.fn();
+    vi.stubGlobal("requestIdleCallback", requestIdleCallbackMock);
+
+    render(<Terminal ptyId="ws-1" />);
+
+    expect(MockTerminal).toHaveBeenCalledOnce();
+    expect(requestIdleCallbackMock).not.toHaveBeenCalled();
+
+    vi.unstubAllGlobals();
+  });
+
+  it("should write stdout received from the matching workspace", async () => {
     render(<Terminal ptyId="ws-1" />);
 
     await vi.waitFor(() => {
@@ -141,16 +129,11 @@ describe("Terminal", () => {
       handler({ workspaceId: "ws-1", data: "boot output" });
     });
 
-    expect(mockWrite).not.toHaveBeenCalled();
-
-    flushIdleCallback();
-
     expect(mockWrite).toHaveBeenCalledWith("boot output");
   });
 
   it("should write data from stdout event", async () => {
     render(<Terminal ptyId="ws-1" />);
-    flushIdleCallback();
 
     await vi.waitFor(() => {
       expect(onEvent).toHaveBeenCalledWith(
@@ -174,7 +157,6 @@ describe("Terminal", () => {
 
   it("should not write stdout for different ptyId", async () => {
     render(<Terminal ptyId="ws-1" />);
-    flushIdleCallback();
 
     await vi.waitFor(() => {
       expect(onEvent).toHaveBeenCalledWith(
@@ -198,7 +180,6 @@ describe("Terminal", () => {
 
   it("should call pty_write on keypress", () => {
     render(<Terminal ptyId="ws-1" />);
-    flushIdleCallback();
 
     expect(mockOnData).toHaveBeenCalledOnce();
     const calls = (mockOnData as Mock).mock.calls;
@@ -231,7 +212,6 @@ describe("Terminal", () => {
     vi.stubGlobal("ResizeObserver", MockResizeObserver);
 
     render(<Terminal ptyId="ws-1" />);
-    flushIdleCallback();
 
     expect(mockObserve).toHaveBeenCalledOnce();
 
@@ -251,7 +231,6 @@ describe("Terminal", () => {
 
   it("should cleanup on unmount", async () => {
     const { unmount } = render(<Terminal ptyId="ws-1" />);
-    flushIdleCallback();
 
     await vi.waitFor(() => {
       expect(onEvent).toHaveBeenCalledOnce();
@@ -259,27 +238,7 @@ describe("Terminal", () => {
 
     unmount();
 
-    // dispose is synchronous, unlisten is deferred via .then()
     expect(mockDispose).toHaveBeenCalledOnce();
-    await vi.waitFor(() => {
-      expect(unlistenStdout).toHaveBeenCalledOnce();
-    });
-  });
-
-  it("should cancel deferred initialization on unmount before idle callback", () => {
-    const { unmount } = render(<Terminal ptyId="ws-1" />);
-
-    unmount();
-
-    expect(cancelIdleCallbackMock).toHaveBeenCalledWith(1);
-    expect(MockTerminal).not.toHaveBeenCalled();
-  });
-
-  it("should unlisten stdout on unmount before idle callback", async () => {
-    const { unmount } = render(<Terminal ptyId="ws-1" />);
-
-    unmount();
-
     await vi.waitFor(() => {
       expect(unlistenStdout).toHaveBeenCalledOnce();
     });

--- a/src/components/Workspace/Terminal.tsx
+++ b/src/components/Workspace/Terminal.tsx
@@ -41,16 +41,53 @@ export function Terminal({ ptyId }: TerminalProps) {
     });
     const fitAddon = new FitAddon();
     const webLinksAddon = new WebLinksAddon();
+    const bufferedStdout: string[] = [];
+    let disposed = false;
+    let listenerReady = false;
+
+    const flushBufferedStdout = () => {
+      if (disposed || !listenerReady || bufferedStdout.length === 0) return;
+      for (const chunk of bufferedStdout) {
+        term.write(chunk);
+      }
+      bufferedStdout.length = 0;
+    };
+
+    const notifyResize = () => {
+      const dims = fitAddon.proposeDimensions();
+      if (!dims) return;
+
+      ptyResize({ workspaceId: ptyId, cols: dims.cols, rows: dims.rows }).catch(
+        (err: unknown) => {
+          console.error("[Terminal] ptyResize failed:", err);
+        },
+      );
+    };
 
     const unlistenPromise = onEvent<PtyOutput>("workspace:stdout", (payload) => {
-      if (payload.workspaceId !== ptyId) return;
+      if (payload.workspaceId !== ptyId || disposed) return;
+      if (!listenerReady) {
+        bufferedStdout.push(payload.data);
+        return;
+      }
+
       term.write(payload.data);
     });
+    void unlistenPromise
+      .then(() => {
+        listenerReady = true;
+        flushBufferedStdout();
+      })
+      .catch(() => {
+        listenerReady = true;
+        bufferedStdout.length = 0;
+      });
 
     term.loadAddon(fitAddon);
     term.loadAddon(webLinksAddon);
     term.open(container);
     fitAddon.fit();
+    notifyResize();
 
     // stdin: forward user keystrokes to PTY
     term.onData((data) => {
@@ -62,18 +99,12 @@ export function Terminal({ ptyId }: TerminalProps) {
     // resize: observe container and notify PTY
     const resizeObserver = new ResizeObserver(() => {
       fitAddon.fit();
-      const dims = fitAddon.proposeDimensions();
-      if (dims) {
-        ptyResize({ workspaceId: ptyId, cols: dims.cols, rows: dims.rows }).catch(
-          (err: unknown) => {
-            console.error("[Terminal] ptyResize failed:", err);
-          },
-        );
-      }
+      notifyResize();
     });
     resizeObserver.observe(container);
 
     return () => {
+      disposed = true;
       resizeObserver.disconnect();
       unlistenPromise
         .then((unlisten) => unlisten())

--- a/src/components/Workspace/Terminal.tsx
+++ b/src/components/Workspace/Terminal.tsx
@@ -33,103 +33,52 @@ export function Terminal({ ptyId }: TerminalProps) {
     const container = containerRef.current;
     if (!container) return;
 
-    const idleScheduler = globalThis as typeof globalThis & {
-      requestIdleCallback?: (
-        callback: IdleRequestCallback,
-        options?: IdleRequestOptions,
-      ) => number;
-      cancelIdleCallback?: (handle: number) => void;
-    };
-
-    let disposed = false;
-    let cleanupTerminal: (() => void) | undefined;
-    const bufferedStdout: string[] = [];
-    let term: XTerm | undefined;
+    const term = new XTerm({
+      cursorBlink: true,
+      fontSize: 14,
+      fontFamily: "'JetBrains Mono', 'Fira Code', monospace",
+      theme: PRISM_THEME,
+    });
+    const fitAddon = new FitAddon();
+    const webLinksAddon = new WebLinksAddon();
 
     const unlistenPromise = onEvent<PtyOutput>("workspace:stdout", (payload) => {
       if (payload.workspaceId !== ptyId) return;
-
-      if (!term) {
-        bufferedStdout.push(payload.data);
-        return;
-      }
-
       term.write(payload.data);
     });
 
-    const initializeTerminal = () => {
-      if (disposed || !containerRef.current) return;
+    term.loadAddon(fitAddon);
+    term.loadAddon(webLinksAddon);
+    term.open(container);
+    fitAddon.fit();
 
-      term = new XTerm({
-        cursorBlink: true,
-        fontSize: 14,
-        fontFamily: "'JetBrains Mono', 'Fira Code', monospace",
-        theme: PRISM_THEME,
+    // stdin: forward user keystrokes to PTY
+    term.onData((data) => {
+      ptyWrite({ workspaceId: ptyId, data }).catch((err: unknown) => {
+        console.error("[Terminal] ptyWrite failed:", err);
       });
+    });
 
-      const fitAddon = new FitAddon();
-      const webLinksAddon = new WebLinksAddon();
-
-      term.loadAddon(fitAddon);
-      term.loadAddon(webLinksAddon);
-      term.open(containerRef.current);
+    // resize: observe container and notify PTY
+    const resizeObserver = new ResizeObserver(() => {
       fitAddon.fit();
-
-      // stdin: forward user keystrokes to PTY
-      term.onData((data) => {
-        ptyWrite({ workspaceId: ptyId, data }).catch((err: unknown) => {
-          console.error("[Terminal] ptyWrite failed:", err);
-        });
-      });
-
-      for (const chunk of bufferedStdout) {
-        term.write(chunk);
+      const dims = fitAddon.proposeDimensions();
+      if (dims) {
+        ptyResize({ workspaceId: ptyId, cols: dims.cols, rows: dims.rows }).catch(
+          (err: unknown) => {
+            console.error("[Terminal] ptyResize failed:", err);
+          },
+        );
       }
-      bufferedStdout.length = 0;
-
-      // resize: observe container and notify PTY
-      const resizeObserver = new ResizeObserver(() => {
-        fitAddon.fit();
-        const dims = fitAddon.proposeDimensions();
-        if (dims) {
-          ptyResize({ workspaceId: ptyId, cols: dims.cols, rows: dims.rows }).catch(
-            (err: unknown) => {
-              console.error("[Terminal] ptyResize failed:", err);
-            },
-          );
-        }
-      });
-      resizeObserver.observe(containerRef.current);
-
-      cleanupTerminal = () => {
-        resizeObserver.disconnect();
-        unlistenPromise
-          .then((unlisten) => unlisten())
-          .catch(() => {});
-        term?.dispose();
-        term = undefined;
-      };
-    };
-
-    const cancelInitialization = idleScheduler.requestIdleCallback
-      ? (() => {
-          const handle = idleScheduler.requestIdleCallback(initializeTerminal, { timeout: 200 });
-          return () => idleScheduler.cancelIdleCallback?.(handle);
-        })()
-      : (() => {
-          const handle = window.setTimeout(initializeTerminal, 0);
-          return () => window.clearTimeout(handle);
-        })();
+    });
+    resizeObserver.observe(container);
 
     return () => {
-      disposed = true;
-      cancelInitialization();
-      cleanupTerminal?.();
-      if (!cleanupTerminal) {
-        unlistenPromise
-          .then((unlisten) => unlisten())
-          .catch(() => {});
-      }
+      resizeObserver.disconnect();
+      unlistenPromise
+        .then((unlisten) => unlisten())
+        .catch(() => {});
+      term.dispose();
     };
   }, [ptyId]);
 

--- a/src/components/Workspace/Terminal.tsx
+++ b/src/components/Workspace/Terminal.tsx
@@ -78,8 +78,8 @@ export function Terminal({ ptyId }: TerminalProps) {
         listenerReady = true;
         flushBufferedStdout();
       })
-      .catch(() => {
-        listenerReady = true;
+      .catch((err: unknown) => {
+        console.error("[Terminal] workspace:stdout subscription failed:", err);
         bufferedStdout.length = 0;
       });
 


### PR DESCRIPTION
## Summary

- initialize the workspace terminal immediately on mount instead of deferring xterm setup behind `requestIdleCallback`
- keep PTY stdout, stdin, and resize wiring attached as soon as the resumed workspace view renders
- simplify the terminal tests to match the immediate initialization path and add a regression check that idle scheduling is not reintroduced

## Why

Resuming a suspended workspace could show a black, non-interactive terminal surface because the frontend deferred terminal initialization. If the idle callback never ran promptly after resume, the terminal container rendered but xterm never opened, so no input or output wiring became active.

## Impact

Resumed workspaces reopen with a live terminal immediately instead of waiting for idle time. This removes the black-screen state reported in issue #192.

## Validation

- `npx vitest run src/components/Workspace/Terminal.test.tsx src/components/Workspace/WorkspaceView.test.tsx`
- `npx oxlint src/components/Workspace/Terminal.tsx src/components/Workspace/Terminal.test.tsx`

Closes #192

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the black, non-interactive terminal after resuming a workspace by initializing `xterm` immediately and keeping PTY wiring active. Resumed workspaces now open with a live terminal and correct initial size. Fixes #192.

- **Bug Fixes**
  - Initialize `xterm` on mount, remove `requestIdleCallback`, fit, and send the proposed initial size to the PTY.
  - Buffer stdout until the `workspace:stdout` subscription resolves; ignore stdout after unmount; keep stdin and resize observers active.
  - Update tests for initial resize, no idle scheduling, stdout buffering and workspace filtering, unmount cleanup, and resize handling.

<sup>Written for commit 624a0ac997a85758306e821397668f27065112b9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Terminal now initializes and becomes ready immediately on mount for faster, deterministic startup.
* **Bug Fixes**
  * Buffered output is held until the terminal is ready and no longer triggers writes after unmount.
  * Resizing consistently reports accurate initial dimensions on mount and logs resize errors.
  * Cleanup on unmount is unconditional to prevent leaked listeners or instances.
* **Tests**
  * Tests updated to validate immediate initialization, stdout buffering behavior, resize signaling, and proper cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->