### PR TITLE
fix(workspace): reconcile orphaned active sessions after restart

### DIFF
--- a/src-tauri/src/cache/workspaces.rs
+++ b/src-tauri/src/cache/workspaces.rs
@@ -213,6 +213,42 @@ pub async fn update_workspace_state(
     require_workspace(row, id)
 }
 
+/// Best-effort self-healing for a workspace that is marked `Active` in the DB
+/// but no longer has a live PTY attached in process memory.
+///
+/// Returns `true` when the workspace was transitioned to `Suspended`,
+/// `false` when it was already in another state or did not exist.
+pub async fn suspend_workspace_if_active(pool: &SqlitePool, id: &str) -> Result<bool, AppError> {
+    let now = now_utc_millis();
+    let result = sqlx::query(
+        "UPDATE workspaces SET state = $1, updated_at = $2 WHERE id = $3 AND state = $4",
+    )
+    .bind(workspace_state_to_str(&WorkspaceState::Suspended))
+    .bind(&now)
+    .bind(id)
+    .bind(workspace_state_to_str(&WorkspaceState::Active))
+    .execute(pool)
+    .await?;
+
+    Ok(result.rows_affected() > 0)
+}
+
+/// Startup reconciliation for process-local PTY state.
+///
+/// PTYs do not survive an app restart, so any persisted `active` workspaces
+/// must be downgraded to `suspended` before the frontend queries them.
+pub async fn suspend_orphaned_active_workspaces(pool: &SqlitePool) -> Result<u64, AppError> {
+    let now = now_utc_millis();
+    let result = sqlx::query("UPDATE workspaces SET state = $1, updated_at = $2 WHERE state = $3")
+        .bind(workspace_state_to_str(&WorkspaceState::Suspended))
+        .bind(&now)
+        .bind(workspace_state_to_str(&WorkspaceState::Active))
+        .execute(pool)
+        .await?;
+
+    Ok(result.rows_affected())
+}
+
 /// Update the Claude Code session ID and `updated_at` timestamp.
 /// Returns the updated workspace via `RETURNING`.
 pub async fn update_claude_session(
@@ -531,6 +567,65 @@ mod tests {
             err.is_err(),
             "guarded transition should reject state mismatch"
         );
+
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_suspend_workspace_if_active_transitions_once() {
+        let (pool, _tmp) = test_pool().await;
+        upsert_repo(&pool, &sample_repo()).await.unwrap();
+
+        let ws = sample_workspace("ws-1", 42);
+        create_workspace(&pool, &ws).await.unwrap();
+
+        let changed = suspend_workspace_if_active(&pool, "ws-1").await.unwrap();
+        assert!(changed, "active workspace should be suspended");
+
+        let updated = get_workspace(&pool, "ws-1").await.unwrap().unwrap();
+        assert_eq!(updated.state, WorkspaceState::Suspended);
+
+        let changed_again = suspend_workspace_if_active(&pool, "ws-1").await.unwrap();
+        assert!(
+            !changed_again,
+            "already-suspended workspace should not report a change"
+        );
+
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_suspend_orphaned_active_workspaces_only_downgrades_active() {
+        let (pool, _tmp) = test_pool().await;
+        upsert_repo(&pool, &sample_repo()).await.unwrap();
+
+        create_workspace(&pool, &sample_workspace("ws-active", 1))
+            .await
+            .unwrap();
+
+        let ws_suspended = sample_workspace("ws-suspended", 2);
+        create_workspace(&pool, &ws_suspended).await.unwrap();
+        update_workspace_state(&pool, "ws-suspended", &WorkspaceState::Suspended, None)
+            .await
+            .unwrap();
+
+        let ws_archived = sample_workspace("ws-archived", 3);
+        create_workspace(&pool, &ws_archived).await.unwrap();
+        update_workspace_state(&pool, "ws-archived", &WorkspaceState::Archived, None)
+            .await
+            .unwrap();
+
+        let changed = suspend_orphaned_active_workspaces(&pool).await.unwrap();
+        assert_eq!(changed, 1, "only active workspaces should be downgraded");
+
+        let active = get_workspace(&pool, "ws-active").await.unwrap().unwrap();
+        assert_eq!(active.state, WorkspaceState::Suspended);
+
+        let suspended = get_workspace(&pool, "ws-suspended").await.unwrap().unwrap();
+        assert_eq!(suspended.state, WorkspaceState::Suspended);
+
+        let archived = get_workspace(&pool, "ws-archived").await.unwrap().unwrap();
+        assert_eq!(archived.state, WorkspaceState::Archived);
 
         pool.close().await;
     }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -14,7 +14,9 @@ use crate::cache::dashboard::{assemble_dashboard_data, compute_dashboard_stats};
 use crate::cache::repos::{get_repo, list_repos, set_local_path, set_repo_enabled};
 use crate::cache::stats::compute_personal_stats;
 use crate::cache::sync::sync_dashboard;
-use crate::cache::workspaces::{get_notes, list_workspaces, update_workspace_state};
+use crate::cache::workspaces::{
+    get_notes, list_workspaces, suspend_workspace_if_active, update_workspace_state,
+};
 use crate::error::AppError;
 use crate::github::auth;
 use crate::github::client::GitHubClient;
@@ -1321,6 +1323,28 @@ pub async fn workspace_cleanup(
     Ok(u32::try_from(archived_ids.len()).unwrap_or(u32::MAX))
 }
 
+async fn reconcile_missing_pty(
+    pool: &SqlitePool,
+    app_handle: &tauri::AppHandle,
+    workspace_id: &str,
+) {
+    match suspend_workspace_if_active(pool, workspace_id).await {
+        Ok(true) => {
+            let payload = crate::types::WorkspaceStateChanged {
+                workspace_id: workspace_id.to_string(),
+                new_state: WorkspaceState::Suspended,
+            };
+            if let Err(e) = app_handle.emit("workspace:state_changed", &payload) {
+                warn!(
+                    "failed to emit workspace:state_changed while reconciling missing PTY for '{workspace_id}': {e}"
+                );
+            }
+        }
+        Ok(false) => {}
+        Err(e) => warn!("failed to reconcile missing PTY for workspace '{workspace_id}': {e}"),
+    }
+}
+
 /// Writes data to a PTY's stdin and touches `last_active_at` for the
 /// associated workspace so the lifecycle auto-suspend timer is reset.
 ///
@@ -1329,12 +1353,14 @@ pub async fn workspace_cleanup(
 pub async fn pty_write(
     pool: tauri::State<'_, SqlitePool>,
     pty_state: tauri::State<'_, PtyManagerState>,
+    app_handle: tauri::AppHandle,
     workspace_id: String,
     data: String,
 ) -> Result<(), String> {
-    let pty_id = pty_state
-        .lookup_pty_by_workspace(&workspace_id)
-        .ok_or_else(|| format!("no PTY for workspace '{workspace_id}'"))?;
+    let Some(pty_id) = pty_state.lookup_pty_by_workspace(&workspace_id) else {
+        reconcile_missing_pty(&pool, &app_handle, &workspace_id).await;
+        return Err(format!("no PTY for workspace '{workspace_id}'"));
+    };
 
     pty_state
         .manager
@@ -1356,14 +1382,17 @@ pub async fn pty_write(
 /// Tauri 2 renames `workspace_id` → `workspaceId` for the JS caller.
 #[tauri::command]
 pub async fn pty_resize(
+    pool: tauri::State<'_, SqlitePool>,
     pty_state: tauri::State<'_, PtyManagerState>,
+    app_handle: tauri::AppHandle,
     workspace_id: String,
     cols: u16,
     rows: u16,
 ) -> Result<(), String> {
-    let pty_id = pty_state
-        .lookup_pty_by_workspace(&workspace_id)
-        .ok_or_else(|| format!("no PTY for workspace '{workspace_id}'"))?;
+    let Some(pty_id) = pty_state.lookup_pty_by_workspace(&workspace_id) else {
+        reconcile_missing_pty(&pool, &app_handle, &workspace_id).await;
+        return Err(format!("no PTY for workspace '{workspace_id}'"));
+    };
 
     pty_state
         .manager

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -199,6 +199,13 @@ pub fn run() {
             let db_path = data_dir.join("prism.db");
             let pool = tauri::async_runtime::block_on(cache::db::init_db(&db_path))
                 .map_err(|e| e.to_string())?;
+            let reconciled = tauri::async_runtime::block_on(
+                cache::workspaces::suspend_orphaned_active_workspaces(&pool),
+            )
+            .map_err(|e| e.to_string())?;
+            if reconciled > 0 {
+                info!("startup: downgraded {reconciled} orphaned active workspace(s) to suspended");
+            }
             let poll_pool = pool.clone();
             app.manage(pool);
 


### PR DESCRIPTION
## Summary

- downgrade persisted `active` workspaces to `suspended` during app startup because PTYs do not survive a Prism restart
- self-heal `pty_write` and `pty_resize` calls that target a workspace with no in-memory PTY by reconciling that workspace back to `suspended`
- add focused tests for the reconciliation helpers and keep the resume PTY regression test green on the new branch

## Why

PR #193 fixed the frontend timing issue, but the backend could still keep a workspace in `active` state after the app restarted. In that case the UI mounted an xterm instance for a workspace that no longer had a PTY mapping in memory, which produced repeated `no PTY for workspace` errors and a black terminal surface.

## Validation

- `cargo test --manifest-path src-tauri/Cargo.toml suspend_orphaned_active_workspaces`
- `cargo test --manifest-path src-tauri/Cargo.toml suspend_workspace_if_active`
- `cargo test --manifest-path src-tauri/Cargo.toml resume_spawns_pty`

## Notes

This is a follow-up to the already merged fix for issue #192. It addresses the restart/orphaned-session path that was still leaving the terminal unusable.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes orphaned terminal sessions after app restart by downgrading persisted active workspaces to suspended and auto-reconciling missing PTYs on write/resize. This prevents black terminals and repeated “no PTY” errors.

- **Bug Fixes**
  - On startup, `suspend_orphaned_active_workspaces` downgrades all persisted `active` workspaces to `suspended`.
  - In `pty_write` and `pty_resize`, if no PTY is found, `suspend_workspace_if_active` reconciles the workspace to `Suspended` and emits `workspace:state_changed`.
  - Added focused tests for both reconciliation helpers and kept the PTY resume test passing.

<sup>Written for commit dda0e58a0eb461b727540881374a4dde2e0ad653. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace state reconciliation at startup to properly handle orphaned active workspaces.
  * Enhanced session recovery logic to automatically suspend workspaces when their terminal sessions are unexpectedly lost, preventing stale state issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->