### PR TITLE
fix(workspace): isolate PTY shell environment (CWE-78)

### DIFF
--- a/src-tauri/src/workspace/pty.rs
+++ b/src-tauri/src/workspace/pty.rs
@@ -41,17 +41,23 @@ fn normalized_shell_name(shell_path: &str) -> String {
 /// Returns shell isolation flags that prevent loading user/system configuration files.
 ///
 /// Different shells use different flags to skip startup files:
-/// - bash / sh (often `bash` in POSIX mode): `--noprofile --norc`
+/// - bash: `--noprofile --norc` (skip `~/.bash_profile` and `~/.bashrc`)
 /// - zsh: `--no-rcs --no-globalrcs` (skip all zshrc files including `/etc/zshrc`)
 /// - fish: `--no-config` (skip `config.fish`)
-/// - Others: no flags (unknown shells get no isolation)
+/// - Others (including bare `sh`): no flags
+///
+/// `sh` deliberately receives no flags. On Debian/Ubuntu and derivatives,
+/// `/bin/sh` is `dash`, which rejects bash-specific flags (`dash: 0: Illegal
+/// option --`) and would prevent the PTY from spawning. On macOS and RHEL
+/// `sh` is bash in POSIX mode, but `dash` is already safer by default
+/// (it does not source user rc files in non-login mode), so the residual
+/// risk on `sh = bash` systems is mitigated by the `HOME` pinning and
+/// dangerous-env-var stripping that runs unconditionally.
 ///
 /// Windows variants like `bash.exe` are handled via [`normalized_shell_name`].
 fn isolation_flags_for_shell(shell_path: &str) -> Vec<&'static str> {
     match normalized_shell_name(shell_path).as_str() {
-        // `sh` is treated as bash because on macOS and many Linux distros
-        // `/bin/sh` is bash invoked in POSIX mode.
-        "bash" | "sh" => vec!["--noprofile", "--norc"],
+        "bash" => vec!["--noprofile", "--norc"],
         "zsh" => vec!["--no-rcs", "--no-globalrcs"],
         "fish" => vec!["--no-config"],
         _ => vec![],
@@ -529,11 +535,19 @@ mod tests {
     }
 
     #[test]
-    fn test_isolation_flags_sh_treated_as_bash() {
-        // /bin/sh is bash in POSIX mode on macOS and many Linux distros,
-        // so we apply the same isolation flags.
+    fn test_isolation_flags_sh_returns_empty() {
+        // /bin/sh is dash on Debian/Ubuntu, which rejects bash flags with
+        // "Illegal option --". Returning empty flags keeps PTY spawn working
+        // on dash systems and is acceptable on bash-as-sh systems because
+        // HOME pinning and env sanitization still apply unconditionally.
         let flags = isolation_flags_for_shell("/bin/sh");
-        assert_eq!(flags, vec!["--noprofile", "--norc"]);
+        assert!(flags.is_empty());
+    }
+
+    #[test]
+    fn test_isolation_flags_dash_returns_empty() {
+        let flags = isolation_flags_for_shell("/bin/dash");
+        assert!(flags.is_empty());
     }
 
     #[test]

--- a/src-tauri/src/workspace/pty.rs
+++ b/src-tauri/src/workspace/pty.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::ffi::OsString;
 use std::io::Write;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -9,63 +10,106 @@ use uuid::Uuid;
 
 use crate::error::AppError;
 
-/// Environment variables that can cause shells to source arbitrary files.
-/// Removed from the PTY environment to prevent code execution from untrusted repositories.
-///
-/// - `BASH_ENV`: bash sources this file in non-interactive mode
-/// - `ENV`: sh/bash sources this file for non-interactive shells
-/// - `ZDOTDIR`: zsh looks for startup files in this directory instead of `$HOME`
+/// Environment variables that can cause shells to source arbitrary files
+/// or alter execution semantics. Removed from the PTY environment to prevent
+/// code execution from untrusted repositories and avoid silent UX breakage.
 const DANGEROUS_ENV_VARS: &[&str] = &[
     "BASH_ENV",       // bash sources this file in non-interactive mode
     "ENV",            // sh/bash sources this file for non-interactive shells
     "ZDOTDIR",        // zsh looks for startup files in this directory
     "PROMPT_COMMAND", // bash executes this before each prompt (interactive)
     "PS0",            // bash 4.4+ expands this before command execution (supports $(...))
+    "SHELLOPTS",      // bash option flags inherited by child shells (e.g. extdebug, noexec)
+    "BASHOPTS",       // bash 4.0+ shopt options inherited by child shells
 ];
+
+/// Normalizes a shell binary name to its canonical lowercase form,
+/// stripping a trailing `.exe` extension when present.
+///
+/// Splits on both `/` and `\` so that Windows-style paths (e.g.
+/// `C:\Program Files\Git\bin\bash.exe`) are handled correctly even on
+/// platforms where `Path` does not recognize backslash as a separator.
+fn normalized_shell_name(shell_path: &str) -> String {
+    let basename = shell_path.rsplit(['/', '\\']).next().unwrap_or("");
+    let lower = basename.to_ascii_lowercase();
+    lower
+        .strip_suffix(".exe")
+        .map(str::to_string)
+        .unwrap_or(lower)
+}
 
 /// Returns shell isolation flags that prevent loading user/system configuration files.
 ///
 /// Different shells use different flags to skip startup files:
-/// - bash: `--noprofile --norc` (skip `~/.bash_profile` and `~/.bashrc`)
+/// - bash / sh (often `bash` in POSIX mode): `--noprofile --norc`
 /// - zsh: `--no-rcs --no-globalrcs` (skip all zshrc files including `/etc/zshrc`)
 /// - fish: `--no-config` (skip `config.fish`)
 /// - Others: no flags (unknown shells get no isolation)
+///
+/// Windows variants like `bash.exe` are handled via [`normalized_shell_name`].
 fn isolation_flags_for_shell(shell_path: &str) -> Vec<&'static str> {
-    let shell_name = Path::new(shell_path)
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("");
-
-    match shell_name {
-        "bash" => vec!["--noprofile", "--norc"],
+    match normalized_shell_name(shell_path).as_str() {
+        // `sh` is treated as bash because on macOS and many Linux distros
+        // `/bin/sh` is bash invoked in POSIX mode.
+        "bash" | "sh" => vec!["--noprofile", "--norc"],
         "zsh" => vec!["--no-rcs", "--no-globalrcs"],
         "fish" => vec!["--no-config"],
         _ => vec![],
     }
 }
 
-/// Configures the command environment to prevent untrusted code execution.
+/// Computes the full set of environment variable names to strip from the
+/// PTY environment, including both the static `DANGEROUS_ENV_VARS` list and
+/// any `BASH_FUNC_*` exported functions discovered in the parent process env.
 ///
-/// - Removes environment variables that cause shells to source arbitrary files
-/// - Explicitly sets `HOME` to the user's real home directory, ensuring the shell
-///   does not look for configuration files in the worktree directory
-fn configure_safe_environment(cmd: &mut CommandBuilder) {
-    for var in DANGEROUS_ENV_VARS {
-        cmd.env_remove(var);
-    }
+/// Uses [`std::env::vars_os`] so that non-UTF-8 environment entries (which
+/// are valid on Unix) do not cause a panic.
+fn env_vars_to_remove() -> Vec<OsString> {
+    let mut vars: Vec<OsString> = DANGEROUS_ENV_VARS.iter().map(OsString::from).collect();
 
     // Bash encodes exported shell functions as BASH_FUNC_<name>%% env vars.
     // These are loaded by the interpreter before --norc/--noprofile take effect,
     // so they must be stripped explicitly.
-    for (key, _) in std::env::vars() {
-        if key.starts_with("BASH_FUNC_") {
-            cmd.env_remove(&key);
+    for (key, _) in std::env::vars_os() {
+        if key.to_string_lossy().starts_with("BASH_FUNC_") {
+            vars.push(key);
         }
     }
 
-    if let Ok(home) = std::env::var("HOME") {
-        cmd.env("HOME", &home);
+    vars
+}
+
+/// Configures the command environment to prevent untrusted code execution.
+///
+/// - Removes environment variables that cause shells to source arbitrary files
+/// - Strips `BASH_FUNC_*` exported functions inherited from the parent process
+/// - Explicitly sets `HOME` to the user's real home directory (preserving the
+///   inherited value via [`std::env::var_os`] to remain non-UTF-8 safe)
+fn configure_safe_environment(cmd: &mut CommandBuilder) {
+    for var in env_vars_to_remove() {
+        cmd.env_remove(&var);
     }
+
+    if let Some(home) = std::env::var_os("HOME") {
+        cmd.env("HOME", home);
+    }
+}
+
+/// Builds a `CommandBuilder` for spawning an isolated PTY shell.
+///
+/// This is the single source of truth for PTY command construction:
+/// applies isolation flags ([`isolation_flags_for_shell`]), sanitizes
+/// the environment ([`configure_safe_environment`]), and pins the working
+/// directory. Extracted from [`PtyManager::spawn`] so that command
+/// construction can be unit-tested for security regressions.
+fn build_isolated_pty_command(shell: &str, cwd: &Path) -> CommandBuilder {
+    let mut cmd = CommandBuilder::new(shell);
+    for flag in isolation_flags_for_shell(shell) {
+        cmd.arg(flag);
+    }
+    configure_safe_environment(&mut cmd);
+    cmd.cwd(cwd);
+    cmd
 }
 
 /// Handle for a single PTY session.
@@ -150,12 +194,7 @@ impl PtyManager {
         } else {
             std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".into())
         };
-        let mut cmd = CommandBuilder::new(&shell);
-        for flag in isolation_flags_for_shell(&shell) {
-            cmd.arg(flag);
-        }
-        configure_safe_environment(&mut cmd);
-        cmd.cwd(cwd);
+        let cmd = build_isolated_pty_command(&shell, cwd);
 
         let child = pair
             .slave
@@ -490,8 +529,16 @@ mod tests {
     }
 
     #[test]
-    fn test_isolation_flags_unknown_shell() {
+    fn test_isolation_flags_sh_treated_as_bash() {
+        // /bin/sh is bash in POSIX mode on macOS and many Linux distros,
+        // so we apply the same isolation flags.
         let flags = isolation_flags_for_shell("/bin/sh");
+        assert_eq!(flags, vec!["--noprofile", "--norc"]);
+    }
+
+    #[test]
+    fn test_isolation_flags_unknown_shell() {
+        let flags = isolation_flags_for_shell("/usr/bin/csh");
         assert!(flags.is_empty());
     }
 
@@ -508,12 +555,85 @@ mod tests {
     }
 
     #[test]
+    fn test_isolation_flags_windows_bash_exe() {
+        // Git for Windows ships bash.exe — strip the .exe to match.
+        let flags = isolation_flags_for_shell("C:\\Program Files\\Git\\bin\\bash.exe");
+        assert_eq!(flags, vec!["--noprofile", "--norc"]);
+    }
+
+    #[test]
+    fn test_isolation_flags_windows_zsh_exe() {
+        let flags = isolation_flags_for_shell("zsh.exe");
+        assert_eq!(flags, vec!["--no-rcs", "--no-globalrcs"]);
+    }
+
+    #[test]
+    fn test_isolation_flags_uppercase_shell_name() {
+        // Windows file systems are case-insensitive; normalize to lowercase.
+        let flags = isolation_flags_for_shell("BASH.EXE");
+        assert_eq!(flags, vec!["--noprofile", "--norc"]);
+    }
+
+    #[test]
     fn test_dangerous_env_vars_contains_known_threats() {
         assert!(DANGEROUS_ENV_VARS.contains(&"BASH_ENV"));
         assert!(DANGEROUS_ENV_VARS.contains(&"ENV"));
         assert!(DANGEROUS_ENV_VARS.contains(&"ZDOTDIR"));
         assert!(DANGEROUS_ENV_VARS.contains(&"PROMPT_COMMAND"));
         assert!(DANGEROUS_ENV_VARS.contains(&"PS0"));
+        assert!(DANGEROUS_ENV_VARS.contains(&"SHELLOPTS"));
+        assert!(DANGEROUS_ENV_VARS.contains(&"BASHOPTS"));
+    }
+
+    #[test]
+    fn test_env_vars_to_remove_includes_all_dangerous_vars() {
+        let removed = env_vars_to_remove();
+        let names: Vec<String> = removed
+            .iter()
+            .map(|v| v.to_string_lossy().into_owned())
+            .collect();
+        for &expected in DANGEROUS_ENV_VARS {
+            assert!(
+                names.contains(&expected.to_string()),
+                "env_vars_to_remove() should include {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_build_isolated_pty_command_strips_dangerous_vars() {
+        // Regression guard: if spawn() ever stops calling configure_safe_environment,
+        // or if a new dangerous var is added without sanitization, this fails.
+        let cmd = build_isolated_pty_command("/bin/bash", Path::new("/tmp"));
+        for &var in DANGEROUS_ENV_VARS {
+            assert!(
+                cmd.get_env(var).is_none(),
+                "{var} must be absent from PTY environment after isolation"
+            );
+        }
+    }
+
+    #[test]
+    fn test_build_isolated_pty_command_sets_cwd() {
+        let cmd = build_isolated_pty_command("/bin/bash", Path::new("/tmp"));
+        let cwd = cmd
+            .get_cwd()
+            .map(|c| c.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        assert_eq!(cwd, "/tmp");
+    }
+
+    #[test]
+    fn test_build_isolated_pty_command_preserves_home_when_set() {
+        // The test runner inherits HOME from the developer/CI environment,
+        // so we expect it to be set in the PTY env after build.
+        if std::env::var_os("HOME").is_some() {
+            let cmd = build_isolated_pty_command("/bin/bash", Path::new("/tmp"));
+            assert!(
+                cmd.get_env("HOME").is_some(),
+                "HOME should be preserved in PTY environment when set in parent"
+            );
+        }
     }
 
     #[tokio::test]

--- a/src-tauri/src/workspace/pty.rs
+++ b/src-tauri/src/workspace/pty.rs
@@ -9,6 +9,65 @@ use uuid::Uuid;
 
 use crate::error::AppError;
 
+/// Environment variables that can cause shells to source arbitrary files.
+/// Removed from the PTY environment to prevent code execution from untrusted repositories.
+///
+/// - `BASH_ENV`: bash sources this file in non-interactive mode
+/// - `ENV`: sh/bash sources this file for non-interactive shells
+/// - `ZDOTDIR`: zsh looks for startup files in this directory instead of `$HOME`
+const DANGEROUS_ENV_VARS: &[&str] = &[
+    "BASH_ENV",       // bash sources this file in non-interactive mode
+    "ENV",            // sh/bash sources this file for non-interactive shells
+    "ZDOTDIR",        // zsh looks for startup files in this directory
+    "PROMPT_COMMAND", // bash executes this before each prompt (interactive)
+    "PS0",            // bash 4.4+ expands this before command execution (supports $(...))
+];
+
+/// Returns shell isolation flags that prevent loading user/system configuration files.
+///
+/// Different shells use different flags to skip startup files:
+/// - bash: `--noprofile --norc` (skip `~/.bash_profile` and `~/.bashrc`)
+/// - zsh: `--no-rcs --no-globalrcs` (skip all zshrc files including `/etc/zshrc`)
+/// - fish: `--no-config` (skip `config.fish`)
+/// - Others: no flags (unknown shells get no isolation)
+fn isolation_flags_for_shell(shell_path: &str) -> Vec<&'static str> {
+    let shell_name = Path::new(shell_path)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("");
+
+    match shell_name {
+        "bash" => vec!["--noprofile", "--norc"],
+        "zsh" => vec!["--no-rcs", "--no-globalrcs"],
+        "fish" => vec!["--no-config"],
+        _ => vec![],
+    }
+}
+
+/// Configures the command environment to prevent untrusted code execution.
+///
+/// - Removes environment variables that cause shells to source arbitrary files
+/// - Explicitly sets `HOME` to the user's real home directory, ensuring the shell
+///   does not look for configuration files in the worktree directory
+fn configure_safe_environment(cmd: &mut CommandBuilder) {
+    for var in DANGEROUS_ENV_VARS {
+        cmd.env_remove(var);
+    }
+
+    // Bash encodes exported shell functions as BASH_FUNC_<name>%% env vars.
+    // These are loaded by the interpreter before --norc/--noprofile take effect,
+    // so they must be stripped explicitly.
+    for (key, _) in std::env::vars() {
+        if key.starts_with("BASH_FUNC_") {
+            cmd.env_remove(&key);
+        }
+    }
+
+    if let Ok(home) = std::env::var("HOME") {
+        cmd.env("HOME", &home);
+    }
+}
+
 /// Handle for a single PTY session.
 ///
 /// Holds the writer and master (per-PTY locks), the child process,
@@ -92,6 +151,10 @@ impl PtyManager {
             std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".into())
         };
         let mut cmd = CommandBuilder::new(&shell);
+        for flag in isolation_flags_for_shell(&shell) {
+            cmd.arg(flag);
+        }
+        configure_safe_environment(&mut cmd);
         cmd.cwd(cwd);
 
         let child = pair
@@ -404,6 +467,53 @@ mod tests {
 
         manager.kill(&id1).unwrap();
         manager.kill(&id3).unwrap();
+    }
+
+    // ── Shell isolation tests ──────────────────────────────────────
+
+    #[test]
+    fn test_isolation_flags_bash() {
+        let flags = isolation_flags_for_shell("/bin/bash");
+        assert_eq!(flags, vec!["--noprofile", "--norc"]);
+    }
+
+    #[test]
+    fn test_isolation_flags_zsh() {
+        let flags = isolation_flags_for_shell("/bin/zsh");
+        assert_eq!(flags, vec!["--no-rcs", "--no-globalrcs"]);
+    }
+
+    #[test]
+    fn test_isolation_flags_fish() {
+        let flags = isolation_flags_for_shell("/usr/bin/fish");
+        assert_eq!(flags, vec!["--no-config"]);
+    }
+
+    #[test]
+    fn test_isolation_flags_unknown_shell() {
+        let flags = isolation_flags_for_shell("/bin/sh");
+        assert!(flags.is_empty());
+    }
+
+    #[test]
+    fn test_isolation_flags_bare_name() {
+        let flags = isolation_flags_for_shell("bash");
+        assert_eq!(flags, vec!["--noprofile", "--norc"]);
+    }
+
+    #[test]
+    fn test_isolation_flags_full_path_with_usr_local() {
+        let flags = isolation_flags_for_shell("/usr/local/bin/zsh");
+        assert_eq!(flags, vec!["--no-rcs", "--no-globalrcs"]);
+    }
+
+    #[test]
+    fn test_dangerous_env_vars_contains_known_threats() {
+        assert!(DANGEROUS_ENV_VARS.contains(&"BASH_ENV"));
+        assert!(DANGEROUS_ENV_VARS.contains(&"ENV"));
+        assert!(DANGEROUS_ENV_VARS.contains(&"ZDOTDIR"));
+        assert!(DANGEROUS_ENV_VARS.contains(&"PROMPT_COMMAND"));
+        assert!(DANGEROUS_ENV_VARS.contains(&"PS0"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Spawned PTY shells now use shell-specific isolation flags to prevent loading configuration files from untrusted repositories (`--noprofile --norc` for bash, `--no-rcs --no-globalrcs` for zsh, `--no-config` for fish)
- Environment sanitized: removes `BASH_ENV`, `ENV`, `ZDOTDIR`, `PROMPT_COMMAND`, `PS0`, and all `BASH_FUNC_*` exported functions that bypass `--norc`
- `HOME` explicitly preserved to user's real home directory

Closes #203

## Security

**CWE-78** — A malicious repository could contain shell startup files (`.bashrc`, `.zshrc`) that execute arbitrary code when a user opens a workspace in PRism. This patch blocks all known shell configuration file loading vectors.

**Vectors mitigated:**
| Vector | Mitigation |
|--------|-----------|
| `.bashrc` / `.bash_profile` sourcing | `--noprofile --norc` flags |
| `.zshrc` / `.zshenv` sourcing | `--no-rcs --no-globalrcs` flags |
| `BASH_ENV` / `ENV` file sourcing | `env_remove` |
| `ZDOTDIR` directory override | `env_remove` |
| `BASH_FUNC_*` exported functions | Prefix-match strip |
| `PROMPT_COMMAND` / `PS0` code execution | `env_remove` |

## Test plan

- [x] `test_isolation_flags_bash` — bash gets `--noprofile --norc`
- [x] `test_isolation_flags_zsh` — zsh gets `--no-rcs --no-globalrcs`
- [x] `test_isolation_flags_fish` — fish gets `--no-config`
- [x] `test_isolation_flags_unknown_shell` — unknown shells get no flags
- [x] `test_isolation_flags_bare_name` — bare "bash" works (not just /bin/bash)
- [x] `test_isolation_flags_full_path_with_usr_local` — /usr/local/bin/zsh works
- [x] `test_dangerous_env_vars_contains_known_threats` — all 5 vars present
- [x] All 7 existing PTY tests pass (spawn, write, resize, kill, multiple, exit)
- [x] `cargo clippy` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolates PTY shells to block repo-controlled RC files and prevent code execution on terminal startup (CWE-78; fixes #203). Applies per-shell no-rc flags, sanitizes the environment, preserves the real HOME, and normalizes Windows shell names.

- **Bug Fixes**
  - Pass isolation flags: bash `--noprofile --norc`, zsh `--no-rcs --no-globalrcs`, fish `--no-config`; `sh`/`dash` and unknown shells get no flags; handle Windows paths, `.exe`, and case.
  - Sanitize env: remove `BASH_ENV`, `ENV`, `ZDOTDIR`, `PROMPT_COMMAND`, `PS0`, `SHELLOPTS`, `BASHOPTS`; strip `BASH_FUNC_*` exports; keep `HOME` to the user’s real home.

- **Refactors**
  - Centralized PTY command construction in `build_isolated_pty_command` to apply flags, env cleanup, and `cwd` in one place.

<sup>Written for commit e1c699e67679875b04cc7bc6986754f3349d0d9f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal launch security: strips dangerous environment entries, applies per-shell isolation flags, preserves HOME when present, and ensures the working directory is respected.

* **Tests**
  * Added unit tests covering isolation-flag selection across shell name formats and verifying unsafe environment variables are removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->