### PR TITLE
perf(ui): subset @fontsource imports to latin (#212)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,10 +1,10 @@
-@import "@fontsource/ibm-plex-sans/400.css";
-@import "@fontsource/ibm-plex-sans/500.css";
-@import "@fontsource/ibm-plex-sans/600.css";
-@import "@fontsource/ibm-plex-sans/700.css";
-@import "@fontsource/ibm-plex-mono/400.css";
-@import "@fontsource/ibm-plex-mono/500.css";
-@import "@fontsource/ibm-plex-mono/600.css";
+@import "@fontsource/ibm-plex-sans/latin-400.css";
+@import "@fontsource/ibm-plex-sans/latin-500.css";
+@import "@fontsource/ibm-plex-sans/latin-600.css";
+@import "@fontsource/ibm-plex-sans/latin-700.css";
+@import "@fontsource/ibm-plex-mono/latin-400.css";
+@import "@fontsource/ibm-plex-mono/latin-500.css";
+@import "@fontsource/ibm-plex-mono/latin-600.css";
 @import "tailwindcss";
 
 @theme {


### PR DESCRIPTION
## Summary

- Swap `@fontsource/ibm-plex-{sans,mono}/{weight}.css` for their `latin-{weight}.css` counterparts in `src/index.css`.
- Drops 5 unused `@font-face` blocks per weight (cyrillic-ext, cyrillic, greek, vietnamese, latin-ext) since PRism is a GitHub review client whose UI chrome is Latin-only.

## Impact

Measured directly on the production Vite bundle:

| Metric | Before | After |
|---|---|---|
| Bundled font files | 84 (7 weights × 6 subsets × 2 formats) | 14 (7 weights × 1 subset × 2 formats) |
| Fetched on first paint | 42 woff2 | 7 woff2 |

The fonts now bundled (from `dist/assets/`) total ~270 KB across all 14 files, well under the previous multi-subset total. This should tighten FCP on cold cache.

## Tradeoff

Non-latin content coming from the GitHub API (PR titles, commit messages, or user display names in Cyrillic, CJK, Arabic, Hebrew, etc.) now falls back to `system-ui` rather than IBM Plex Sans. This is called out explicitly in the issue; a more involved font-loading strategy (dynamic subset loading on detection, or swapping to a Noto variant) would be needed if we want full script coverage back.

## Test plan

- [x] `npm run lint` — oxlint clean
- [x] `npm run format:check` — `src/index.css` clean (pre-existing format drift in other files is unrelated)
- [x] `npm run build` — Vite build succeeds, only `latin-*` font assets emitted
- [x] `npm test` — 548/548 vitest tests pass, no regressions
- [x] Grep: no hardcoded non-latin strings in `src/`
- [x] Grep: no test asserting `font-family` on IBM Plex Sans

Closes #212

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch `@fontsource/ibm-plex-{sans,mono}` imports in `src/index.css` to `latin-*` subsets to cut font payload and speed up first paint. Bundled fonts drop from 84 to 14 files (42 to 7 fetched on first paint); non‑Latin text now falls back to `system-ui` per #212.

<sup>Written for commit 89f8ef9b8a37493beffe66564c68e1b8e8daefb5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated font imports to optimized Latin variants for improved loading performance and reduced file sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->