### PR TITLE
feat(ui): add consistent focus-visible styles for keyboard nav (WCAG 2.4.7)

### DIFF
--- a/src/components/ActivityFeed/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed/ActivityFeed.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FOCUS_RING } from "../../lib/a11y";
 import type { Activity, Repo } from "../../lib/types";
 import { ActivityFeed } from "./ActivityFeed";
 
@@ -45,14 +46,45 @@ function makeActivity(overrides: Partial<Activity> = {}): Activity {
   };
 }
 
-const commentActivity = makeActivity({ id: "act-c", activityType: "comment_added", message: "A comment" });
-const mentionActivity = makeActivity({ id: "act-m", activityType: "comment_added", message: "Hey @alice check this out" });
-const reviewActivity = makeActivity({ id: "act-r", activityType: "review_submitted", message: "Approved" });
-const ciActivity = makeActivity({ id: "act-ci", activityType: "ci_completed", message: "CI passed" });
-const prOpenedActivity = makeActivity({ id: "act-pr", activityType: "pr_opened", message: "Opened PR" });
-const issueClosed = makeActivity({ id: "act-ic", activityType: "issue_closed", message: "Issue closed" });
+const commentActivity = makeActivity({
+  id: "act-c",
+  activityType: "comment_added",
+  message: "A comment",
+});
+const mentionActivity = makeActivity({
+  id: "act-m",
+  activityType: "comment_added",
+  message: "Hey @alice check this out",
+});
+const reviewActivity = makeActivity({
+  id: "act-r",
+  activityType: "review_submitted",
+  message: "Approved",
+});
+const ciActivity = makeActivity({
+  id: "act-ci",
+  activityType: "ci_completed",
+  message: "CI passed",
+});
+const prOpenedActivity = makeActivity({
+  id: "act-pr",
+  activityType: "pr_opened",
+  message: "Opened PR",
+});
+const issueClosed = makeActivity({
+  id: "act-ic",
+  activityType: "issue_closed",
+  message: "Issue closed",
+});
 
-const allActivities = [commentActivity, mentionActivity, reviewActivity, ciActivity, prOpenedActivity, issueClosed];
+const allActivities = [
+  commentActivity,
+  mentionActivity,
+  reviewActivity,
+  ciActivity,
+  prOpenedActivity,
+  issueClosed,
+];
 
 const onMarkAllRead = vi.fn();
 
@@ -62,6 +94,14 @@ beforeEach(() => {
 });
 
 describe("ActivityFeed", () => {
+  it("should apply the focus-visible ring to the search input (WCAG 2.4.7)", () => {
+    render(<ActivityFeed activities={allActivities} onMarkAllRead={onMarkAllRead} />);
+    const search = screen.getByRole("searchbox", { name: /filter activity/i });
+    for (const token of FOCUS_RING.split(" ")) {
+      expect(search).toHaveClass(token);
+    }
+  });
+
   it("should render all activities when no filter is selected", () => {
     render(<ActivityFeed activities={allActivities} onMarkAllRead={onMarkAllRead} />);
 

--- a/src/components/ActivityFeed/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed/ActivityFeed.test.tsx
@@ -97,7 +97,7 @@ describe("ActivityFeed", () => {
   it("should apply the focus-visible ring to the search input (WCAG 2.4.7)", () => {
     render(<ActivityFeed activities={allActivities} onMarkAllRead={onMarkAllRead} />);
     const search = screen.getByRole("searchbox", { name: /filter activity/i });
-    for (const token of FOCUS_RING.split(" ")) {
+    for (const token of FOCUS_RING.trim().split(/\s+/)) {
       expect(search).toHaveClass(token);
     }
   });

--- a/src/components/ActivityFeed/ActivityFeed.tsx
+++ b/src/components/ActivityFeed/ActivityFeed.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { type ReactElement, useMemo, useState } from "react";
 import { FOCUS_RING } from "../../lib/a11y";
 import { listRepos } from "../../lib/tauri";
+import { ACTION_BUTTON_CLASS, FILTER_BUTTON_CLASS } from "../../lib/uiClasses";
 import type { Activity, ActivityType } from "../../lib/types";
 import { EmptyState } from "../atoms/EmptyState";
 import { SectionHead } from "../atoms/SectionHead";
@@ -42,10 +43,6 @@ const FILTER_LABEL: Record<FilterType, string> = {
   mention: "mention",
   other: "other",
 };
-
-const FILTER_BUTTON_CLASS = `${FOCUS_RING} inline-flex min-h-11 min-w-11 items-center justify-center rounded px-3 text-xs leading-none transition-colors`;
-
-const ACTION_BUTTON_CLASS = `${FOCUS_RING} inline-flex min-h-11 items-center rounded px-3 text-xs transition-colors`;
 
 function matchesFilter(activity: Activity, filter: FilterType): boolean {
   if (filter === "all") return true;

--- a/src/components/ActivityFeed/ActivityFeed.tsx
+++ b/src/components/ActivityFeed/ActivityFeed.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { type ReactElement, useMemo, useState } from "react";
+import { FOCUS_RING } from "../../lib/a11y";
 import { listRepos } from "../../lib/tauri";
 import type { Activity, ActivityType } from "../../lib/types";
 import { EmptyState } from "../atoms/EmptyState";
@@ -24,7 +25,14 @@ const FILTER_MATCH: Record<Exclude<FilterType, "all" | "mention">, readonly Acti
 
 const MENTION_PATTERN = /(^|\s)@\w+/;
 
-const FILTER_LABELS = ["all", "comment", "review", "ci", "mention", "other"] as const satisfies readonly FilterType[];
+const FILTER_LABELS = [
+  "all",
+  "comment",
+  "review",
+  "ci",
+  "mention",
+  "other",
+] as const satisfies readonly FilterType[];
 
 const FILTER_LABEL: Record<FilterType, string> = {
   all: "all",
@@ -35,11 +43,9 @@ const FILTER_LABEL: Record<FilterType, string> = {
   other: "other",
 };
 
-const FILTER_BUTTON_CLASS =
-  "inline-flex min-h-11 min-w-11 items-center justify-center rounded px-3 text-xs leading-none transition-colors";
+const FILTER_BUTTON_CLASS = `${FOCUS_RING} inline-flex min-h-11 min-w-11 items-center justify-center rounded px-3 text-xs leading-none transition-colors`;
 
-const ACTION_BUTTON_CLASS =
-  "inline-flex min-h-11 items-center rounded px-3 text-xs transition-colors";
+const ACTION_BUTTON_CLASS = `${FOCUS_RING} inline-flex min-h-11 items-center rounded px-3 text-xs transition-colors`;
 
 function matchesFilter(activity: Activity, filter: FilterType): boolean {
   if (filter === "all") return true;
@@ -110,7 +116,7 @@ export function ActivityFeed({
             onChange={(e) => setSearchQuery(e.target.value)}
             placeholder="Filter activity..."
             aria-label="Filter activity"
-            className="w-full rounded-md border border-border bg-bg px-3 py-2 text-sm text-fg placeholder:text-muted"
+            className={`${FOCUS_RING} w-full rounded-md border border-border bg-bg px-3 py-2 text-sm text-fg placeholder:text-muted`}
           />
 
           <div className="flex min-w-0 flex-wrap items-center gap-1">

--- a/src/components/AuthSetup/AuthSetup.tsx
+++ b/src/components/AuthSetup/AuthSetup.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { openUrl } from "@tauri-apps/plugin-opener";
+import { FOCUS_RING } from "../../lib/a11y";
 import { authSetToken, authGetStatus, authLogout } from "../../lib/tauri";
 
 function extractErrorMessage(error: unknown): string {
@@ -76,7 +77,7 @@ export function AuthSetup() {
         <button
           type="button"
           onClick={() => statusQuery.refetch()}
-          className="rounded-md border border-border bg-bg px-4 py-2 text-sm text-fg transition-colors hover:bg-surface"
+          className={`${FOCUS_RING} rounded-md border border-border bg-bg px-4 py-2 text-sm text-fg transition-colors hover:bg-surface`}
         >
           Retry
         </button>
@@ -93,7 +94,7 @@ export function AuthSetup() {
           type="button"
           onClick={() => logoutMutation.mutate()}
           disabled={logoutMutation.isPending}
-          className="rounded-md border border-border bg-bg px-4 py-2 text-sm text-fg transition-colors hover:bg-surface disabled:opacity-50"
+          className={`${FOCUS_RING} rounded-md border border-border bg-bg px-4 py-2 text-sm text-fg transition-colors hover:bg-surface disabled:opacity-50`}
         >
           Disconnect
         </button>
@@ -118,8 +119,12 @@ export function AuthSetup() {
         <p className="text-xs text-muted">
           <button
             type="button"
-            onClick={() => { openUrl("https://github.com/settings/tokens/new?scopes=repo,read:org&description=PRism").catch(() => {}); }}
-            className="text-accent underline hover:opacity-80"
+            onClick={() => {
+              openUrl(
+                "https://github.com/settings/tokens/new?scopes=repo,read:org&description=PRism",
+              ).catch(() => {});
+            }}
+            className={`${FOCUS_RING} rounded text-accent underline hover:opacity-80`}
           >
             Create a token
           </button>
@@ -137,7 +142,7 @@ export function AuthSetup() {
         onChange={(e) => setToken(e.target.value)}
         placeholder="ghp_..."
         autoComplete="off"
-        className="rounded-md border border-border bg-bg px-3 py-2 font-mono text-sm text-fg placeholder:text-muted"
+        className={`${FOCUS_RING} rounded-md border border-border bg-bg px-3 py-2 font-mono text-sm text-fg placeholder:text-muted`}
       />
 
       {displayError && (
@@ -149,7 +154,7 @@ export function AuthSetup() {
       <button
         type="submit"
         disabled={!token.trim() || setTokenMutation.isPending}
-        className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-bg transition-colors hover:opacity-90 disabled:opacity-50"
+        className={`${FOCUS_RING} rounded-md bg-accent px-4 py-2 text-sm font-medium text-bg transition-colors hover:opacity-90 disabled:opacity-50`}
       >
         {setTokenMutation.isPending ? "Connecting…" : "Connect"}
       </button>

--- a/src/components/CommandPalette/CommandPalette.tsx
+++ b/src/components/CommandPalette/CommandPalette.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState, type ReactElement } from "re
 import { Command } from "cmdk";
 import { useQuery } from "@tanstack/react-query";
 import { useGitHubData } from "../../hooks/useGitHubData";
+import { FOCUS_RING } from "../../lib/a11y";
 import { listRepos } from "../../lib/tauri";
 import { useDashboardStore } from "../../stores/dashboard";
 import { openUrl } from "../../lib/open";
@@ -64,7 +65,9 @@ function PaletteItemRow({ item }: { readonly item: PaletteItem }): ReactElement 
   return (
     <>
       <span className="shrink-0 text-fg/50">#{item.number}</span>
-      <span className="truncate" title={item.title}>{item.title}</span>
+      <span className="truncate" title={item.title}>
+        {item.title}
+      </span>
       <span className="shrink-0 rounded bg-fg/10 px-1.5 py-0.5 text-xs text-fg/60">
         {item.repoName}
       </span>
@@ -93,10 +96,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
     }
 
     return new Map(
-      repos.map((repo) => [
-        repo.id,
-        nameCounts.get(repo.name) === 1 ? repo.name : repo.fullName,
-      ]),
+      repos.map((repo) => [repo.id, nameCounts.get(repo.name) === 1 ? repo.name : repo.fullName]),
     );
   }, [repos]);
 
@@ -114,10 +114,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
     return { prItems: allPrItems, issueItems: allIssueItems };
   }, [dashboard, repoMap]);
 
-  const allItems = useMemo(
-    () => [...prItems, ...issueItems],
-    [prItems, issueItems],
-  );
+  const allItems = useMemo(() => [...prItems, ...issueItems], [prItems, issueItems]);
 
   const findSelectedItem = useCallback(
     () => allItems.find((item) => item.id.toLowerCase() === selectedValue) ?? null,
@@ -154,7 +151,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
       <div className="w-full max-w-lg rounded-lg border border-border bg-bg shadow-xl">
         <Command.Input
           placeholder="Search PRs and issues…"
-          className="w-full border-b border-border bg-transparent px-4 py-3 text-sm text-fg placeholder:text-fg/50"
+          className={`${FOCUS_RING} w-full border-b border-border bg-transparent px-4 py-3 text-sm text-fg placeholder:text-fg/50`}
         />
         <Command.List className="max-h-80 overflow-y-auto p-2">
           <Command.Empty className="px-4 py-6 text-center text-sm text-fg/50">

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import { Component, Fragment, type ErrorInfo, type ReactNode } from "react";
+import { FOCUS_RING } from "../../lib/a11y";
 
 interface ErrorBoundaryProps {
   readonly children: ReactNode;
@@ -35,7 +36,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
           <p className="text-lg font-medium">Something went wrong</p>
           <button
             type="button"
-            className="rounded border border-border px-4 py-2 text-sm hover:bg-bg-hover"
+            className={`${FOCUS_RING} rounded border border-border px-4 py-2 text-sm hover:bg-bg-hover`}
             onClick={() =>
               this.setState((prev) => ({
                 error: null,

--- a/src/components/Issues/IssueCard.tsx
+++ b/src/components/Issues/IssueCard.tsx
@@ -1,4 +1,5 @@
 import type { MouseEvent, ReactElement } from "react";
+import { FOCUS_RING } from "../../lib/a11y";
 import { timeAgo } from "../../lib/timeAgo";
 import type { Issue, IssueState } from "../../lib/types";
 import { LabelTag } from "../atoms/LabelTag";
@@ -26,7 +27,7 @@ export function IssueCard({ issue, repoName, onOpen }: IssueCardProps): ReactEle
       href={issue.url}
       onClick={handleClick}
       aria-label={`Issue #${issue.number}: ${issue.title} (${issue.state})`}
-      className="group/card flex min-w-0 cursor-pointer flex-col gap-1 rounded border border-border px-3 py-2 no-underline hover:bg-surface-hover"
+      className={`${FOCUS_RING} group/card flex min-w-0 cursor-pointer flex-col gap-1 rounded border border-border px-3 py-2 no-underline hover:bg-surface-hover`}
     >
       <div className="flex min-w-0 items-center gap-2">
         <span
@@ -50,7 +51,12 @@ export function IssueCard({ issue, repoName, onOpen }: IssueCardProps): ReactEle
       </div>
 
       <div className="flex min-w-0 items-center gap-2 pl-[18px]">
-        <span className="min-w-0 max-w-[40%] truncate rounded bg-fg/10 px-1.5 py-0.5 text-xs text-fg/60" title={repoName}>{repoName}</span>
+        <span
+          className="min-w-0 max-w-[40%] truncate rounded bg-fg/10 px-1.5 py-0.5 text-xs text-fg/60"
+          title={repoName}
+        >
+          {repoName}
+        </span>
         {issue.labels.length > 0 && (
           <span className="flex min-w-0 items-center gap-1 overflow-hidden">
             {issue.labels.map((label) => (

--- a/src/components/Issues/Issues.test.tsx
+++ b/src/components/Issues/Issues.test.tsx
@@ -79,7 +79,7 @@ describe("Issues", () => {
   it("should apply the focus-visible ring to the search input (WCAG 2.4.7)", () => {
     render(<Issues issues={allIssues} onOpen={onOpen} />);
     const search = screen.getByRole("searchbox", { name: /filter issues/i });
-    for (const token of FOCUS_RING.split(" ")) {
+    for (const token of FOCUS_RING.trim().split(/\s+/)) {
       expect(search).toHaveClass(token);
     }
   });

--- a/src/components/Issues/Issues.test.tsx
+++ b/src/components/Issues/Issues.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FOCUS_RING } from "../../lib/a11y";
 import type { Issue, Repo } from "../../lib/types";
 import { Issues } from "./Issues";
 
@@ -75,6 +76,14 @@ beforeEach(() => {
 });
 
 describe("Issues", () => {
+  it("should apply the focus-visible ring to the search input (WCAG 2.4.7)", () => {
+    render(<Issues issues={allIssues} onOpen={onOpen} />);
+    const search = screen.getByRole("searchbox", { name: /filter issues/i });
+    for (const token of FOCUS_RING.split(" ")) {
+      expect(search).toHaveClass(token);
+    }
+  });
+
   it("should show open issues by default", () => {
     render(<Issues issues={allIssues} onOpen={onOpen} />);
 
@@ -204,8 +213,18 @@ describe("Issues", () => {
   });
 
   it("should always display fullName for all repos", () => {
-    const issue1 = makeIssue({ number: 1, title: "Issue in org-a", state: "open", repoId: "repo-a" });
-    const issue2 = makeIssue({ number: 2, title: "Issue in org-b", state: "open", repoId: "repo-b" });
+    const issue1 = makeIssue({
+      number: 1,
+      title: "Issue in org-a",
+      state: "open",
+      repoId: "repo-a",
+    });
+    const issue2 = makeIssue({
+      number: 2,
+      title: "Issue in org-b",
+      state: "open",
+      repoId: "repo-b",
+    });
     mockUseQuery.mockReturnValue({
       data: [
         makeRepo({ id: "repo-a", org: "org-a", name: "shared", fullName: "org-a/shared" }),
@@ -220,7 +239,12 @@ describe("Issues", () => {
   });
 
   it("should fallback to repoId when repo not found in map", () => {
-    const orphanIssue = makeIssue({ number: 99, title: "Orphan issue", state: "open", repoId: "unknown-repo" });
+    const orphanIssue = makeIssue({
+      number: 99,
+      title: "Orphan issue",
+      state: "open",
+      repoId: "unknown-repo",
+    });
 
     render(<Issues issues={[orphanIssue]} onOpen={onOpen} />);
 

--- a/src/components/Issues/Issues.tsx
+++ b/src/components/Issues/Issues.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { type ReactElement, useEffect, useMemo, useRef, useState } from "react";
 import { FOCUS_RING } from "../../lib/a11y";
 import { listRepos } from "../../lib/tauri";
+import { FILTER_BUTTON_CLASS } from "../../lib/uiClasses";
 import type { Issue } from "../../lib/types";
 import { useRegisterNavigableItems } from "../../hooks/useRegisterNavigableItems";
 import { EmptyState } from "../atoms/EmptyState";
@@ -17,8 +18,6 @@ interface IssuesProps {
 }
 
 type Tab = "open" | "closed";
-
-const FILTER_BUTTON_CLASS = `${FOCUS_RING} inline-flex min-h-11 min-w-11 items-center justify-center rounded px-3 text-xs leading-none transition-colors`;
 
 function isOpen(issue: Issue): boolean {
   return issue.state === "open";

--- a/src/components/Issues/Issues.tsx
+++ b/src/components/Issues/Issues.tsx
@@ -1,6 +1,7 @@
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { useQuery } from "@tanstack/react-query";
 import { type ReactElement, useEffect, useMemo, useRef, useState } from "react";
+import { FOCUS_RING } from "../../lib/a11y";
 import { listRepos } from "../../lib/tauri";
 import type { Issue } from "../../lib/types";
 import { useRegisterNavigableItems } from "../../hooks/useRegisterNavigableItems";
@@ -17,8 +18,7 @@ interface IssuesProps {
 
 type Tab = "open" | "closed";
 
-const FILTER_BUTTON_CLASS =
-  "inline-flex min-h-11 min-w-11 items-center justify-center rounded px-3 text-xs leading-none transition-colors";
+const FILTER_BUTTON_CLASS = `${FOCUS_RING} inline-flex min-h-11 min-w-11 items-center justify-center rounded px-3 text-xs leading-none transition-colors`;
 
 function isOpen(issue: Issue): boolean {
   return issue.state === "open";
@@ -28,11 +28,7 @@ function isClosed(issue: Issue): boolean {
   return issue.state === "closed";
 }
 
-export function Issues({
-  issues,
-  isLoading = false,
-  onOpen,
-}: IssuesProps): ReactElement {
+export function Issues({ issues, isLoading = false, onOpen }: IssuesProps): ReactElement {
   const [tab, setTab] = useState<Tab>("open");
   const [searchQuery, setSearchQuery] = useState("");
   const parentRef = useRef<HTMLDivElement>(null);
@@ -73,10 +69,7 @@ export function Issues({
     useFlushSync: false,
   });
 
-  const navItems = useMemo(
-    () => visible.map((issue) => ({ url: issue.url })),
-    [visible],
-  );
+  const navItems = useMemo(() => visible.map((issue) => ({ url: issue.url })), [visible]);
   useRegisterNavigableItems(navItems);
 
   return (
@@ -112,7 +105,7 @@ export function Issues({
             onChange={(e) => setSearchQuery(e.target.value)}
             placeholder="Filter issues..."
             aria-label="Filter issues"
-            className="w-full rounded-md border border-border bg-bg px-3 py-2 text-sm text-fg placeholder:text-muted"
+            className={`${FOCUS_RING} w-full rounded-md border border-border bg-bg px-3 py-2 text-sm text-fg placeholder:text-muted`}
           />
 
           <div className="flex gap-1" role="group" aria-label="Filter by state">
@@ -145,17 +138,17 @@ export function Issues({
           {visible.length === 0 ? (
             <EmptyState icon="◎" message="No issues to display" />
           ) : (
-            <div
-              ref={parentRef}
-              className="max-h-[600px] overflow-y-auto"
-            >
+            <div ref={parentRef} className="max-h-[600px] overflow-y-auto">
               <div
                 className="relative w-full"
                 style={{ height: `${virtualizer.getTotalSize()}px` }}
               >
                 {virtualizer.getVirtualItems().map((virtualItem) => {
                   const issue = visible[virtualItem.index];
-                  if (!issue) return <div key={virtualItem.key} style={{ height: `${virtualItem.size}px` }} />;
+                  if (!issue)
+                    return (
+                      <div key={virtualItem.key} style={{ height: `${virtualItem.size}px` }} />
+                    );
                   return (
                     <div
                       key={virtualItem.key}

--- a/src/components/MyPRs/MyPRs.test.tsx
+++ b/src/components/MyPRs/MyPRs.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FOCUS_RING } from "../../lib/a11y";
 import type { PullRequestWithReview, Repo } from "../../lib/types";
 import { MyPRs } from "./MyPRs";
 
@@ -79,6 +80,14 @@ beforeEach(() => {
 });
 
 describe("MyPRs", () => {
+  it("should apply the focus-visible ring to the search input (WCAG 2.4.7)", () => {
+    render(<MyPRs prs={allPrs} onOpen={onOpen} />);
+    const search = screen.getByRole("searchbox", { name: /filter prs/i });
+    for (const token of FOCUS_RING.split(" ")) {
+      expect(search).toHaveClass(token);
+    }
+  });
+
   it("should show open PRs by default", () => {
     render(<MyPRs prs={allPrs} onOpen={onOpen} />);
 

--- a/src/components/MyPRs/MyPRs.test.tsx
+++ b/src/components/MyPRs/MyPRs.test.tsx
@@ -83,7 +83,7 @@ describe("MyPRs", () => {
   it("should apply the focus-visible ring to the search input (WCAG 2.4.7)", () => {
     render(<MyPRs prs={allPrs} onOpen={onOpen} />);
     const search = screen.getByRole("searchbox", { name: /filter prs/i });
-    for (const token of FOCUS_RING.split(" ")) {
+    for (const token of FOCUS_RING.trim().split(/\s+/)) {
       expect(search).toHaveClass(token);
     }
   });

--- a/src/components/MyPRs/MyPRs.tsx
+++ b/src/components/MyPRs/MyPRs.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { type ReactElement, useEffect, useMemo, useRef, useState } from "react";
+import { FOCUS_RING } from "../../lib/a11y";
 import { listRepos } from "../../lib/tauri";
 import type { PullRequestWithReview } from "../../lib/types";
 import { useRegisterNavigableItems } from "../../hooks/useRegisterNavigableItems";
@@ -25,8 +26,7 @@ interface MyPRsProps {
 
 type Tab = "open" | "merged";
 
-const FILTER_BUTTON_CLASS =
-  "inline-flex min-h-11 min-w-11 items-center justify-center rounded px-3 text-xs leading-none transition-colors";
+const FILTER_BUTTON_CLASS = `${FOCUS_RING} inline-flex min-h-11 min-w-11 items-center justify-center rounded px-3 text-xs leading-none transition-colors`;
 
 function isOpen(pr: PullRequestWithReview): boolean {
   const { state } = pr.pullRequest;
@@ -58,12 +58,9 @@ export function MyPRs({
     if (normalizedQuery.length === 0) return true;
     const repoName = repoMap.get(pr.pullRequest.repoId) ?? pr.pullRequest.repoId;
 
-    return [
-      pr.pullRequest.title,
-      pr.pullRequest.author,
-      repoName,
-      ...pr.pullRequest.labels,
-    ].some((value) => value.toLowerCase().includes(normalizedQuery));
+    return [pr.pullRequest.title, pr.pullRequest.author, repoName, ...pr.pullRequest.labels].some(
+      (value) => value.toLowerCase().includes(normalizedQuery),
+    );
   };
 
   const matchingPrs = prs.filter(matchesSearch);
@@ -75,10 +72,7 @@ export function MyPRs({
     listRef.current?.scrollTo({ top: 0, behavior: "instant" });
   }, [tab, normalizedQuery]);
 
-  const navItems = useMemo(
-    () => visible.map((pr) => ({ url: pr.pullRequest.url })),
-    [visible],
-  );
+  const navItems = useMemo(() => visible.map((pr) => ({ url: pr.pullRequest.url })), [visible]);
   useRegisterNavigableItems(navItems);
 
   return (
@@ -117,7 +111,7 @@ export function MyPRs({
             onChange={(e) => setSearchQuery(e.target.value)}
             placeholder="Filter PRs..."
             aria-label="Filter PRs"
-            className="w-full rounded-md border border-border bg-bg px-3 py-2 text-sm text-fg placeholder:text-muted"
+            className={`${FOCUS_RING} w-full rounded-md border border-border bg-bg px-3 py-2 text-sm text-fg placeholder:text-muted`}
           />
 
           <div className="flex gap-1" role="group" aria-label="Filter by state">
@@ -150,10 +144,7 @@ export function MyPRs({
           {visible.length === 0 ? (
             <EmptyState icon="↗" message="No pull requests to display" />
           ) : (
-            <div
-              ref={listRef}
-              className="max-h-[600px] overflow-y-auto"
-            >
+            <div ref={listRef} className="max-h-[600px] overflow-y-auto">
               <div className="flex flex-col gap-1">
                 {visible.map((pr) => (
                   <MyPrCard

--- a/src/components/MyPRs/MyPRs.tsx
+++ b/src/components/MyPRs/MyPRs.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { type ReactElement, useEffect, useMemo, useRef, useState } from "react";
 import { FOCUS_RING } from "../../lib/a11y";
 import { listRepos } from "../../lib/tauri";
+import { FILTER_BUTTON_CLASS } from "../../lib/uiClasses";
 import type { PullRequestWithReview } from "../../lib/types";
 import { useRegisterNavigableItems } from "../../hooks/useRegisterNavigableItems";
 import { EmptyState } from "../atoms/EmptyState";
@@ -25,8 +26,6 @@ interface MyPRsProps {
 }
 
 type Tab = "open" | "merged";
-
-const FILTER_BUTTON_CLASS = `${FOCUS_RING} inline-flex min-h-11 min-w-11 items-center justify-center rounded px-3 text-xs leading-none transition-colors`;
 
 function isOpen(pr: PullRequestWithReview): boolean {
   const { state } = pr.pullRequest;

--- a/src/components/MyPRs/MyPrCard.tsx
+++ b/src/components/MyPRs/MyPrCard.tsx
@@ -1,4 +1,5 @@
 import { type ReactElement, useState } from "react";
+import { FOCUS_RING } from "../../lib/a11y";
 import { timeAgo } from "../../lib/timeAgo";
 import type { CiStatus, PullRequestWithReview } from "../../lib/types";
 import { CI } from "../atoms/CI";
@@ -40,19 +41,20 @@ interface ReviewDot {
   readonly color: string;
 }
 
-function buildReviewDots(reviewSummary: PullRequestWithReview["reviewSummary"]): readonly ReviewDot[] {
+function buildReviewDots(
+  reviewSummary: PullRequestWithReview["reviewSummary"],
+): readonly ReviewDot[] {
   const dots: ReviewDot[] = [];
-  for (let i = 0; i < reviewSummary.approved; i++) dots.push({ key: `approved-${i}`, color: "bg-green" });
-  for (let i = 0; i < reviewSummary.changesRequested; i++) dots.push({ key: `changes-${i}`, color: "bg-red" });
-  for (let i = 0; i < reviewSummary.pending; i++) dots.push({ key: `pending-${i}`, color: "bg-dim" });
+  for (let i = 0; i < reviewSummary.approved; i++)
+    dots.push({ key: `approved-${i}`, color: "bg-green" });
+  for (let i = 0; i < reviewSummary.changesRequested; i++)
+    dots.push({ key: `changes-${i}`, color: "bg-red" });
+  for (let i = 0; i < reviewSummary.pending; i++)
+    dots.push({ key: `pending-${i}`, color: "bg-dim" });
   return dots;
 }
 
-export function MyPrCard({
-  data,
-  onOpen,
-  onWorkspaceAction,
-}: MyPrCardProps): ReactElement {
+export function MyPrCard({ data, onOpen, onWorkspaceAction }: MyPrCardProps): ReactElement {
   const { pullRequest: pr, workspace } = data;
   const merged = pr.state === "merged";
   const [loading, setLoading] = useState(false);
@@ -86,7 +88,7 @@ export function MyPrCard({
         href={pr.url}
         onClick={handleClick}
         aria-label={`PR #${pr.number}: ${pr.title}`}
-        className="flex min-w-0 flex-1 cursor-pointer items-center gap-3 no-underline"
+        className={`${FOCUS_RING} flex min-w-0 flex-1 cursor-pointer items-center gap-3 rounded no-underline`}
       >
         <span
           data-testid="ci-dot"
@@ -132,14 +134,16 @@ export function MyPrCard({
         </div>
       </a>
 
-      {onWorkspaceAction && (pr.state === "open" || pr.state === "draft") && ((workspace && workspace.state !== "archived") || pr.headRefName) && (
-        <WsBadge
-          state={workspace?.state === "archived" ? undefined : workspace?.state}
-          loading={loading}
-          onClick={handleWorkspace}
-          ariaLabel={`${workspace?.state === "active" ? "Resume" : workspace?.state === "suspended" ? "Wake" : "Open"} workspace for PR #${pr.number}`}
-        />
-      )}
+      {onWorkspaceAction &&
+        (pr.state === "open" || pr.state === "draft") &&
+        ((workspace && workspace.state !== "archived") || pr.headRefName) && (
+          <WsBadge
+            state={workspace?.state === "archived" ? undefined : workspace?.state}
+            loading={loading}
+            onClick={handleWorkspace}
+            ariaLabel={`${workspace?.state === "active" ? "Resume" : workspace?.state === "suspended" ? "Wake" : "Open"} workspace for PR #${pr.number}`}
+          />
+        )}
     </div>
   );
 }

--- a/src/components/Overview/Overview.tsx
+++ b/src/components/Overview/Overview.tsx
@@ -1,6 +1,7 @@
 import { type ReactElement, useCallback, useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useGitHubData } from "../../hooks/useGitHubData";
+import { FOCUS_RING } from "../../lib/a11y";
 import { markAllActivityRead, openWorkspace, resumeWorkspace } from "../../lib/tauri";
 import { useWorkspacesStore } from "../../stores/workspaces";
 import { useDashboardStore } from "../../stores/dashboard";
@@ -214,7 +215,7 @@ export function Overview(): ReactElement {
               aria-expanded={isActivityExpanded}
               aria-controls={isActivityExpanded ? "overview-activity-content" : undefined}
               onClick={() => setIsActivityExpanded((current) => !current)}
-              className="rounded-full border border-border px-3 py-1 text-xs text-dim transition-colors hover:border-foreground hover:text-foreground"
+              className={`${FOCUS_RING} rounded-full border border-border px-3 py-1 text-xs text-dim transition-colors hover:border-foreground hover:text-foreground`}
             >
               {isActivityExpanded ? "Collapse" : "Expand"}
             </button>

--- a/src/components/ReviewQueue/ReviewCard.tsx
+++ b/src/components/ReviewQueue/ReviewCard.tsx
@@ -1,4 +1,5 @@
 import { type ReactElement, useState } from "react";
+import { FOCUS_RING } from "../../lib/a11y";
 import { timeAgo } from "../../lib/timeAgo";
 import type { PullRequestWithReview } from "../../lib/types";
 import { CI } from "../atoms/CI";
@@ -18,11 +19,7 @@ interface ReviewCardProps {
   }) => void;
 }
 
-export function ReviewCard({
-  data,
-  onOpen,
-  onWorkspaceAction,
-}: ReviewCardProps): ReactElement {
+export function ReviewCard({ data, onOpen, onWorkspaceAction }: ReviewCardProps): ReactElement {
   const { pullRequest: pr, workspace } = data;
   const [loading, setLoading] = useState(false);
 
@@ -51,7 +48,7 @@ export function ReviewCard({
         href={pr.url}
         onClick={handleClick}
         aria-label={`PR #${pr.number}: ${pr.title} by ${pr.author}`}
-        className="flex min-w-0 flex-1 cursor-pointer items-center gap-3 no-underline"
+        className={`${FOCUS_RING} flex min-w-0 flex-1 cursor-pointer items-center gap-3 rounded no-underline`}
       >
         <PriorityBar priority={pr.priority} />
 
@@ -74,14 +71,16 @@ export function ReviewCard({
         </div>
       </a>
 
-      {onWorkspaceAction && pr.state === "open" && ((workspace && workspace.state !== "archived") || pr.headRefName) && (
-        <WsBadge
-          state={workspace?.state === "archived" ? undefined : workspace?.state}
-          loading={loading}
-          onClick={handleWorkspace}
-          ariaLabel={`${workspace?.state === "active" ? "Resume" : workspace?.state === "suspended" ? "Wake" : "Open"} workspace for PR #${pr.number}`}
-        />
-      )}
+      {onWorkspaceAction &&
+        pr.state === "open" &&
+        ((workspace && workspace.state !== "archived") || pr.headRefName) && (
+          <WsBadge
+            state={workspace?.state === "archived" ? undefined : workspace?.state}
+            loading={loading}
+            onClick={handleWorkspace}
+            ariaLabel={`${workspace?.state === "active" ? "Resume" : workspace?.state === "suspended" ? "Wake" : "Open"} workspace for PR #${pr.number}`}
+          />
+        )}
     </div>
   );
 }

--- a/src/components/ReviewQueue/ReviewQueue.tsx
+++ b/src/components/ReviewQueue/ReviewQueue.tsx
@@ -1,4 +1,5 @@
 import { type ReactElement, useEffect, useMemo } from "react";
+import { FOCUS_RING } from "../../lib/a11y";
 import type { Priority, PullRequestWithReview } from "../../lib/types";
 import { useRegisterNavigableItems } from "../../hooks/useRegisterNavigableItems";
 import { useDashboardStore } from "../../stores/dashboard";
@@ -33,34 +34,23 @@ type PriorityFilter = "all" | Priority;
 
 const FOCUS_PRIORITIES: readonly Priority[] = ["critical", "high"];
 
-const PRIORITY_FILTERS: readonly PriorityFilter[] = [
-  "all",
-  "critical",
-  "high",
-  "medium",
-  "low",
-];
+const PRIORITY_FILTERS: readonly PriorityFilter[] = ["all", "critical", "high", "medium", "low"];
 
-const FILTER_BUTTON_CLASS =
-  "inline-flex min-h-11 min-w-11 items-center justify-center rounded px-3 text-xs leading-none transition-colors";
+const FILTER_BUTTON_CLASS = `${FOCUS_RING} inline-flex min-h-11 min-w-11 items-center justify-center rounded px-3 text-xs leading-none transition-colors`;
 
-const INLINE_CONTROL_CLASS =
-  "min-h-11 rounded px-3 text-xs transition-colors";
+const INLINE_CONTROL_CLASS = `${FOCUS_RING} min-h-11 rounded px-3 text-xs transition-colors`;
 
 function sortByPriority(
   reviews: readonly PullRequestWithReview[],
 ): readonly PullRequestWithReview[] {
   return [...reviews].sort(
     (a, b) =>
-      PRIORITY_ORDER[b.pullRequest.priority] -
-        PRIORITY_ORDER[a.pullRequest.priority] ||
+      PRIORITY_ORDER[b.pullRequest.priority] - PRIORITY_ORDER[a.pullRequest.priority] ||
       b.pullRequest.updatedAt.localeCompare(a.pullRequest.updatedAt),
   );
 }
 
-function getUniqueRepos(
-  reviews: readonly PullRequestWithReview[],
-): readonly string[] {
+function getUniqueRepos(reviews: readonly PullRequestWithReview[]): readonly string[] {
   return [...new Set(reviews.map((r) => r.pullRequest.repoId))].sort();
 }
 
@@ -94,10 +84,8 @@ export function ReviewQueue({
 
   const sorted = useMemo(() => {
     const filtered = reviews.filter((r) => {
-      if (focusMode && !FOCUS_PRIORITIES.includes(r.pullRequest.priority))
-        return false;
-      if (priorityFilter !== "all" && r.pullRequest.priority !== priorityFilter)
-        return false;
+      if (focusMode && !FOCUS_PRIORITIES.includes(r.pullRequest.priority)) return false;
+      if (priorityFilter !== "all" && r.pullRequest.priority !== priorityFilter) return false;
       if (repoFilter && r.pullRequest.repoId !== repoFilter) return false;
       return true;
     });
@@ -139,10 +127,7 @@ export function ReviewQueue({
             ))}
           </div>
 
-          <div
-            data-testid="review-queue-loading"
-            className="flex flex-col gap-1"
-          >
+          <div data-testid="review-queue-loading" className="flex flex-col gap-1">
             {Array.from({ length: 3 }, (_, index) => (
               <CardSkeleton
                 key={`review-skeleton-${index}`}
@@ -162,9 +147,7 @@ export function ReviewQueue({
                   key={f}
                   type="button"
                   aria-pressed={priorityFilter === f}
-                  onClick={() =>
-                    setFilter({ priority: f === "all" ? undefined : f })
-                  }
+                  onClick={() => setFilter({ priority: f === "all" ? undefined : f })}
                   className={`${FILTER_BUTTON_CLASS} ${
                     priorityFilter === f
                       ? "bg-accent text-bg font-semibold hover:bg-accent/80"
@@ -180,9 +163,7 @@ export function ReviewQueue({
               <select
                 aria-label="Filter by repo"
                 value={repoFilter}
-                onChange={(e) =>
-                  setFilter({ repo: e.target.value || undefined })
-                }
+                onChange={(e) => setFilter({ repo: e.target.value || undefined })}
                 className={`cursor-pointer border border-border bg-surface text-foreground hover:border-foreground ${INLINE_CONTROL_CLASS}`}
               >
                 <option value="">All repos</option>

--- a/src/components/ReviewQueue/ReviewQueue.tsx
+++ b/src/components/ReviewQueue/ReviewQueue.tsx
@@ -1,5 +1,6 @@
 import { type ReactElement, useEffect, useMemo } from "react";
 import { FOCUS_RING } from "../../lib/a11y";
+import { FILTER_BUTTON_CLASS } from "../../lib/uiClasses";
 import type { Priority, PullRequestWithReview } from "../../lib/types";
 import { useRegisterNavigableItems } from "../../hooks/useRegisterNavigableItems";
 import { useDashboardStore } from "../../stores/dashboard";
@@ -35,8 +36,6 @@ type PriorityFilter = "all" | Priority;
 const FOCUS_PRIORITIES: readonly Priority[] = ["critical", "high"];
 
 const PRIORITY_FILTERS: readonly PriorityFilter[] = ["all", "critical", "high", "medium", "low"];
-
-const FILTER_BUTTON_CLASS = `${FOCUS_RING} inline-flex min-h-11 min-w-11 items-center justify-center rounded px-3 text-xs leading-none transition-colors`;
 
 const INLINE_CONTROL_CLASS = `${FOCUS_RING} min-h-11 rounded px-3 text-xs transition-colors`;
 

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, type ReactElement } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { FOCUS_RING } from "../../lib/a11y";
 import { getConfig, setConfig, listRepos, setRepoEnabled } from "../../lib/tauri";
 import type { PartialAppConfig, Repo } from "../../lib/types";
 import { AuthSetup } from "../AuthSetup/AuthSetup";
@@ -69,7 +70,7 @@ function NumberField({
         value={draft}
         onChange={(e) => setDraft(e.target.value)}
         onBlur={handleBlur}
-        className="bg-surface border-border w-24 rounded border px-2 py-1 font-mono text-sm text-white"
+        className={`${FOCUS_RING} bg-surface border-border w-24 rounded border px-2 py-1 font-mono text-sm text-white`}
       />
     </label>
   );
@@ -92,7 +93,7 @@ function RepoRow({ repo, disabled, onToggle }: RepoRowProps): ReactElement {
         checked={repo.enabled}
         disabled={disabled}
         onChange={() => onToggle(repo.id, !repo.enabled)}
-        className="accent-accent h-4 w-4"
+        className={`${FOCUS_RING} accent-accent h-4 w-4`}
       />
     </label>
   );
@@ -155,8 +156,7 @@ function getRepoBatchUpdateErrorMessage(err: unknown): string {
 }
 
 const sectionClass = "flex flex-col gap-3 border-b border-border pb-4";
-const controlButtonClass =
-  "rounded border border-border px-2 py-1 text-xs font-medium text-dim transition-colors hover:border-accent hover:text-white disabled:cursor-not-allowed disabled:opacity-50";
+const controlButtonClass = `${FOCUS_RING} rounded border border-border px-2 py-1 text-xs font-medium text-dim transition-colors hover:border-accent hover:text-white disabled:cursor-not-allowed disabled:opacity-50`;
 
 export function Settings(): ReactElement {
   const queryClient = useQueryClient();
@@ -291,7 +291,7 @@ export function Settings(): ReactElement {
           placeholder="Filter repositories..."
           value={repoSearch}
           onChange={(e) => setRepoSearch(e.target.value)}
-          className="bg-surface border-border rounded border px-2 py-1 text-sm text-white placeholder:text-muted outline-none"
+          className={`${FOCUS_RING} bg-surface border-border rounded border px-2 py-1 text-sm text-white placeholder:text-muted`}
         />
         <div className="flex flex-wrap items-center gap-2">
           <button

--- a/src/components/Sidebar/NavItem.test.tsx
+++ b/src/components/Sidebar/NavItem.test.tsx
@@ -1,13 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { FOCUS_RING } from "../../lib/a11y";
 import { NavItem } from "./NavItem";
 
 describe("NavItem", () => {
   it("should render label", () => {
-    render(
-      <NavItem label="Overview" view="overview" isActive={false} onClick={vi.fn()} />,
-    );
+    render(<NavItem label="Overview" view="overview" isActive={false} onClick={vi.fn()} />);
     expect(screen.getByText("Overview")).toBeInTheDocument();
   });
 
@@ -19,33 +18,25 @@ describe("NavItem", () => {
   });
 
   it("should not render count when zero", () => {
-    render(
-      <NavItem label="Issues" view="issues" count={0} isActive={false} onClick={vi.fn()} />,
-    );
+    render(<NavItem label="Issues" view="issues" count={0} isActive={false} onClick={vi.fn()} />);
     expect(screen.queryByText("0")).not.toBeInTheDocument();
   });
 
   it("should highlight when active", () => {
-    render(
-      <NavItem label="Overview" view="overview" isActive={true} onClick={vi.fn()} />,
-    );
+    render(<NavItem label="Overview" view="overview" isActive={true} onClick={vi.fn()} />);
     const button = screen.getByRole("button", { name: /overview/i });
     expect(button).toHaveAttribute("aria-current", "page");
   });
 
   it("should not highlight when inactive", () => {
-    render(
-      <NavItem label="Overview" view="overview" isActive={false} onClick={vi.fn()} />,
-    );
+    render(<NavItem label="Overview" view="overview" isActive={false} onClick={vi.fn()} />);
     const button = screen.getByRole("button", { name: /overview/i });
     expect(button).not.toHaveAttribute("aria-current");
   });
 
   it("should call onClick with view when clicked", async () => {
     const handleClick = vi.fn();
-    render(
-      <NavItem label="Reviews" view="reviews" isActive={false} onClick={handleClick} />,
-    );
+    render(<NavItem label="Reviews" view="reviews" isActive={false} onClick={handleClick} />);
     await userEvent.click(screen.getByRole("button", { name: /reviews/i }));
     expect(handleClick).toHaveBeenCalledWith("reviews");
   });
@@ -59,19 +50,23 @@ describe("NavItem", () => {
   });
 
   it("should not have aria-label when count is absent", () => {
-    render(
-      <NavItem label="Overview" view="overview" isActive={false} onClick={vi.fn()} />,
-    );
+    render(<NavItem label="Overview" view="overview" isActive={false} onClick={vi.fn()} />);
     const button = screen.getByRole("button");
     expect(button).not.toHaveAttribute("aria-label");
   });
 
   it("should not have aria-label when count is zero", () => {
-    render(
-      <NavItem label="Issues" view="issues" count={0} isActive={false} onClick={vi.fn()} />,
-    );
+    render(<NavItem label="Issues" view="issues" count={0} isActive={false} onClick={vi.fn()} />);
     const button = screen.getByRole("button");
     expect(button).not.toHaveAttribute("aria-label");
+  });
+
+  it("should apply the focus-visible ring for keyboard accessibility (WCAG 2.4.7)", () => {
+    render(<NavItem label="Overview" view="overview" isActive={false} onClick={vi.fn()} />);
+    const button = screen.getByRole("button", { name: /overview/i });
+    for (const token of FOCUS_RING.split(" ")) {
+      expect(button).toHaveClass(token);
+    }
   });
 
   it("should pass through keyboard and focus props", async () => {

--- a/src/components/Sidebar/NavItem.test.tsx
+++ b/src/components/Sidebar/NavItem.test.tsx
@@ -64,7 +64,7 @@ describe("NavItem", () => {
   it("should apply the focus-visible ring for keyboard accessibility (WCAG 2.4.7)", () => {
     render(<NavItem label="Overview" view="overview" isActive={false} onClick={vi.fn()} />);
     const button = screen.getByRole("button", { name: /overview/i });
-    for (const token of FOCUS_RING.split(" ")) {
+    for (const token of FOCUS_RING.trim().split(/\s+/)) {
       expect(button).toHaveClass(token);
     }
   });

--- a/src/components/Sidebar/NavItem.tsx
+++ b/src/components/Sidebar/NavItem.tsx
@@ -1,9 +1,5 @@
-import type {
-  FocusEventHandler,
-  KeyboardEventHandler,
-  ReactElement,
-  Ref,
-} from "react";
+import type { FocusEventHandler, KeyboardEventHandler, ReactElement, Ref } from "react";
+import { FOCUS_RING } from "../../lib/a11y";
 import type { DashboardView } from "../../stores/dashboard";
 
 interface NavItemProps {
@@ -39,7 +35,7 @@ export function NavItem({
       aria-current={isActive ? "page" : undefined}
       aria-label={count !== undefined && count > 0 ? `${label} (${count})` : undefined}
       tabIndex={tabIndex}
-      className={`flex w-full items-center justify-between rounded px-2 py-1.5 text-left text-sm ${
+      className={`${FOCUS_RING} flex w-full items-center justify-between rounded px-2 py-1.5 text-left text-sm ${
         isActive
           ? "bg-surface text-white hover:bg-surface-hover"
           : "text-dim hover:bg-surface-hover hover:text-foreground"

--- a/src/components/Sidebar/RepoList.tsx
+++ b/src/components/Sidebar/RepoList.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import type { ReactElement } from "react";
+import { FOCUS_RING } from "../../lib/a11y";
 import type { Repo } from "../../lib/types";
 import { useDebounce } from "../../hooks/useDebounce";
 
@@ -48,7 +49,7 @@ export function RepoList({
           placeholder="Filter repos..."
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
-          className="w-full bg-transparent border-b border-border text-xs text-foreground placeholder:text-muted px-2 py-1 outline-none"
+          className={`${FOCUS_RING} w-full bg-transparent border-b border-border text-xs text-foreground placeholder:text-muted px-2 py-1`}
         />
         {(onSelectAll !== undefined || onDeselectAll !== undefined) && (
           <div className="flex shrink-0 gap-1 pl-1">
@@ -56,7 +57,7 @@ export function RepoList({
               <button
                 type="button"
                 onClick={onSelectAll}
-                className="text-[10px] text-dim hover:text-foreground"
+                className={`${FOCUS_RING} rounded text-[10px] text-dim hover:text-foreground`}
               >
                 Select all
               </button>
@@ -65,7 +66,7 @@ export function RepoList({
               <button
                 type="button"
                 onClick={onDeselectAll}
-                className="text-[10px] text-dim hover:text-foreground"
+                className={`${FOCUS_RING} rounded text-[10px] text-dim hover:text-foreground`}
               >
                 Deselect all
               </button>
@@ -88,7 +89,7 @@ export function RepoList({
                 checked={repo.enabled}
                 onChange={() => onToggleRepo(repo.id, !repo.enabled)}
                 aria-label={`Enable ${repo.fullName} repository`}
-                className="accent-accent"
+                className={`${FOCUS_RING} accent-accent`}
               />
               <span>{repo.fullName}</span>
             </label>
@@ -98,7 +99,7 @@ export function RepoList({
             <button
               type="button"
               onClick={() => setShowAll(true)}
-              className="px-2 py-1 text-left text-xs text-dim hover:text-foreground"
+              className={`${FOCUS_RING} rounded px-2 py-1 text-left text-xs text-dim hover:text-foreground`}
             >
               Show {hiddenCount} more
             </button>

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -5,6 +5,7 @@ import { useDashboardStore } from "../../stores/dashboard";
 import type { DashboardView } from "../../stores/dashboard";
 import { useWorkspacesStore } from "../../stores/workspaces";
 import { useGitHubData } from "../../hooks/useGitHubData";
+import { FOCUS_RING } from "../../lib/a11y";
 import { listRepos, setRepoEnabled, authGetStatus } from "../../lib/tauri";
 import { NavItem } from "./NavItem";
 import { WorkspaceList } from "./WorkspaceList";
@@ -13,7 +14,12 @@ import { RepoList } from "./RepoList";
 interface NavEntry {
   readonly label: string;
   readonly view: DashboardView;
-  readonly countKey?: "pendingReviews" | "openPrs" | "openIssues" | "totalWorkspaces" | "unreadActivity";
+  readonly countKey?:
+    | "pendingReviews"
+    | "openPrs"
+    | "openIssues"
+    | "totalWorkspaces"
+    | "unreadActivity";
 }
 
 const NAV_ITEMS: readonly NavEntry[] = [
@@ -76,9 +82,7 @@ export function Sidebar(): ReactElement {
   const navGroupRef = useRef<HTMLDivElement | null>(null);
   const navItemRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
-  const workspaces = (dashboard?.workspaces ?? []).filter(
-    (ws) => ws.state !== "archived",
-  );
+  const workspaces = (dashboard?.workspaces ?? []).filter((ws) => ws.state !== "archived");
   const repos = reposQuery.data ?? [];
   const enabledRepos = repos.filter((r) => r.enabled);
   const username = authQuery.data?.username ?? null;
@@ -92,9 +96,7 @@ export function Sidebar(): ReactElement {
 
   async function handleSelectAll() {
     const toEnable = repos.filter((r) => !r.enabled);
-    const results = await Promise.allSettled(
-      toEnable.map((r) => setRepoEnabled(r.id, true)),
-    );
+    const results = await Promise.allSettled(toEnable.map((r) => setRepoEnabled(r.id, true)));
     await queryClient.invalidateQueries({ queryKey: ["repos"] });
     const failures = results.filter((r) => r.status === "rejected");
     if (failures.length > 0) {
@@ -104,9 +106,7 @@ export function Sidebar(): ReactElement {
 
   async function handleDeselectAll() {
     const toDisable = repos.filter((r) => r.enabled);
-    const results = await Promise.allSettled(
-      toDisable.map((r) => setRepoEnabled(r.id, false)),
-    );
+    const results = await Promise.allSettled(toDisable.map((r) => setRepoEnabled(r.id, false)));
     await queryClient.invalidateQueries({ queryKey: ["repos"] });
     const failures = results.filter((r) => r.status === "rejected");
     if (failures.length > 0) {
@@ -146,7 +146,11 @@ export function Sidebar(): ReactElement {
   }
 
   return (
-    <nav data-testid="sidebar" aria-label="Main navigation" className="flex h-full flex-col gap-4 p-3">
+    <nav
+      data-testid="sidebar"
+      aria-label="Main navigation"
+      className="flex h-full flex-col gap-4 p-3"
+    >
       {/* Logo */}
       <div className="px-2 py-1">
         <h1 className="text-sm font-bold text-white">PRism</h1>
@@ -154,7 +158,12 @@ export function Sidebar(): ReactElement {
       </div>
 
       {/* Navigation */}
-      <div ref={navGroupRef} className="flex flex-col gap-0.5" role="group" aria-label="Primary views">
+      <div
+        ref={navGroupRef}
+        className="flex flex-col gap-0.5"
+        role="group"
+        aria-label="Primary views"
+      >
         {NAV_ITEMS.map((item, index) => (
           <NavItem
             key={item.view}
@@ -175,14 +184,18 @@ export function Sidebar(): ReactElement {
 
       {/* Workspaces section */}
       {workspaces.length > 0 && (
-        <div role="region" aria-labelledby="sidebar-workspaces-heading" className="flex flex-col gap-1">
-          <h3 id="sidebar-workspaces-heading" className="px-2 text-[10px] font-semibold uppercase tracking-wider text-dim">
+        <div
+          role="region"
+          aria-labelledby="sidebar-workspaces-heading"
+          className="flex flex-col gap-1"
+        >
+          <h3
+            id="sidebar-workspaces-heading"
+            className="px-2 text-[10px] font-semibold uppercase tracking-wider text-dim"
+          >
             Workspaces
           </h3>
-          <WorkspaceList
-            workspaces={workspaces}
-            onWorkspaceClick={handleWorkspaceClick}
-          />
+          <WorkspaceList workspaces={workspaces} onWorkspaceClick={handleWorkspaceClick} />
         </div>
       )}
 
@@ -198,7 +211,7 @@ export function Sidebar(): ReactElement {
             aria-expanded={isReposExpanded}
             aria-label={`Repos ${enabledRepos.length}`}
             onClick={() => setIsReposExpanded((prev) => !prev)}
-            className="flex w-full items-center justify-between px-2 text-[10px] font-semibold uppercase tracking-wider text-dim hover:text-foreground"
+            className={`${FOCUS_RING} flex w-full items-center justify-between rounded px-2 text-[10px] font-semibold uppercase tracking-wider text-dim hover:text-foreground`}
           >
             <span id="sidebar-repos-heading" className="inline-flex items-baseline">
               <span>Repos</span>
@@ -225,7 +238,7 @@ export function Sidebar(): ReactElement {
           type="button"
           aria-pressed={focusMode}
           onClick={toggleFocusMode}
-          className={`w-full rounded px-2 py-2 text-xs font-medium ${
+          className={`${FOCUS_RING} w-full rounded px-2 py-2 text-xs font-medium ${
             focusMode
               ? "bg-accent text-bg font-semibold hover:bg-accent/80"
               : "text-dim hover:text-foreground"
@@ -237,9 +250,7 @@ export function Sidebar(): ReactElement {
 
       {/* Footer */}
       <div className="mt-auto border-t border-border px-2 pt-2">
-        {username && (
-          <p className="truncate text-xs text-dim">{username}</p>
-        )}
+        {username && <p className="truncate text-xs text-dim">{username}</p>}
         <p className="text-[10px] text-dim/60">⌘K</p>
       </div>
     </nav>

--- a/src/components/Sidebar/WorkspaceList.tsx
+++ b/src/components/Sidebar/WorkspaceList.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from "react";
+import { FOCUS_RING } from "../../lib/a11y";
 import type { Workspace, WorkspaceState } from "../../lib/types";
 
 interface WorkspaceListProps {
@@ -12,10 +13,7 @@ const DOT_COLOR: Record<WorkspaceState, string> = {
   archived: "bg-dim",
 };
 
-export function WorkspaceList({
-  workspaces,
-  onWorkspaceClick,
-}: WorkspaceListProps): ReactElement {
+export function WorkspaceList({ workspaces, onWorkspaceClick }: WorkspaceListProps): ReactElement {
   return (
     <div className="flex flex-col gap-0.5">
       {workspaces.map((ws) => (
@@ -24,7 +22,7 @@ export function WorkspaceList({
           type="button"
           onClick={() => onWorkspaceClick(ws.id)}
           aria-label={`PR #${ws.pullRequestNumber} (${ws.state})`}
-          className="flex items-center gap-2 rounded px-2 py-2 text-left text-xs text-dim hover:bg-surface-hover hover:text-foreground"
+          className={`${FOCUS_RING} flex items-center gap-2 rounded px-2 py-2 text-left text-xs text-dim hover:bg-surface-hover hover:text-foreground`}
         >
           <span
             data-state={ws.state}

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -1,5 +1,6 @@
 import { CircleCheck, CircleX, Eye, type LucideIcon } from "lucide-react";
 import { useCallback, useEffect, useRef, type ReactElement } from "react";
+import { FOCUS_RING } from "../../lib/a11y";
 import { useNotifications } from "../../hooks/useNotifications";
 import type { Notification } from "../../hooks/useNotifications";
 import { useDashboardStore } from "../../stores/dashboard";
@@ -70,12 +71,9 @@ function ToastItem({ notification, onDismiss, onNavigate }: ToastItemProps): Rea
       type="button"
       aria-label={`${meta.label}${summary ? ` ${summary}` : ""} — click to navigate`}
       onClick={handleClick}
-      className="flex w-72 items-center gap-3 rounded-lg border border-border bg-bg-secondary p-3 shadow-lg transition-opacity hover:opacity-80"
+      className={`${FOCUS_RING} flex w-72 items-center gap-3 rounded-lg border border-border bg-bg-secondary p-3 shadow-lg transition-opacity hover:opacity-80`}
     >
-      <span
-        className="flex h-5 w-5 items-center justify-center text-fg"
-        aria-hidden="true"
-      >
+      <span className="flex h-5 w-5 items-center justify-center text-fg" aria-hidden="true">
         <Icon
           data-testid={`toast-icon-${notification.type}`}
           className="h-5 w-5"
@@ -84,9 +82,7 @@ function ToastItem({ notification, onDismiss, onNavigate }: ToastItemProps): Rea
       </span>
       <div className="flex flex-col items-start">
         <span className="text-sm font-medium text-fg">{meta.label}</span>
-        {summary !== undefined && (
-          <span className="text-xs text-fg-muted">{summary}</span>
-        )}
+        {summary !== undefined && <span className="text-xs text-fg-muted">{summary}</span>}
       </div>
     </button>
   );
@@ -103,12 +99,7 @@ export function Toast(): ReactElement {
       className="fixed bottom-4 right-4 z-50 flex flex-col gap-2"
     >
       {notifications.map((n) => (
-        <ToastItem
-          key={n.id}
-          notification={n}
-          onDismiss={clearNotification}
-          onNavigate={setView}
-        />
+        <ToastItem key={n.id} notification={n} onDismiss={clearNotification} onNavigate={setView} />
       ))}
     </div>
   );

--- a/src/components/Workspace/WorkspaceListPage.tsx
+++ b/src/components/Workspace/WorkspaceListPage.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from "react";
+import { FOCUS_RING } from "../../lib/a11y";
 import type { WorkspaceListEntry, WorkspaceState } from "../../lib/types";
 import { CI } from "../atoms/CI";
 import { EmptyState } from "../atoms/EmptyState";
@@ -34,57 +35,65 @@ export function WorkspaceListPage({
   return (
     <section data-testid="workspace-list" className="flex h-full flex-col">
       <ul className="flex-1 divide-y divide-border overflow-y-auto" role="list">
-        {entries.map(({ workspace, branch, ahead, behind, ciStatus, sessionCount, diskUsageMb, lastNote }) => (
-          <li key={workspace.id}>
-            <button
-              type="button"
-              onClick={() => onWorkspaceClick(workspace.id)}
-              disabled={workspace.state === "archived"}
-              aria-label={`PR #${workspace.pullRequestNumber} (${workspace.state})`}
-              className={`flex w-full items-start gap-3 px-4 py-3 text-left ${
-                workspace.state === "archived"
-                  ? "cursor-default opacity-50"
-                  : "hover:bg-surface-hover"
-              }`}
-            >
-              <span
-                data-state={workspace.state}
-                className={`mt-1.5 inline-block h-2 w-2 shrink-0 rounded-full ${DOT_COLOR[workspace.state]}`}
-              />
+        {entries.map(
+          ({ workspace, branch, ahead, behind, ciStatus, sessionCount, diskUsageMb, lastNote }) => (
+            <li key={workspace.id}>
+              <button
+                type="button"
+                onClick={() => onWorkspaceClick(workspace.id)}
+                disabled={workspace.state === "archived"}
+                aria-label={`PR #${workspace.pullRequestNumber} (${workspace.state})`}
+                className={`${FOCUS_RING} flex w-full items-start gap-3 rounded px-4 py-3 text-left ${
+                  workspace.state === "archived"
+                    ? "cursor-default opacity-50"
+                    : "hover:bg-surface-hover"
+                }`}
+              >
+                <span
+                  data-state={workspace.state}
+                  className={`mt-1.5 inline-block h-2 w-2 shrink-0 rounded-full ${DOT_COLOR[workspace.state]}`}
+                />
 
-              <div className="min-w-0 flex-1">
-                <div className="flex items-center gap-2">
-                  <span className="text-sm font-medium text-foreground">
-                    PR #{workspace.pullRequestNumber}
-                  </span>
-                  {ciStatus && <CI status={ciStatus} />}
-                </div>
-
-                {branch && (
-                  <div className="mt-0.5 flex items-center gap-2 text-xs text-dim">
-                    <span className="truncate" title={branch}>{branch}</span>
-                    {(ahead > 0 || behind > 0) && (
-                      <span>
-                        {ahead > 0 && <span className="text-green">+{ahead}</span>}
-                        {ahead > 0 && behind > 0 && " "}
-                        {behind > 0 && <span className="text-orange">-{behind}</span>}
-                      </span>
-                    )}
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium text-foreground">
+                      PR #{workspace.pullRequestNumber}
+                    </span>
+                    {ciStatus && <CI status={ciStatus} />}
                   </div>
-                )}
 
-                <div className="mt-0.5 flex items-center gap-3 text-xs text-dim">
-                  <span>{sessionCount} {sessionCount === 1 ? "session" : "sessions"}</span>
-                  {diskUsageMb != null && <span>{diskUsageMb} MB</span>}
+                  {branch && (
+                    <div className="mt-0.5 flex items-center gap-2 text-xs text-dim">
+                      <span className="truncate" title={branch}>
+                        {branch}
+                      </span>
+                      {(ahead > 0 || behind > 0) && (
+                        <span>
+                          {ahead > 0 && <span className="text-green">+{ahead}</span>}
+                          {ahead > 0 && behind > 0 && " "}
+                          {behind > 0 && <span className="text-orange">-{behind}</span>}
+                        </span>
+                      )}
+                    </div>
+                  )}
+
+                  <div className="mt-0.5 flex items-center gap-3 text-xs text-dim">
+                    <span>
+                      {sessionCount} {sessionCount === 1 ? "session" : "sessions"}
+                    </span>
+                    {diskUsageMb != null && <span>{diskUsageMb} MB</span>}
+                  </div>
+
+                  {lastNote && (
+                    <p className="mt-1 truncate text-xs text-dim/70" title={lastNote}>
+                      {lastNote}
+                    </p>
+                  )}
                 </div>
-
-                {lastNote && (
-                  <p className="mt-1 truncate text-xs text-dim/70" title={lastNote}>{lastNote}</p>
-                )}
-              </div>
-            </button>
-          </li>
-        ))}
+              </button>
+            </li>
+          ),
+        )}
       </ul>
 
       {totalDisk && (

--- a/src/components/Workspace/WorkspaceStatusBar.tsx
+++ b/src/components/Workspace/WorkspaceStatusBar.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from "react";
+import { FOCUS_RING } from "../../lib/a11y";
 import type { CiStatus } from "../../lib/types";
 import { ptyWrite } from "../../lib/tauri";
 import { CI } from "../atoms/CI";
@@ -81,7 +82,7 @@ export function WorkspaceStatusBar({
           data-testid="btn-git-push"
           type="button"
           aria-label="Git push"
-          className="rounded px-2 py-2 text-muted hover:bg-surface-hover hover:text-text"
+          className={`${FOCUS_RING} rounded px-2 py-2 text-muted hover:bg-surface-hover hover:text-text`}
           onClick={() => handlePtyCommand("git push")}
         >
           push
@@ -90,7 +91,7 @@ export function WorkspaceStatusBar({
           data-testid="btn-git-pull"
           type="button"
           aria-label="Git pull"
-          className="rounded px-2 py-2 text-muted hover:bg-surface-hover hover:text-text"
+          className={`${FOCUS_RING} rounded px-2 py-2 text-muted hover:bg-surface-hover hover:text-text`}
           onClick={() => handlePtyCommand("git pull")}
         >
           pull
@@ -101,7 +102,7 @@ export function WorkspaceStatusBar({
           target="_blank"
           rel="noopener noreferrer"
           aria-label="Open pull request on GitHub"
-          className="rounded px-2 py-2 text-muted hover:bg-surface-hover hover:text-text"
+          className={`${FOCUS_RING} rounded px-2 py-2 text-muted hover:bg-surface-hover hover:text-text`}
         >
           github
         </a>

--- a/src/components/Workspace/WorkspaceSwitcher.tsx
+++ b/src/components/Workspace/WorkspaceSwitcher.tsx
@@ -1,4 +1,5 @@
 import { useRef, useCallback, useMemo } from "react";
+import { FOCUS_RING } from "../../lib/a11y";
 import { useWorkspacesStore } from "../../stores/workspaces";
 import { useSettingsStore } from "../../stores/settings";
 import type { Workspace, WorkspaceState } from "../../lib/types";
@@ -20,15 +21,10 @@ function sanitizeMax(value: number | undefined | null): number {
   return Number.isFinite(value) && value! > 0 ? value! : DEFAULT_MAX_ACTIVE;
 }
 
-export function WorkspaceSwitcher({
-  workspaces,
-  onBackToDashboard,
-}: WorkspaceSwitcherProps) {
+export function WorkspaceSwitcher({ workspaces, onBackToDashboard }: WorkspaceSwitcherProps) {
   const activeWorkspaceId = useWorkspacesStore((s) => s.activeWorkspaceId);
   const setActiveWorkspace = useWorkspacesStore((s) => s.setActiveWorkspace);
-  const maxActiveWorkspaces = sanitizeMax(
-    useSettingsStore((s) => s.config?.maxActiveWorkspaces),
-  );
+  const maxActiveWorkspaces = sanitizeMax(useSettingsStore((s) => s.config?.maxActiveWorkspaces));
 
   const visibleWorkspaces = useMemo(
     () => workspaces.filter((w) => w.state !== "archived"),
@@ -38,7 +34,7 @@ export function WorkspaceSwitcher({
   const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
   const focusedId = visibleWorkspaces.some((w) => w.id === activeWorkspaceId)
     ? activeWorkspaceId
-    : visibleWorkspaces[0]?.id ?? null;
+    : (visibleWorkspaces[0]?.id ?? null);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent, index: number) => {
@@ -81,7 +77,7 @@ export function WorkspaceSwitcher({
       <button
         type="button"
         onClick={onBackToDashboard}
-        className="mr-2 rounded px-2 py-2 text-xs text-dim hover:bg-surface-hover hover:text-text"
+        className={`${FOCUS_RING} mr-2 rounded px-2 py-2 text-xs text-dim hover:bg-surface-hover hover:text-text`}
       >
         Dashboard
       </button>
@@ -92,7 +88,9 @@ export function WorkspaceSwitcher({
           return (
             <button
               key={ws.id}
-              ref={(el) => { tabRefs.current[i] = el; }}
+              ref={(el) => {
+                tabRefs.current[i] = el;
+              }}
               type="button"
               role="tab"
               aria-selected={isActive}
@@ -101,7 +99,7 @@ export function WorkspaceSwitcher({
               data-active={isActive ? "true" : "false"}
               onClick={() => setActiveWorkspace(ws.id)}
               onKeyDown={(e) => handleKeyDown(e, i)}
-              className={`flex items-center gap-1.5 rounded px-2.5 py-2 text-xs transition-colors ${
+              className={`${FOCUS_RING} flex items-center gap-1.5 rounded px-2.5 py-2 text-xs transition-colors ${
                 isActive
                   ? "bg-surface-hover text-accent hover:bg-accent/10"
                   : "text-dim hover:bg-surface-hover hover:text-text"

--- a/src/components/Workspace/WorkspaceView.tsx
+++ b/src/components/Workspace/WorkspaceView.tsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense, useCallback, useState, type ReactElement } from "react";
 import { useQueryClient } from "@tanstack/react-query";
+import { FOCUS_RING } from "../../lib/a11y";
 import type { Workspace, WorkspaceListEntry, WorkspaceStatusInfo } from "../../lib/types";
 import { resumeWorkspace } from "../../lib/tauri";
 import { useWorkspacesStore } from "../../stores/workspaces";
@@ -7,9 +8,7 @@ import { WorkspaceSwitcher } from "./WorkspaceSwitcher";
 import { WorkspaceStatusBar } from "./WorkspaceStatusBar";
 import { WorkspaceListPage } from "./WorkspaceListPage";
 
-const Terminal = lazy(() =>
-  import("./Terminal").then((module) => ({ default: module.Terminal })),
-);
+const Terminal = lazy(() => import("./Terminal").then((module) => ({ default: module.Terminal })));
 
 function TerminalLoadingFallback(): ReactElement {
   return (
@@ -80,14 +79,8 @@ export function WorkspaceView({
   );
 
   return (
-    <section
-      data-testid="workspace-view"
-      className="flex h-full flex-col"
-    >
-      <WorkspaceSwitcher
-        workspaces={workspaces}
-        onBackToDashboard={onBackToDashboard}
-      />
+    <section data-testid="workspace-view" className="flex h-full flex-col">
+      <WorkspaceSwitcher workspaces={workspaces} onBackToDashboard={onBackToDashboard} />
 
       {active && isSuspended ? (
         <div
@@ -98,7 +91,7 @@ export function WorkspaceView({
           <button
             data-testid="btn-wake-workspace"
             type="button"
-            className="rounded bg-neutral-700 px-4 py-2 text-sm text-white hover:bg-neutral-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
+            className={`${FOCUS_RING} rounded bg-neutral-700 px-4 py-2 text-sm text-white hover:bg-neutral-600 disabled:cursor-not-allowed disabled:opacity-50`}
             disabled={waking}
             onClick={handleWakeWorkspace}
           >

--- a/src/components/atoms/WsBadge.tsx
+++ b/src/components/atoms/WsBadge.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from "react";
+import { FOCUS_RING } from "../../lib/a11y";
 import type { WorkspaceState } from "../../lib/types";
 
 interface WsBadgeProps {
@@ -18,7 +19,11 @@ export function WsBadge({ state, loading, onClick, ariaLabel }: WsBadgeProps): R
     return null;
   }
 
-  const label = loading ? "cloning…" : state ? LABEL_MAP[state as Exclude<WorkspaceState, "archived">] : "open";
+  const label = loading
+    ? "cloning…"
+    : state
+      ? LABEL_MAP[state as Exclude<WorkspaceState, "archived">]
+      : "open";
 
   return (
     <button
@@ -26,7 +31,7 @@ export function WsBadge({ state, loading, onClick, ariaLabel }: WsBadgeProps): R
       onClick={loading ? undefined : onClick}
       disabled={loading}
       aria-label={ariaLabel}
-      className={`rounded border border-accent/30 px-2 py-2 text-xs text-accent ${loading ? "animate-pulse opacity-60" : "hover:bg-accent/10"}`}
+      className={`${FOCUS_RING} rounded border border-accent/30 px-2 py-2 text-xs text-accent ${loading ? "animate-pulse opacity-60" : "hover:bg-accent/10"}`}
     >
       {label}
     </button>

--- a/src/components/atoms/WsBadge.tsx
+++ b/src/components/atoms/WsBadge.tsx
@@ -21,8 +21,8 @@ export function WsBadge({ state, loading, onClick, ariaLabel }: WsBadgeProps): R
 
   const label = loading
     ? "cloning…"
-    : state
-      ? LABEL_MAP[state as Exclude<WorkspaceState, "archived">]
+    : state === "active" || state === "suspended"
+      ? LABEL_MAP[state]
       : "open";
 
   return (

--- a/src/index.css
+++ b/src/index.css
@@ -49,11 +49,17 @@ body {
 /* Interactive elements should also carry the `FOCUS_RING` Tailwind class from
    src/lib/a11y.ts for a polished ring. This fallback keeps keyboard focus
    visible on any element that slipped through (third-party widgets, future
-   code). We avoid box-shadow here so it does not conflict with the Tailwind
-   `ring-*` utilities (which render via box-shadow). */
-:focus-visible {
-  outline: 2px solid var(--color-accent);
-  outline-offset: 2px;
+   code).
+
+   Wrapped in `@layer base` so Tailwind v4's `utilities` layer (where
+   `outline-none` lives as part of `FOCUS_RING`) can override it — unlayered
+   rules beat every named layer regardless of specificity, which would
+   otherwise force a double focus indicator on instrumented elements. */
+@layer base {
+  :focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
+  }
 }
 
 /* ── Scrollbar dark theme ─────────────────────── */

--- a/src/index.css
+++ b/src/index.css
@@ -45,15 +45,15 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
-/* ── Focus ring global (WCAG AA) ─────────────── */
-:root {
-  --focus-shadow: 0 0 0 4px color-mix(in srgb, var(--color-accent) 30%, transparent);
-}
-
+/* ── Focus ring global (WCAG 2.4.7 safety net) ── */
+/* Interactive elements should also carry the `FOCUS_RING` Tailwind class from
+   src/lib/a11y.ts for a polished ring. This fallback keeps keyboard focus
+   visible on any element that slipped through (third-party widgets, future
+   code). We avoid box-shadow here so it does not conflict with the Tailwind
+   `ring-*` utilities (which render via box-shadow). */
 :focus-visible {
   outline: 2px solid var(--color-accent);
   outline-offset: 2px;
-  box-shadow: var(--focus-shadow);
 }
 
 /* ── Scrollbar dark theme ─────────────────────── */

--- a/src/lib/a11y.test.ts
+++ b/src/lib/a11y.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { FOCUS_RING } from "./a11y";
+
+describe("FOCUS_RING", () => {
+  it("should remove default outline so browser focus ring does not conflict with the Tailwind ring", () => {
+    expect(FOCUS_RING).toContain("outline-none");
+  });
+
+  it("should include focus-visible:ring-2 to install a 2px ring on keyboard focus only", () => {
+    expect(FOCUS_RING).toContain("focus-visible:ring-2");
+  });
+
+  it("should use the accent color for the ring to match the PRism design system", () => {
+    expect(FOCUS_RING).toContain("focus-visible:ring-accent");
+  });
+
+  it("should include a 2px ring offset to separate the ring from the element border", () => {
+    expect(FOCUS_RING).toContain("focus-visible:ring-offset-2");
+  });
+
+  it("should offset against the page background (bg token) so the ring reads on dark surfaces", () => {
+    expect(FOCUS_RING).toContain("focus-visible:ring-offset-bg");
+  });
+
+  it("should not rely on the plain :focus selector which would trigger on mouse clicks", () => {
+    expect(FOCUS_RING).not.toMatch(/\bfocus:ring/);
+  });
+});

--- a/src/lib/a11y.test.ts
+++ b/src/lib/a11y.test.ts
@@ -18,8 +18,8 @@ describe("FOCUS_RING", () => {
     expect(FOCUS_RING).toContain("focus-visible:ring-offset-2");
   });
 
-  it("should offset against the page background (bg token) so the ring reads on dark surfaces", () => {
-    expect(FOCUS_RING).toContain("focus-visible:ring-offset-bg");
+  it("should offset with a transparent color so the element's own background shows through on any surface", () => {
+    expect(FOCUS_RING).toContain("focus-visible:ring-offset-transparent");
   });
 
   it("should not rely on the plain :focus selector which would trigger on mouse clicks", () => {

--- a/src/lib/a11y.ts
+++ b/src/lib/a11y.ts
@@ -4,11 +4,16 @@
  * WCAG 2.4.7 — Focus Visible (Level AA).
  * Apply {@link FOCUS_RING} to every interactive element (button, link, input,
  * label acting as a control). It removes the browser default outline and
- * installs a high-contrast accent ring on keyboard focus only, matching the
- * PRism dark theme (`bg` offset + `accent` ring color).
+ * installs a high-contrast accent ring on keyboard focus only.
+ *
+ * The ring offset is `transparent` so the element's own background shows
+ * through the 2px gap between the element edge and the accent ring. This is
+ * resilient to any parent surface (`bg-bg`, `bg-surface`, `bg-surface-hover`,
+ * …) and avoids the subtle dark-halo mismatch a hardcoded `ring-offset-bg`
+ * would create on elements sitting on `bg-surface` panels.
  *
  * Keeping a single exported constant is the single source of truth for focus
  * styling across the app — do not duplicate the class list inline.
  */
 export const FOCUS_RING =
-  "outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg";
+  "outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-transparent";

--- a/src/lib/a11y.ts
+++ b/src/lib/a11y.ts
@@ -1,0 +1,14 @@
+/**
+ * Accessibility utilities for PRism.
+ *
+ * WCAG 2.4.7 — Focus Visible (Level AA).
+ * Apply {@link FOCUS_RING} to every interactive element (button, link, input,
+ * label acting as a control). It removes the browser default outline and
+ * installs a high-contrast accent ring on keyboard focus only, matching the
+ * PRism dark theme (`bg` offset + `accent` ring color).
+ *
+ * Keeping a single exported constant is the single source of truth for focus
+ * styling across the app — do not duplicate the class list inline.
+ */
+export const FOCUS_RING =
+  "outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg";

--- a/src/lib/uiClasses.ts
+++ b/src/lib/uiClasses.ts
@@ -1,0 +1,22 @@
+import { FOCUS_RING } from "./a11y";
+
+/**
+ * Shared class strings for interactive controls that appear in more than one
+ * feature surface. Centralising them mirrors the single-source-of-truth
+ * treatment given to {@link FOCUS_RING}: a shape tweak only needs to happen
+ * once.
+ */
+
+/**
+ * Square-ish filter button used on list headers (Issues, MyPRs, ReviewQueue,
+ * ActivityFeed). Sized to the 44px minimum touch target.
+ */
+export const FILTER_BUTTON_CLASS =
+  `${FOCUS_RING} inline-flex min-h-11 min-w-11 items-center justify-center rounded px-3 text-xs leading-none transition-colors`;
+
+/**
+ * Inline action button used alongside filters (e.g. "Mark all read" in the
+ * activity feed).
+ */
+export const ACTION_BUTTON_CLASS =
+  `${FOCUS_RING} inline-flex min-h-11 items-center rounded px-3 text-xs transition-colors`;


### PR DESCRIPTION
Closes #206

## Summary

- Introduces `FOCUS_RING` constant in `src/lib/a11y.ts` as the single source of truth for keyboard focus styling
- Applies `FOCUS_RING` to every interactive element in the app (22 components) so keyboard users can always identify the focused control (WCAG 2.4.7 — Focus Visible, Level AA)
- Removes two `outline-none` anti-patterns on `<input type="search">` (RepoList, Settings) that were actively suppressing keyboard focus indicators
- Replaces one hardcoded `focus-visible:outline-blue-500` in `WorkspaceView` with the shared constant to harmonize the design

## FOCUS_RING constant

```ts
export const FOCUS_RING =
  "outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg";
```

- Uses Tailwind v4 utilities backed by the project's `@theme` tokens (`--color-accent`, `--color-bg`)
- `outline-none` suppresses the browser default; the ring activates only on `:focus-visible` so mouse clicks don't show a halo
- Applied inline or through existing shared class constants (`FILTER_BUTTON_CLASS`, `ACTION_BUTTON_CLASS`, `INLINE_CONTROL_CLASS`, `controlButtonClass`) when present

## Global CSS safety net

`src/index.css` keeps a minimal `:focus-visible { outline: ... }` rule as a fallback for any interactive element that slips through in the future (third-party widgets, new components). The `box-shadow` was removed to avoid conflicting with Tailwind's ring (which itself uses `box-shadow`).

## Components updated

**Sidebar**: NavItem · Sidebar (Repos toggle, Focus mode) · RepoList (search input, buttons, checkboxes) · WorkspaceList  
**Workspace**: WorkspaceSwitcher (back + tabs) · WorkspaceView (wake button) · WorkspaceStatusBar (push/pull/github) · WorkspaceListPage  
**Cards**: MyPrCard · ReviewCard · IssueCard (links)  
**Lists**: MyPRs · ReviewQueue · Issues · ActivityFeed (filter buttons + search inputs)  
**Misc**: Overview (expand button) · Settings (NumberField, search, checkboxes, control buttons) · AuthSetup (5 interactive elements) · Toast (notification button) · ErrorBoundary (retry) · CommandPalette (search input) · WsBadge (action)

## Tests

- New `src/lib/a11y.test.ts` — 6 substring tests guarding the constant shape
- New focus-visible assertions in `NavItem.test.tsx`, `Issues.test.tsx`, `MyPRs.test.tsx`, `ActivityFeed.test.tsx` (iterates every token in `FOCUS_RING` via `toHaveClass`)
- **558 tests passing** (was 555)
- `npm run lint` — 0 warnings / 0 errors
- `tsc --noEmit` — clean
- `npm run build` — clean (the `a11y` module becomes a 500-byte shared chunk via Rollup dedup)

## Test plan

- [ ] Tab through every screen (Overview, Reviews, MyPRs, Issues, Activity, Workspaces, Settings) — every focused element should show a visible accent ring
- [ ] Click elements with mouse — no ring should appear (focus-visible only fires for keyboard)
- [ ] Test the RepoList search input and Settings repo search (the two inputs that previously had `outline-none`)
- [ ] Open the Command Palette (⌘K) — the search input should have the ring on focus, cmdk arrow navigation still works
- [ ] Resize to dark/light (N/A — app is dark-only) and verify ring contrast against `bg-bg`

## Acceptance criteria

- [x] All interactive elements have visible focus indicators
- [x] Focus ring uses `focus-visible` (not `focus`) to avoid showing on mouse click
- [x] Focus ring contrasts sufficiently against app background (accent #c8ff00 on bg #111110 — excellent contrast)
- [ ] Manually tested: Tab through entire app, every interactive element visually identifiable
- [x] No visual regression on mouse interactions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a consistent `:focus-visible` ring for all keyboard-focusable controls to meet WCAG 2.4.7, resolving #206. Refines the ring offset and consolidates shared UI classes for consistency; mouse clicks still don’t show a ring.

- New Features
  - `FOCUS_RING` in `src/lib/a11y.ts` now uses `focus-visible:ring-offset-transparent` for reliable contrast on any surface.
  - Centralized shared control classes in `src/lib/uiClasses.ts` (`FILTER_BUTTON_CLASS`, `ACTION_BUTTON_CLASS`) and replaced local duplicates.
  - Applied `FOCUS_RING` across interactive elements (buttons, links, inputs) in 22 components; replaced one hardcoded ring.

- Bug Fixes
  - Layered the global `:focus-visible` fallback in `index.css` under `@layer base` to prevent double rings while keeping a safety net.
  - Removed `outline-none` on search inputs in RepoList and Settings so focus indicators are visible.

<sup>Written for commit bc46f33b3abe27e8622d548987c8420dd5d871af. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved keyboard focus visibility and consistency across interactive UI (buttons, inputs, links, toggles), providing clearer, high-contrast focus rings for better keyboard navigation accessibility.
* **Tests**
  * Added tests to ensure focus-ring styling is applied consistently to interactive components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->