### PR TITLE
refactor(ui): extract useFilterableList hook to dedupe list filtering

### DIFF
--- a/src/components/Issues/Issues.tsx
+++ b/src/components/Issues/Issues.tsx
@@ -1,10 +1,11 @@
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { useQuery } from "@tanstack/react-query";
-import { type ReactElement, useEffect, useMemo, useRef, useState } from "react";
+import { type ReactElement, useCallback, useEffect, useMemo, useRef } from "react";
 import { FOCUS_RING } from "../../lib/a11y";
 import { listRepos } from "../../lib/tauri";
 import { FILTER_BUTTON_CLASS } from "../../lib/uiClasses";
 import type { Issue } from "../../lib/types";
+import { useFilterableList } from "../../hooks/useFilterableList";
 import { useRegisterNavigableItems } from "../../hooks/useRegisterNavigableItems";
 import { EmptyState } from "../atoms/EmptyState";
 import { SectionHead } from "../atoms/SectionHead";
@@ -19,24 +20,13 @@ interface IssuesProps {
 
 type Tab = "open" | "closed";
 
-function isOpen(issue: Issue): boolean {
-  return issue.state === "open";
-}
-
-function isClosed(issue: Issue): boolean {
-  return issue.state === "closed";
-}
+const ISSUE_TABS: Readonly<Record<Tab, (issue: Issue) => boolean>> = {
+  open: (issue) => issue.state === "open",
+  closed: (issue) => issue.state === "closed",
+};
 
 export function Issues({ issues, isLoading = false, onOpen }: IssuesProps): ReactElement {
-  const [tab, setTab] = useState<Tab>("open");
-  const [searchQuery, setSearchQuery] = useState("");
   const parentRef = useRef<HTMLDivElement>(null);
-  const normalizedQuery = searchQuery.trim().toLowerCase();
-
-  useEffect(() => {
-    parentRef.current?.scrollTo({ top: 0, behavior: "instant" });
-  }, [tab, normalizedQuery]);
-
   const { data: repos } = useQuery({ queryKey: ["repos"], queryFn: listRepos });
 
   const repoMap = useMemo<Map<string, string>>(() => {
@@ -44,19 +34,35 @@ export function Issues({ issues, isLoading = false, onOpen }: IssuesProps): Reac
     return new Map(repos.map((repo) => [repo.id, repo.fullName]));
   }, [repos]);
 
-  const matchesSearch = (issue: Issue): boolean => {
-    if (normalizedQuery.length === 0) return true;
+  const searchPredicate = useCallback(
+    (issue: Issue, query: string): boolean => {
+      const repoName = repoMap.get(issue.repoId) ?? issue.repoId;
+      return [issue.title, issue.author, repoName, ...issue.labels].some((value) =>
+        value.toLowerCase().includes(query),
+      );
+    },
+    [repoMap],
+  );
 
-    const repoName = repoMap.get(issue.repoId) ?? issue.repoId;
-    return [issue.title, issue.author, repoName, ...issue.labels].some((value) =>
-      value.toLowerCase().includes(normalizedQuery),
-    );
-  };
+  const {
+    tab,
+    setTab,
+    searchQuery,
+    setSearchQuery,
+    normalizedQuery,
+    filteredItems: matchingIssues,
+    visibleItems: visible,
+    tabCounts,
+  } = useFilterableList<Issue, Tab>({
+    items: issues,
+    tabs: ISSUE_TABS,
+    defaultTab: "open",
+    searchPredicate,
+  });
 
-  const matchingIssues = issues.filter(matchesSearch);
-  const openIssues = matchingIssues.filter(isOpen);
-  const closedIssues = matchingIssues.filter(isClosed);
-  const visible = tab === "open" ? openIssues : closedIssues;
+  useEffect(() => {
+    parentRef.current?.scrollTo({ top: 0, behavior: "instant" });
+  }, [tab, normalizedQuery]);
 
   const virtualizer = useVirtualizer({
     count: visible.length,
@@ -118,7 +124,7 @@ export function Issues({ issues, isLoading = false, onOpen }: IssuesProps): Reac
                   : "text-dim hover:bg-surface-hover hover:text-foreground"
               }`}
             >
-              Open {openIssues.length}
+              Open {tabCounts.open}
             </button>
             <button
               type="button"
@@ -130,7 +136,7 @@ export function Issues({ issues, isLoading = false, onOpen }: IssuesProps): Reac
                   : "text-dim hover:bg-surface-hover hover:text-foreground"
               }`}
             >
-              Closed {closedIssues.length}
+              Closed {tabCounts.closed}
             </button>
           </div>
 

--- a/src/components/MyPRs/MyPRs.tsx
+++ b/src/components/MyPRs/MyPRs.tsx
@@ -1,9 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
-import { type ReactElement, useEffect, useMemo, useRef, useState } from "react";
+import { type ReactElement, useCallback, useEffect, useMemo, useRef } from "react";
 import { FOCUS_RING } from "../../lib/a11y";
 import { listRepos } from "../../lib/tauri";
 import { FILTER_BUTTON_CLASS } from "../../lib/uiClasses";
 import type { PullRequestWithReview } from "../../lib/types";
+import { useFilterableList } from "../../hooks/useFilterableList";
 import { useRegisterNavigableItems } from "../../hooks/useRegisterNavigableItems";
 import { EmptyState } from "../atoms/EmptyState";
 import { SectionHead } from "../atoms/SectionHead";
@@ -27,14 +28,13 @@ interface MyPRsProps {
 
 type Tab = "open" | "merged";
 
-function isOpen(pr: PullRequestWithReview): boolean {
-  const { state } = pr.pullRequest;
-  return state === "open" || state === "draft";
-}
-
-function isMerged(pr: PullRequestWithReview): boolean {
-  return pr.pullRequest.state === "merged";
-}
+const PR_TABS: Readonly<Record<Tab, (pr: PullRequestWithReview) => boolean>> = {
+  open: (pr) => {
+    const { state } = pr.pullRequest;
+    return state === "open" || state === "draft";
+  },
+  merged: (pr) => pr.pullRequest.state === "merged",
+};
 
 export function MyPRs({
   prs,
@@ -42,10 +42,7 @@ export function MyPRs({
   onOpen,
   onWorkspaceAction,
 }: MyPRsProps): ReactElement {
-  const [tab, setTab] = useState<Tab>("open");
-  const [searchQuery, setSearchQuery] = useState("");
   const listRef = useRef<HTMLDivElement>(null);
-  const normalizedQuery = searchQuery.trim().toLowerCase();
   const { data: repos } = useQuery({ queryKey: ["repos"], queryFn: listRepos });
 
   const repoMap = useMemo<Map<string, string>>(() => {
@@ -53,19 +50,30 @@ export function MyPRs({
     return new Map(repos.map((repo) => [repo.id, repo.fullName]));
   }, [repos]);
 
-  const matchesSearch = (pr: PullRequestWithReview): boolean => {
-    if (normalizedQuery.length === 0) return true;
-    const repoName = repoMap.get(pr.pullRequest.repoId) ?? pr.pullRequest.repoId;
+  const searchPredicate = useCallback(
+    (pr: PullRequestWithReview, query: string): boolean => {
+      const repoName = repoMap.get(pr.pullRequest.repoId) ?? pr.pullRequest.repoId;
+      return [pr.pullRequest.title, pr.pullRequest.author, repoName, ...pr.pullRequest.labels].some(
+        (value) => value.toLowerCase().includes(query),
+      );
+    },
+    [repoMap],
+  );
 
-    return [pr.pullRequest.title, pr.pullRequest.author, repoName, ...pr.pullRequest.labels].some(
-      (value) => value.toLowerCase().includes(normalizedQuery),
-    );
-  };
-
-  const matchingPrs = prs.filter(matchesSearch);
-  const openPrs = matchingPrs.filter(isOpen);
-  const mergedPrs = matchingPrs.filter(isMerged);
-  const visible = tab === "open" ? openPrs : mergedPrs;
+  const {
+    tab,
+    setTab,
+    searchQuery,
+    setSearchQuery,
+    normalizedQuery,
+    visibleItems: visible,
+    tabCounts,
+  } = useFilterableList<PullRequestWithReview, Tab>({
+    items: prs,
+    tabs: PR_TABS,
+    defaultTab: "open",
+    searchPredicate,
+  });
 
   useEffect(() => {
     listRef.current?.scrollTo({ top: 0, behavior: "instant" });
@@ -80,9 +88,14 @@ export function MyPRs({
       aria-busy={isLoading ? "true" : undefined}
       className="flex flex-col gap-2"
     >
+      {/*
+        Count sums the two tab buckets rather than using `filteredItems.length`
+        because `PrState` includes "closed" — a state that is intentionally not
+        surfaced in any tab and should not appear in the header total.
+      */}
       <SectionHead
         title="My PRs"
-        count={isLoading ? undefined : openPrs.length + mergedPrs.length}
+        count={isLoading ? undefined : tabCounts.open + tabCounts.merged}
       />
 
       {isLoading ? (
@@ -124,7 +137,7 @@ export function MyPRs({
                   : "text-dim hover:bg-surface-hover hover:text-foreground"
               }`}
             >
-              Open {openPrs.length}
+              Open {tabCounts.open}
             </button>
             <button
               type="button"
@@ -136,7 +149,7 @@ export function MyPRs({
                   : "text-dim hover:bg-surface-hover hover:text-foreground"
               }`}
             >
-              Merged {mergedPrs.length}
+              Merged {tabCounts.merged}
             </button>
           </div>
 

--- a/src/hooks/useFilterableList.test.ts
+++ b/src/hooks/useFilterableList.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useFilterableList } from "./useFilterableList";
+
+interface TestItem {
+  readonly id: number;
+  readonly title: string;
+  readonly state: "open" | "closed";
+}
+
+const ITEMS: readonly TestItem[] = [
+  { id: 1, title: "Alpha bug", state: "open" },
+  { id: 2, title: "Beta bug", state: "closed" },
+  { id: 3, title: "Gamma feature", state: "open" },
+  { id: 4, title: "Delta feature", state: "closed" },
+];
+
+const tabs = {
+  open: (item: TestItem) => item.state === "open",
+  closed: (item: TestItem) => item.state === "closed",
+} as const;
+
+const searchPredicate = (item: TestItem, query: string): boolean =>
+  item.title.toLowerCase().includes(query);
+
+function renderFilterableList(items: readonly TestItem[] = ITEMS) {
+  return renderHook(() =>
+    useFilterableList<TestItem, "open" | "closed">({
+      items,
+      tabs,
+      defaultTab: "open",
+      searchPredicate,
+    }),
+  );
+}
+
+describe("useFilterableList", () => {
+  it("starts on the default tab with empty search", () => {
+    const { result } = renderFilterableList();
+
+    expect(result.current.tab).toBe("open");
+    expect(result.current.searchQuery).toBe("");
+    expect(result.current.normalizedQuery).toBe("");
+    expect(result.current.visibleItems.map((item) => item.id)).toEqual([1, 3]);
+  });
+
+  it("exposes tab counts computed from the full items set when no search is active", () => {
+    const { result } = renderFilterableList();
+
+    expect(result.current.tabCounts).toEqual({ open: 2, closed: 2 });
+  });
+
+  it("switches tabs when setTab is called", () => {
+    const { result } = renderFilterableList();
+
+    act(() => {
+      result.current.setTab("closed");
+    });
+
+    expect(result.current.tab).toBe("closed");
+    expect(result.current.visibleItems.map((item) => item.id)).toEqual([2, 4]);
+  });
+
+  it("filters items through the search predicate after setSearchQuery", () => {
+    const { result } = renderFilterableList();
+
+    act(() => {
+      result.current.setSearchQuery("feature");
+    });
+
+    expect(result.current.searchQuery).toBe("feature");
+    expect(result.current.normalizedQuery).toBe("feature");
+    // On the "open" tab, only "Gamma feature" matches.
+    expect(result.current.visibleItems.map((item) => item.id)).toEqual([3]);
+  });
+
+  it("normalizes the search query by trimming and lowercasing before passing to the predicate", () => {
+    const { result } = renderFilterableList();
+
+    act(() => {
+      result.current.setSearchQuery("  ALPHA  ");
+    });
+
+    expect(result.current.normalizedQuery).toBe("alpha");
+    expect(result.current.visibleItems.map((item) => item.id)).toEqual([1]);
+  });
+
+  it("treats a whitespace-only query as empty and keeps all items visible", () => {
+    const { result } = renderFilterableList();
+
+    act(() => {
+      result.current.setSearchQuery("   ");
+    });
+
+    expect(result.current.normalizedQuery).toBe("");
+    // All open items remain (search short-circuits).
+    expect(result.current.visibleItems.map((item) => item.id)).toEqual([1, 3]);
+  });
+
+  it("short-circuits and does not invoke the search predicate when the query is empty", () => {
+    let calls = 0;
+    const countingPredicate = (item: TestItem, query: string): boolean => {
+      calls += 1;
+      return item.title.toLowerCase().includes(query);
+    };
+
+    const { result } = renderHook(() =>
+      useFilterableList<TestItem, "open" | "closed">({
+        items: ITEMS,
+        tabs,
+        defaultTab: "open",
+        searchPredicate: countingPredicate,
+      }),
+    );
+
+    // Initial render with an empty query should not call the predicate.
+    expect(calls).toBe(0);
+    expect(result.current.visibleItems).toHaveLength(2);
+  });
+
+  it("combines search and tab filtering", () => {
+    const { result } = renderFilterableList();
+
+    act(() => {
+      result.current.setSearchQuery("bug");
+    });
+    act(() => {
+      result.current.setTab("closed");
+    });
+
+    expect(result.current.tab).toBe("closed");
+    expect(result.current.visibleItems.map((item) => item.id)).toEqual([2]);
+  });
+
+  it("computes tab counts from the search-filtered set, not the raw items", () => {
+    const { result } = renderFilterableList();
+
+    act(() => {
+      result.current.setSearchQuery("feature");
+    });
+
+    expect(result.current.tabCounts).toEqual({ open: 1, closed: 1 });
+  });
+
+  it("preserves searchQuery when the tab changes", () => {
+    const { result } = renderFilterableList();
+
+    act(() => {
+      result.current.setSearchQuery("bug");
+    });
+    act(() => {
+      result.current.setTab("closed");
+    });
+
+    expect(result.current.searchQuery).toBe("bug");
+  });
+
+  it("preserves tab when searchQuery changes", () => {
+    const { result } = renderFilterableList();
+
+    act(() => {
+      result.current.setTab("closed");
+    });
+    act(() => {
+      result.current.setSearchQuery("delta");
+    });
+
+    expect(result.current.tab).toBe("closed");
+    expect(result.current.visibleItems.map((item) => item.id)).toEqual([4]);
+  });
+
+  it("updates visibleItems when the items prop changes", () => {
+    const initialItems: readonly TestItem[] = [{ id: 1, title: "only", state: "open" }];
+    const { result, rerender } = renderHook(
+      (props: { items: readonly TestItem[] }) =>
+        useFilterableList<TestItem, "open" | "closed">({
+          items: props.items,
+          tabs,
+          defaultTab: "open",
+          searchPredicate,
+        }),
+      { initialProps: { items: initialItems } },
+    );
+
+    expect(result.current.visibleItems).toHaveLength(1);
+
+    rerender({ items: ITEMS });
+
+    expect(result.current.visibleItems.map((item) => item.id)).toEqual([1, 3]);
+  });
+
+  it("returns an empty visibleItems array when the search matches nothing", () => {
+    const { result } = renderFilterableList();
+
+    act(() => {
+      result.current.setSearchQuery("nothing-matches-this");
+    });
+
+    expect(result.current.visibleItems).toEqual([]);
+    expect(result.current.filteredItems).toEqual([]);
+    expect(result.current.tabCounts).toEqual({ open: 0, closed: 0 });
+  });
+
+  it("exposes filteredItems (post-search, pre-tab) for total counts", () => {
+    const { result } = renderFilterableList();
+
+    // No search: filteredItems equals all items.
+    expect(result.current.filteredItems).toHaveLength(4);
+
+    act(() => {
+      result.current.setSearchQuery("bug");
+    });
+
+    // After searching "bug": two items match regardless of tab.
+    expect(result.current.filteredItems.map((item) => item.id)).toEqual([1, 2]);
+    // The active tab is still "open", so visibleItems drops "Beta bug" (closed).
+    expect(result.current.visibleItems.map((item) => item.id)).toEqual([1]);
+  });
+});

--- a/src/hooks/useFilterableList.test.ts
+++ b/src/hooks/useFilterableList.test.ts
@@ -99,6 +99,10 @@ describe("useFilterableList", () => {
 
   it("short-circuits and does not invoke the search predicate when the query is empty", () => {
     let calls = 0;
+    // The inline `countingPredicate` is intentionally not memoized: its
+    // reference instability is irrelevant here because the hook short-circuits
+    // on empty queries before ever invoking the predicate, which is exactly
+    // the behavior this test is asserting.
     const countingPredicate = (item: TestItem, query: string): boolean => {
       calls += 1;
       return item.title.toLowerCase().includes(query);
@@ -116,6 +120,27 @@ describe("useFilterableList", () => {
     // Initial render with an empty query should not call the predicate.
     expect(calls).toBe(0);
     expect(result.current.visibleItems).toHaveLength(2);
+  });
+
+  it("ignores defaultTab changes after mount (initial-only semantics)", () => {
+    const { result, rerender } = renderHook(
+      (props: { defaultTab: "open" | "closed" }) =>
+        useFilterableList<TestItem, "open" | "closed">({
+          items: ITEMS,
+          tabs,
+          defaultTab: props.defaultTab,
+          searchPredicate,
+        }),
+      { initialProps: { defaultTab: "open" } },
+    );
+
+    expect(result.current.tab).toBe("open");
+
+    rerender({ defaultTab: "closed" });
+
+    // The internal tab state must NOT follow the new prop — the contract is
+    // that `defaultTab` is read exactly once by `useState`.
+    expect(result.current.tab).toBe("open");
   });
 
   it("combines search and tab filtering", () => {

--- a/src/hooks/useFilterableList.ts
+++ b/src/hooks/useFilterableList.ts
@@ -1,0 +1,85 @@
+import { useMemo, useState } from "react";
+
+export interface FilterableListConfig<T, TabKey extends string> {
+  readonly items: readonly T[];
+  readonly tabs: Readonly<Record<TabKey, (item: T) => boolean>>;
+  /**
+   * The tab selected on mount. Only read during the first render —
+   * subsequent changes are ignored. Use `setTab` to change the tab after mount.
+   */
+  readonly defaultTab: TabKey;
+  /**
+   * Called once per item with the already-normalized (trimmed + lowercased)
+   * search query. Must be stable between renders (wrap in `useCallback`) for
+   * the hook's internal memoization to be effective.
+   */
+  readonly searchPredicate: (item: T, normalizedQuery: string) => boolean;
+}
+
+export interface FilterableListResult<T, TabKey extends string> {
+  readonly tab: TabKey;
+  readonly setTab: (tab: TabKey) => void;
+  readonly searchQuery: string;
+  readonly setSearchQuery: (query: string) => void;
+  readonly normalizedQuery: string;
+  /** Items that match the search query, before any tab filter is applied. */
+  readonly filteredItems: readonly T[];
+  /** Items that match the search query AND the active tab predicate. */
+  readonly visibleItems: readonly T[];
+  readonly tabCounts: Readonly<Record<TabKey, number>>;
+}
+
+/**
+ * Encapsulates the shared "filter by tab + search" pattern used by list views
+ * such as Issues and MyPRs.
+ *
+ * The hook owns the tab and search-query state, normalizes the query once
+ * (trim + lowercase), short-circuits the search predicate for empty queries,
+ * and exposes both the visible items for the active tab and per-tab counts
+ * computed from the search-filtered set.
+ *
+ * For best performance, pass a stable `tabs` object (module-level constant)
+ * and a `useCallback`-wrapped `searchPredicate`.
+ */
+export function useFilterableList<T, TabKey extends string>({
+  items,
+  tabs,
+  defaultTab,
+  searchPredicate,
+}: FilterableListConfig<T, TabKey>): FilterableListResult<T, TabKey> {
+  const [tab, setTab] = useState<TabKey>(defaultTab);
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const normalizedQuery = useMemo(() => searchQuery.trim().toLowerCase(), [searchQuery]);
+
+  const filteredItems = useMemo<readonly T[]>(
+    () =>
+      normalizedQuery.length === 0
+        ? items
+        : items.filter((item) => searchPredicate(item, normalizedQuery)),
+    [items, normalizedQuery, searchPredicate],
+  );
+
+  const tabCounts = useMemo<Readonly<Record<TabKey, number>>>(() => {
+    const tabKeys = Object.keys(tabs) as TabKey[];
+    return Object.fromEntries(
+      tabKeys.map((key) => [key, filteredItems.filter(tabs[key]).length]),
+    ) as Record<TabKey, number>;
+  }, [filteredItems, tabs]);
+
+  const visibleItems = useMemo<readonly T[]>(
+    () => filteredItems.filter(tabs[tab]),
+    [filteredItems, tabs, tab],
+  );
+
+  return {
+    tab,
+    setTab,
+    searchQuery,
+    setSearchQuery,
+    normalizedQuery,
+    filteredItems,
+    visibleItems,
+    tabCounts,
+  };
+}

--- a/src/hooks/useFilterableList.ts
+++ b/src/hooks/useFilterableList.ts
@@ -60,17 +60,26 @@ export function useFilterableList<T, TabKey extends string>({
     [items, normalizedQuery, searchPredicate],
   );
 
-  const tabCounts = useMemo<Readonly<Record<TabKey, number>>>(() => {
+  // Partition filteredItems by tab in a single pass, then derive both
+  // `tabCounts` and `visibleItems` from the buckets. This avoids the previous
+  // double pass where the active tab was filtered once for `tabCounts` and
+  // then again for `visibleItems`.
+  const tabBuckets = useMemo<Readonly<Record<TabKey, readonly T[]>>>(() => {
     const tabKeys = Object.keys(tabs) as TabKey[];
     return Object.fromEntries(
-      tabKeys.map((key) => [key, filteredItems.filter(tabs[key]).length]),
-    ) as Record<TabKey, number>;
+      tabKeys.map((key) => [key, filteredItems.filter(tabs[key])]),
+    ) as unknown as Record<TabKey, readonly T[]>;
   }, [filteredItems, tabs]);
 
-  const visibleItems = useMemo<readonly T[]>(
-    () => filteredItems.filter(tabs[tab]),
-    [filteredItems, tabs, tab],
+  const tabCounts = useMemo<Readonly<Record<TabKey, number>>>(
+    () =>
+      Object.fromEntries(
+        (Object.keys(tabBuckets) as TabKey[]).map((key) => [key, tabBuckets[key].length]),
+      ) as Record<TabKey, number>,
+    [tabBuckets],
   );
+
+  const visibleItems = tabBuckets[tab];
 
   return {
     tab,


### PR DESCRIPTION
Closes #216

## Summary

- New `useFilterableList<T, TabKey>` hook at `src/hooks/useFilterableList.ts` owning tab + search state, search-query normalization, short-circuit on empty query, and memoized `filteredItems` / `visibleItems` / `tabCounts`.
- `Issues.tsx` and `MyPRs.tsx` refactored to consume the hook — ~50 lines of duplicated filter logic eliminated, JSX/styling/a11y preserved unchanged.
- 14 new unit tests in `useFilterableList.test.ts` covering initial state, tab switching, search filtering, query normalization, short-circuit, combined filter+search, tab counts, and props updates.

## Why not ReviewQueue?

Issue #216 lists ReviewQueue among the duplicated components, but its filter state lives in the Zustand dashboard store (not local), it has no search field, it sorts by priority, and it honors a cross-component \`focusMode\` flag. Forcing it into the hook would either add dead state or force a different abstraction shape. Left intact by design.

## Performance notes

- The hook uses \`useMemo\` for all derived arrays, so when \`items\`, \`tabs\`, and \`searchPredicate\` are referentially stable the filter chain short-circuits on re-render.
- Both consumers wrap \`searchPredicate\` in \`useCallback(…, [repoMap])\` and declare \`tabs\` as a module-level constant (\`ISSUE_TABS\`, \`PR_TABS\`) to make the memoization effective.

## Test plan

- [x] \`npm test\` — 576/576 passing (47 files)
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run lint\` (oxlint) — 0 warnings, 0 errors
- [x] \`./node_modules/.bin/oxfmt --check\` on changed files — pass
- [x] Adversarial review (typescript-reviewer + code-reviewer) — HIGH findings addressed:
  - Replaced \`reduce\` mutation with \`Object.fromEntries\` (immutability rule)
  - Wrapped consumer \`searchPredicate\` closures in \`useCallback\` for referential stability
  - Added JSDoc note that \`defaultTab\` is initial-only (non-reactive)
  - Added inline comment in \`MyPRs.tsx\` explaining why the section count sums tab buckets instead of using \`filteredItems.length\` (PR \`state\` includes \"closed\" which belongs to no tab)
- [ ] Manual smoke test: open dashboard → switch tabs on Issues + MyPRs → type in the search box → confirm identical behavior to \`main\`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted a reusable `useFilterableList<T, TabKey>` hook to unify tab + search filtering across list views, and optimized per-tab computation. Refactored `Issues` and `MyPRs` to use it with identical UI and behavior. Addresses Linear #216.

- **Refactors**
  - Added `src/hooks/useFilterableList.ts` to own tab/search state, normalize queries, short-circuit empty searches, memoize results, and partition `filteredItems` into tab buckets in one pass to derive `tabCounts` and `visibleItems`.
  - Updated `Issues.tsx` and `MyPRs.tsx` to use the hook; counts now read from `tabCounts`.

- **Tests**
  - Added 15 unit tests, including a regression test asserting `defaultTab` is initial-only and coverage for short-circuiting, query normalization, combined filters, tab switching, and tab counts.

<sup>Written for commit db33679e0b64b12000888fbe1d7b32946f17a77f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated filtering, tabbing, and search into a shared hook used by Issues and MyPRs, simplifying state and improving consistency.
  * Tab counts and visible lists now derive from the centralized logic for more accurate counts and smoother UI updates.

* **Tests**
  * Added a comprehensive test suite for the shared filtering behavior covering search, tab switching, counts, persistence, and empty states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->