### PR TITLE
perf(ui): centralize lucide-react icons via whitelist barrel

### DIFF
--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -1,4 +1,4 @@
-import { CircleCheck, CircleX, Eye, type LucideIcon } from "lucide-react";
+import { CircleCheck, CircleX, Eye, type LucideIcon } from "../../lib/icons";
 import { useCallback, useEffect, useRef, type ReactElement } from "react";
 import { FOCUS_RING } from "../../lib/a11y";
 import { useNotifications } from "../../hooks/useNotifications";

--- a/src/lib/icons.test.ts
+++ b/src/lib/icons.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { createElement } from "react";
+import * as icons from "./icons";
+
+describe("icons barrel", () => {
+  it("should render CircleCheck as a component", () => {
+    const { container } = render(createElement(icons.CircleCheck));
+    expect(container.querySelector("svg")).not.toBeNull();
+  });
+
+  it("should render CircleX as a component", () => {
+    const { container } = render(createElement(icons.CircleX));
+    expect(container.querySelector("svg")).not.toBeNull();
+  });
+
+  it("should render Eye as a component", () => {
+    const { container } = render(createElement(icons.Eye));
+    expect(container.querySelector("svg")).not.toBeNull();
+  });
+
+  it("should expose exactly the whitelisted icons (no accidental wildcard)", () => {
+    const exportedKeys = Object.keys(icons).sort();
+    expect(exportedKeys).toEqual(["CircleCheck", "CircleX", "Eye"].sort());
+  });
+});

--- a/src/lib/icons.ts
+++ b/src/lib/icons.ts
@@ -1,0 +1,4 @@
+// Re-export every lucide icon the app uses here; Vite tree-shakes the rest.
+// Do not use `export *` — it defeats the whitelist.
+export { CircleCheck, CircleX, Eye } from "lucide-react";
+export type { LucideIcon } from "lucide-react";


### PR DESCRIPTION
## Summary

- Introduce `src/lib/icons.ts` as the single re-export point for every lucide-react icon used in the app.
- Update `Toast.tsx` (the only current consumer) to import icons from the barrel.
- Add unit tests that render each whitelisted icon and guard against accidental wildcard exports.

## Why

Issue #209 flagged that named imports directly from `lucide-react` can be fragile for tree-shaking and make future bundle creep invisible. Routing all lucide imports through a whitelist barrel gives us:

- An auditable list of every icon shipped in the bundle.
- A single place to swap strategies later (direct path imports, lazy loading, custom icons).
- A regression guard: adding an icon without updating the test fails loudly.

Only `Toast.tsx` uses lucide today, so the change is small, but the policy prevents drift as more icons get added.

## Test plan

- [x] `npm run test` — 562/562 pass, no regression
- [x] `./node_modules/.bin/oxlint src/lib src/components/Toast` — clean
- [x] `./node_modules/.bin/oxfmt --check src/lib src/components/Toast` — clean
- [x] `npm run build` — production build succeeds
- [x] New unit tests in `src/lib/icons.test.ts`:
  - Each icon renders an `<svg>` element
  - Exported key set equals `["CircleCheck", "CircleX", "Eye"]` exactly (catches accidental `export *`)

Closes #209

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized `lucide-react` icon imports behind a whitelist barrel at `src/lib/icons.ts` to keep the icon set auditable and reduce bundle creep. Routes `Toast.tsx` to the barrel and adds a guard test, addressing #209.

- **Refactors**
  - Added `src/lib/icons.ts` re-exporting `CircleCheck`, `CircleX`, `Eye`, and `LucideIcon` from `lucide-react`.
  - Updated `Toast.tsx` to import icons from the barrel.
  - Added unit tests that render each icon and assert the export set matches the whitelist.

<sup>Written for commit 3be616530933b9aab60f37b29e839aeb4a9f1256. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal icon imports for improved maintainability.

* **Tests**
  * Added test coverage for icon module exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->