### PR TITLE
refactor(settings): decompose Settings into focused sub-components

### DIFF
--- a/src/components/Settings/GitHubSettings.tsx
+++ b/src/components/Settings/GitHubSettings.tsx
@@ -1,0 +1,32 @@
+import { useState, type ReactElement } from "react";
+import type { AppConfig } from "../../lib/types";
+import { AuthSetup } from "../AuthSetup/AuthSetup";
+import { NumberField } from "./NumberField";
+import { useConfigMutation } from "./useConfigMutation";
+import { sectionClass } from "./styles";
+
+interface GitHubSettingsProps {
+  readonly config: AppConfig;
+  readonly onError: (message: string | null) => void;
+}
+
+export function GitHubSettings({ config, onError }: GitHubSettingsProps): ReactElement {
+  const [resetKey, setResetKey] = useState(0);
+  const configMutation = useConfigMutation({
+    onError,
+    onResetDraft: () => setResetKey((k) => k + 1),
+  });
+
+  return (
+    <div data-testid="settings-github" className={sectionClass}>
+      <h2 className="text-accent text-sm font-semibold uppercase tracking-wider">GitHub</h2>
+      <AuthSetup />
+      <NumberField
+        key={resetKey}
+        label="Poll interval (seconds)"
+        value={config.pollIntervalSecs}
+        onCommit={(v) => configMutation.mutate({ pollIntervalSecs: v })}
+      />
+    </div>
+  );
+}

--- a/src/components/Settings/NumberField.tsx
+++ b/src/components/Settings/NumberField.tsx
@@ -1,0 +1,37 @@
+import { useState, type ReactElement } from "react";
+import { FOCUS_RING } from "../../lib/a11y";
+
+interface NumberFieldProps {
+  readonly label: string;
+  readonly value: number;
+  readonly min?: number;
+  readonly onCommit: (value: number) => void;
+}
+
+export function NumberField({ label, value, min = 1, onCommit }: NumberFieldProps): ReactElement {
+  const [draft, setDraft] = useState(String(value));
+
+  function handleBlur(): void {
+    const parsed = Number(draft);
+    if (Number.isInteger(parsed) && parsed >= min && parsed !== value) {
+      onCommit(parsed);
+    } else {
+      setDraft(String(value));
+    }
+  }
+
+  return (
+    <label className="flex items-center justify-between gap-4">
+      <span className="text-dim text-sm">{label}</span>
+      <input
+        type="number"
+        min={min}
+        step={1}
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={handleBlur}
+        className={`${FOCUS_RING} bg-surface border-border w-24 rounded border px-2 py-1 font-mono text-sm text-white`}
+      />
+    </label>
+  );
+}

--- a/src/components/Settings/NumberField.tsx
+++ b/src/components/Settings/NumberField.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactElement } from "react";
+import { useEffect, useState, type ReactElement } from "react";
 import { FOCUS_RING } from "../../lib/a11y";
 
 interface NumberFieldProps {
@@ -10,6 +10,13 @@ interface NumberFieldProps {
 
 export function NumberField({ label, value, min = 1, onCommit }: NumberFieldProps): ReactElement {
   const [draft, setDraft] = useState(String(value));
+
+  // Sync draft when the committed value changes externally (e.g. backend
+  // normalisation after a successful save). Remount via `key` still handles
+  // the error-reset path where `value` is unchanged.
+  useEffect(() => {
+    setDraft(String(value));
+  }, [value]);
 
   function handleBlur(): void {
     const parsed = Number(draft);

--- a/src/components/Settings/RepositorySettings.tsx
+++ b/src/components/Settings/RepositorySettings.tsx
@@ -1,0 +1,240 @@
+import { useState, type ReactElement } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { FOCUS_RING } from "../../lib/a11y";
+import { listRepos, setRepoEnabled } from "../../lib/tauri";
+import type { Repo } from "../../lib/types";
+import { useDebounce } from "../../hooks/useDebounce";
+
+interface RepoUpdate {
+  readonly repoId: string;
+  readonly enabled: boolean;
+}
+
+interface RepoGroup {
+  readonly org: string;
+  readonly repos: readonly Repo[];
+}
+
+interface RepoBatchUpdateError extends Error {
+  failedRepoIds: readonly string[];
+}
+
+interface RepoRowProps {
+  readonly repo: Repo;
+  readonly disabled: boolean;
+  readonly onToggle: (repoId: string, enabled: boolean) => void;
+}
+
+function RepoRow({ repo, disabled, onToggle }: RepoRowProps): ReactElement {
+  return (
+    <label className="flex items-center justify-between gap-3 py-1">
+      <span className="min-w-0 truncate font-mono text-sm text-white" title={repo.name}>
+        {repo.name}
+      </span>
+      <input
+        type="checkbox"
+        checked={repo.enabled}
+        disabled={disabled}
+        onChange={() => onToggle(repo.id, !repo.enabled)}
+        className={`${FOCUS_RING} accent-accent h-4 w-4`}
+      />
+    </label>
+  );
+}
+
+function groupReposByOrg(repos: readonly Repo[]): readonly RepoGroup[] {
+  const groups = new Map<string, Repo[]>();
+
+  for (const repo of repos) {
+    const existing = groups.get(repo.org);
+    if (existing) {
+      existing.push(repo);
+    } else {
+      groups.set(repo.org, [repo]);
+    }
+  }
+
+  return Array.from(groups.entries())
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([org, orgRepos]) => ({
+      org,
+      repos: [...orgRepos].sort((left, right) => left.name.localeCompare(right.name)),
+    }));
+}
+
+function buildRepoUpdates(
+  repos: readonly Repo[],
+  getNextEnabled: (repo: Repo) => boolean,
+): readonly RepoUpdate[] {
+  const updates: RepoUpdate[] = [];
+
+  for (const repo of repos) {
+    const enabled = getNextEnabled(repo);
+    if (enabled !== repo.enabled) {
+      updates.push({ repoId: repo.id, enabled });
+    }
+  }
+
+  return updates;
+}
+
+function createRepoBatchUpdateError(failedRepoIds: readonly string[]): RepoBatchUpdateError {
+  const error = new Error("Failed to update some repositories.") as RepoBatchUpdateError;
+  error.failedRepoIds = failedRepoIds;
+  return error;
+}
+
+function getRepoBatchUpdateErrorMessage(err: unknown): string {
+  if (
+    typeof err === "object" &&
+    err !== null &&
+    "failedRepoIds" in err &&
+    Array.isArray(err.failedRepoIds) &&
+    err.failedRepoIds.length > 0
+  ) {
+    return `Failed to update repositories: ${err.failedRepoIds.join(", ")}`;
+  }
+
+  return "Failed to update repositories. Please retry.";
+}
+
+const controlButtonClass = `${FOCUS_RING} rounded border border-border px-2 py-1 text-xs font-medium text-dim transition-colors hover:border-accent hover:text-white disabled:cursor-not-allowed disabled:opacity-50`;
+
+interface RepositorySettingsProps {
+  readonly onError: (message: string | null) => void;
+}
+
+export function RepositorySettings({
+  onError: reportError,
+}: RepositorySettingsProps): ReactElement {
+  const queryClient = useQueryClient();
+  const reposQuery = useQuery({ queryKey: ["repos"], queryFn: listRepos });
+  const [repoSearch, setRepoSearch] = useState("");
+  const debouncedRepoSearch = useDebounce(repoSearch, 150);
+
+  const repoToggleMutation = useMutation({
+    mutationFn: async (updates: readonly RepoUpdate[]) => {
+      const results = await Promise.allSettled(
+        updates.map(({ repoId, enabled }) => setRepoEnabled(repoId, enabled)),
+      );
+      const failedRepoIds: string[] = [];
+
+      for (const [index, result] of results.entries()) {
+        const update = updates[index];
+        if (result.status === "rejected" && update) {
+          failedRepoIds.push(update.repoId);
+        }
+      }
+
+      if (failedRepoIds.length > 0) {
+        throw createRepoBatchUpdateError(failedRepoIds);
+      }
+    },
+    onMutate: () => reportError(null),
+    onError: (err: unknown) => {
+      console.error("[RepositorySettings] repo toggle failed:", err);
+      reportError(getRepoBatchUpdateErrorMessage(err));
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["repos"] });
+    },
+  });
+
+  const allRepos = reposQuery.data ?? [];
+  const searchLower = debouncedRepoSearch.toLowerCase();
+  const filteredSettingsRepos = allRepos.filter(
+    (r) =>
+      r.name.toLowerCase().includes(searchLower) || r.fullName.toLowerCase().includes(searchLower),
+  );
+  const groupedSettingsRepos = groupReposByOrg(filteredSettingsRepos);
+  const enabledReposCount = allRepos.filter((repo) => repo.enabled).length;
+
+  function mutateRepoUpdates(updates: readonly RepoUpdate[]): void {
+    if (updates.length === 0) {
+      return;
+    }
+
+    repoToggleMutation.mutate(updates);
+  }
+
+  return (
+    <div data-testid="settings-repos" className="flex flex-col gap-3">
+      <div className="flex flex-col gap-1">
+        <h2 className="text-accent text-sm font-semibold uppercase tracking-wider">Repositories</h2>
+        <p className="text-dim text-sm">
+          {enabledReposCount} of {allRepos.length} repositories enabled
+        </p>
+      </div>
+      <input
+        type="search"
+        placeholder="Filter repositories..."
+        value={repoSearch}
+        onChange={(e) => setRepoSearch(e.target.value)}
+        className={`${FOCUS_RING} bg-surface border-border rounded border px-2 py-1 text-sm text-white placeholder:text-muted`}
+      />
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          onClick={() => mutateRepoUpdates(buildRepoUpdates(filteredSettingsRepos, () => true))}
+          disabled={repoToggleMutation.isPending || filteredSettingsRepos.length === 0}
+          className={controlButtonClass}
+        >
+          Select all
+        </button>
+        <button
+          type="button"
+          onClick={() => mutateRepoUpdates(buildRepoUpdates(filteredSettingsRepos, () => false))}
+          disabled={repoToggleMutation.isPending || filteredSettingsRepos.length === 0}
+          className={controlButtonClass}
+        >
+          Deselect all
+        </button>
+        <button
+          type="button"
+          onClick={() =>
+            mutateRepoUpdates(buildRepoUpdates(filteredSettingsRepos, (repo) => !repo.enabled))
+          }
+          disabled={repoToggleMutation.isPending || filteredSettingsRepos.length === 0}
+          className={controlButtonClass}
+        >
+          Invert selection
+        </button>
+        {debouncedRepoSearch.trim() ? (
+          <span className="text-dim text-xs">
+            {filteredSettingsRepos.length} matching current filter
+          </span>
+        ) : null}
+      </div>
+      {reposQuery.isLoading ? (
+        <span className="text-dim text-sm">Loading repositories...</span>
+      ) : reposQuery.error ? (
+        <span className="text-sm text-red-400">Failed to load repositories</span>
+      ) : allRepos.length === 0 ? (
+        <span className="text-dim text-sm">No repositories synced</span>
+      ) : filteredSettingsRepos.length === 0 ? (
+        <span className="text-dim text-sm">No repos match</span>
+      ) : (
+        <div className="flex flex-col gap-4">
+          {groupedSettingsRepos.map((group) => (
+            <div key={group.org} className="flex flex-col gap-1">
+              <div className="flex items-center justify-between gap-3">
+                <h3 className="font-mono text-xs uppercase tracking-wide text-dim">{group.org}/</h3>
+                <span className="text-dim text-xs">
+                  {group.repos.filter((repo) => repo.enabled).length}/{group.repos.length} enabled
+                </span>
+              </div>
+              {group.repos.map((repo) => (
+                <RepoRow
+                  key={repo.id}
+                  repo={repo}
+                  disabled={repoToggleMutation.isPending}
+                  onToggle={(repoId, enabled) => mutateRepoUpdates([{ repoId, enabled }])}
+                />
+              ))}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Settings/RepositorySettings.tsx
+++ b/src/components/Settings/RepositorySettings.tsx
@@ -165,13 +165,16 @@ export function RepositorySettings({
           {enabledReposCount} of {allRepos.length} repositories enabled
         </p>
       </div>
-      <input
-        type="search"
-        placeholder="Filter repositories..."
-        value={repoSearch}
-        onChange={(e) => setRepoSearch(e.target.value)}
-        className={`${FOCUS_RING} bg-surface border-border rounded border px-2 py-1 text-sm text-white placeholder:text-muted`}
-      />
+      <label className="flex flex-col gap-1">
+        <span className="sr-only">Filter repositories</span>
+        <input
+          type="search"
+          placeholder="Filter repositories..."
+          value={repoSearch}
+          onChange={(e) => setRepoSearch(e.target.value)}
+          className={`${FOCUS_RING} bg-surface border-border rounded border px-2 py-1 text-sm text-white placeholder:text-muted`}
+        />
+      </label>
       <div className="flex flex-wrap items-center gap-2">
         <button
           type="button"

--- a/src/components/Settings/Settings.test.tsx
+++ b/src/components/Settings/Settings.test.tsx
@@ -271,7 +271,7 @@ describe("Settings", () => {
     renderWithProviders(<Settings />);
 
     const reposSection = await screen.findByTestId("settings-repos");
-    const toggle = within(reposSection).getByRole("checkbox");
+    const toggle = await within(reposSection).findByRole("checkbox");
     await user.click(toggle);
 
     expect(mockedSetRepoEnabled).toHaveBeenCalledWith("repo-1", false);
@@ -335,7 +335,8 @@ describe("Settings", () => {
     await user.tab();
 
     await screen.findByRole("alert");
-    await waitFor(() => expect(input).toHaveValue(300));
+    // NumberField remounts on reset (keyed by resetKey), so re-query the input
+    await waitFor(() => expect(screen.getByLabelText(/poll interval/i)).toHaveValue(300));
   });
 
   it("should render stats section", async () => {

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -1,216 +1,19 @@
-import { useEffect, useState, type ReactElement } from "react";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { FOCUS_RING } from "../../lib/a11y";
-import { getConfig, setConfig, listRepos, setRepoEnabled } from "../../lib/tauri";
-import type { PartialAppConfig, Repo } from "../../lib/types";
-import { AuthSetup } from "../AuthSetup/AuthSetup";
+import { useState, type ReactElement } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { getConfig } from "../../lib/tauri";
+import { GitHubSettings } from "./GitHubSettings";
+import { WorkspaceSettings } from "./WorkspaceSettings";
+import { RepositorySettings } from "./RepositorySettings";
 import { Stats } from "./Stats";
 import { DebugInfo } from "./DebugInfo";
-import { useDebounce } from "../../hooks/useDebounce";
 
 function useConfigQuery() {
   return useQuery({ queryKey: ["config"], queryFn: getConfig });
 }
 
-function useReposQuery() {
-  return useQuery({ queryKey: ["repos"], queryFn: listRepos });
-}
-
-interface RepoUpdate {
-  readonly repoId: string;
-  readonly enabled: boolean;
-}
-
-interface RepoGroup {
-  readonly org: string;
-  readonly repos: readonly Repo[];
-}
-
-interface RepoBatchUpdateError extends Error {
-  failedRepoIds: readonly string[];
-}
-
-interface NumberFieldProps {
-  readonly label: string;
-  readonly value: number;
-  readonly min?: number;
-  readonly resetKey: number;
-  readonly onCommit: (value: number) => void;
-}
-
-function NumberField({
-  label,
-  value,
-  min = 1,
-  resetKey,
-  onCommit,
-}: NumberFieldProps): ReactElement {
-  const [draft, setDraft] = useState(String(value));
-
-  useEffect(() => {
-    setDraft(String(value));
-  }, [value, resetKey]);
-
-  function handleBlur(): void {
-    const parsed = Number(draft);
-    if (Number.isInteger(parsed) && parsed >= min && parsed !== value) {
-      onCommit(parsed);
-    } else {
-      setDraft(String(value));
-    }
-  }
-
-  return (
-    <label className="flex items-center justify-between gap-4">
-      <span className="text-dim text-sm">{label}</span>
-      <input
-        type="number"
-        min={min}
-        step={1}
-        value={draft}
-        onChange={(e) => setDraft(e.target.value)}
-        onBlur={handleBlur}
-        className={`${FOCUS_RING} bg-surface border-border w-24 rounded border px-2 py-1 font-mono text-sm text-white`}
-      />
-    </label>
-  );
-}
-
-interface RepoRowProps {
-  readonly repo: Repo;
-  readonly disabled: boolean;
-  readonly onToggle: (repoId: string, enabled: boolean) => void;
-}
-
-function RepoRow({ repo, disabled, onToggle }: RepoRowProps): ReactElement {
-  return (
-    <label className="flex items-center justify-between gap-3 py-1">
-      <span className="min-w-0 truncate font-mono text-sm text-white" title={repo.name}>
-        {repo.name}
-      </span>
-      <input
-        type="checkbox"
-        checked={repo.enabled}
-        disabled={disabled}
-        onChange={() => onToggle(repo.id, !repo.enabled)}
-        className={`${FOCUS_RING} accent-accent h-4 w-4`}
-      />
-    </label>
-  );
-}
-
-function groupReposByOrg(repos: readonly Repo[]): readonly RepoGroup[] {
-  const groups = new Map<string, Repo[]>();
-
-  for (const repo of repos) {
-    const existing = groups.get(repo.org);
-    if (existing) {
-      existing.push(repo);
-    } else {
-      groups.set(repo.org, [repo]);
-    }
-  }
-
-  return Array.from(groups.entries())
-    .sort(([left], [right]) => left.localeCompare(right))
-    .map(([org, orgRepos]) => ({
-      org,
-      repos: [...orgRepos].sort((left, right) => left.name.localeCompare(right.name)),
-    }));
-}
-
-function buildRepoUpdates(
-  repos: readonly Repo[],
-  getNextEnabled: (repo: Repo) => boolean,
-): readonly RepoUpdate[] {
-  const updates: RepoUpdate[] = [];
-
-  for (const repo of repos) {
-    const enabled = getNextEnabled(repo);
-    if (enabled !== repo.enabled) {
-      updates.push({ repoId: repo.id, enabled });
-    }
-  }
-
-  return updates;
-}
-
-function createRepoBatchUpdateError(failedRepoIds: readonly string[]): RepoBatchUpdateError {
-  const error = new Error("Failed to update some repositories.") as RepoBatchUpdateError;
-  error.failedRepoIds = failedRepoIds;
-  return error;
-}
-
-function getRepoBatchUpdateErrorMessage(err: unknown): string {
-  if (
-    typeof err === "object" &&
-    err !== null &&
-    "failedRepoIds" in err &&
-    Array.isArray(err.failedRepoIds) &&
-    err.failedRepoIds.length > 0
-  ) {
-    return `Failed to update repositories: ${err.failedRepoIds.join(", ")}`;
-  }
-
-  return "Failed to update repositories. Please retry.";
-}
-
-const sectionClass = "flex flex-col gap-3 border-b border-border pb-4";
-const controlButtonClass = `${FOCUS_RING} rounded border border-border px-2 py-1 text-xs font-medium text-dim transition-colors hover:border-accent hover:text-white disabled:cursor-not-allowed disabled:opacity-50`;
-
 export function Settings(): ReactElement {
-  const queryClient = useQueryClient();
   const configQuery = useConfigQuery();
-  const reposQuery = useReposQuery();
   const [saveError, setSaveError] = useState<string | null>(null);
-  const [resetKey, setResetKey] = useState(0);
-  const [repoSearch, setRepoSearch] = useState("");
-  const debouncedRepoSearch = useDebounce(repoSearch, 150);
-
-  const configMutation = useMutation({
-    mutationFn: (partial: PartialAppConfig) => setConfig(partial),
-    onMutate: () => {
-      setSaveError(null);
-    },
-    onSuccess: (updated) => {
-      queryClient.setQueryData(["config"], updated);
-    },
-    onError: (err: unknown) => {
-      console.error("[Settings] config update failed:", err);
-      setSaveError("Failed to save setting. Please retry.");
-      setResetKey((k) => k + 1);
-    },
-  });
-
-  const repoToggleMutation = useMutation({
-    mutationFn: async (updates: readonly RepoUpdate[]) => {
-      const results = await Promise.allSettled(
-        updates.map(({ repoId, enabled }) => setRepoEnabled(repoId, enabled)),
-      );
-      const failedRepoIds: string[] = [];
-
-      for (const [index, result] of results.entries()) {
-        const update = updates[index];
-        if (result.status === "rejected" && update) {
-          failedRepoIds.push(update.repoId);
-        }
-      }
-
-      if (failedRepoIds.length > 0) {
-        throw createRepoBatchUpdateError(failedRepoIds);
-      }
-    },
-    onSuccess: () => {
-      setSaveError(null);
-    },
-    onError: (err: unknown) => {
-      console.error("[Settings] repo toggle failed:", err);
-      setSaveError(getRepoBatchUpdateErrorMessage(err));
-    },
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: ["repos"] });
-    },
-  });
 
   if (configQuery.error && !configQuery.data) {
     return (
@@ -229,22 +32,6 @@ export function Settings(): ReactElement {
   }
 
   const config = configQuery.data;
-  const allRepos = reposQuery.data ?? [];
-  const searchLower = debouncedRepoSearch.toLowerCase();
-  const filteredSettingsRepos = allRepos.filter(
-    (r) =>
-      r.name.toLowerCase().includes(searchLower) || r.fullName.toLowerCase().includes(searchLower),
-  );
-  const groupedSettingsRepos = groupReposByOrg(filteredSettingsRepos);
-  const enabledReposCount = allRepos.filter((repo) => repo.enabled).length;
-
-  function mutateRepoUpdates(updates: readonly RepoUpdate[]): void {
-    if (updates.length === 0) {
-      return;
-    }
-
-    repoToggleMutation.mutate(updates);
-  }
 
   return (
     <section data-testid="settings" className="flex h-full flex-col gap-6 overflow-y-auto p-4">
@@ -256,109 +43,9 @@ export function Settings(): ReactElement {
         </p>
       ) : null}
 
-      <div data-testid="settings-github" className={sectionClass}>
-        <h2 className="text-accent text-sm font-semibold uppercase tracking-wider">GitHub</h2>
-        <AuthSetup />
-        <NumberField
-          label="Poll interval (seconds)"
-          value={config.pollIntervalSecs}
-          resetKey={resetKey}
-          onCommit={(v) => configMutation.mutate({ pollIntervalSecs: v })}
-        />
-      </div>
-
-      <div data-testid="settings-workspaces" className={sectionClass}>
-        <h2 className="text-accent text-sm font-semibold uppercase tracking-wider">Workspaces</h2>
-        <NumberField
-          label="Max active workspaces"
-          value={config.maxActiveWorkspaces}
-          resetKey={resetKey}
-          onCommit={(v) => configMutation.mutate({ maxActiveWorkspaces: v })}
-        />
-      </div>
-
-      <div data-testid="settings-repos" className="flex flex-col gap-3">
-        <div className="flex flex-col gap-1">
-          <h2 className="text-accent text-sm font-semibold uppercase tracking-wider">
-            Repositories
-          </h2>
-          <p className="text-dim text-sm">
-            {enabledReposCount} of {allRepos.length} repositories enabled
-          </p>
-        </div>
-        <input
-          type="search"
-          placeholder="Filter repositories..."
-          value={repoSearch}
-          onChange={(e) => setRepoSearch(e.target.value)}
-          className={`${FOCUS_RING} bg-surface border-border rounded border px-2 py-1 text-sm text-white placeholder:text-muted`}
-        />
-        <div className="flex flex-wrap items-center gap-2">
-          <button
-            type="button"
-            onClick={() => mutateRepoUpdates(buildRepoUpdates(filteredSettingsRepos, () => true))}
-            disabled={repoToggleMutation.isPending || filteredSettingsRepos.length === 0}
-            className={controlButtonClass}
-          >
-            Select all
-          </button>
-          <button
-            type="button"
-            onClick={() => mutateRepoUpdates(buildRepoUpdates(filteredSettingsRepos, () => false))}
-            disabled={repoToggleMutation.isPending || filteredSettingsRepos.length === 0}
-            className={controlButtonClass}
-          >
-            Deselect all
-          </button>
-          <button
-            type="button"
-            onClick={() =>
-              mutateRepoUpdates(buildRepoUpdates(filteredSettingsRepos, (repo) => !repo.enabled))
-            }
-            disabled={repoToggleMutation.isPending || filteredSettingsRepos.length === 0}
-            className={controlButtonClass}
-          >
-            Invert selection
-          </button>
-          {debouncedRepoSearch.trim() ? (
-            <span className="text-dim text-xs">
-              {filteredSettingsRepos.length} matching current filter
-            </span>
-          ) : null}
-        </div>
-        {reposQuery.isLoading ? (
-          <span className="text-dim text-sm">Loading repositories...</span>
-        ) : reposQuery.error ? (
-          <span className="text-sm text-red-400">Failed to load repositories</span>
-        ) : allRepos.length === 0 ? (
-          <span className="text-dim text-sm">No repositories synced</span>
-        ) : filteredSettingsRepos.length === 0 ? (
-          <span className="text-dim text-sm">No repos match</span>
-        ) : (
-          <div className="flex flex-col gap-4">
-            {groupedSettingsRepos.map((group) => (
-              <div key={group.org} className="flex flex-col gap-1">
-                <div className="flex items-center justify-between gap-3">
-                  <h3 className="font-mono text-xs uppercase tracking-wide text-dim">
-                    {group.org}/
-                  </h3>
-                  <span className="text-dim text-xs">
-                    {group.repos.filter((repo) => repo.enabled).length}/{group.repos.length} enabled
-                  </span>
-                </div>
-                {group.repos.map((repo) => (
-                  <RepoRow
-                    key={repo.id}
-                    repo={repo}
-                    disabled={repoToggleMutation.isPending}
-                    onToggle={(repoId, enabled) => mutateRepoUpdates([{ repoId, enabled }])}
-                  />
-                ))}
-              </div>
-            ))}
-          </div>
-        )}
-      </div>
+      <GitHubSettings config={config} onError={setSaveError} />
+      <WorkspaceSettings config={config} onError={setSaveError} />
+      <RepositorySettings onError={setSaveError} />
 
       <Stats />
 

--- a/src/components/Settings/WorkspaceSettings.tsx
+++ b/src/components/Settings/WorkspaceSettings.tsx
@@ -1,0 +1,30 @@
+import { useState, type ReactElement } from "react";
+import type { AppConfig } from "../../lib/types";
+import { NumberField } from "./NumberField";
+import { useConfigMutation } from "./useConfigMutation";
+import { sectionClass } from "./styles";
+
+interface WorkspaceSettingsProps {
+  readonly config: AppConfig;
+  readonly onError: (message: string | null) => void;
+}
+
+export function WorkspaceSettings({ config, onError }: WorkspaceSettingsProps): ReactElement {
+  const [resetKey, setResetKey] = useState(0);
+  const configMutation = useConfigMutation({
+    onError,
+    onResetDraft: () => setResetKey((k) => k + 1),
+  });
+
+  return (
+    <div data-testid="settings-workspaces" className={sectionClass}>
+      <h2 className="text-accent text-sm font-semibold uppercase tracking-wider">Workspaces</h2>
+      <NumberField
+        key={resetKey}
+        label="Max active workspaces"
+        value={config.maxActiveWorkspaces}
+        onCommit={(v) => configMutation.mutate({ maxActiveWorkspaces: v })}
+      />
+    </div>
+  );
+}

--- a/src/components/Settings/styles.ts
+++ b/src/components/Settings/styles.ts
@@ -1,0 +1,1 @@
+export const sectionClass = "flex flex-col gap-3 border-b border-border pb-4";

--- a/src/components/Settings/useConfigMutation.ts
+++ b/src/components/Settings/useConfigMutation.ts
@@ -17,9 +17,16 @@ export function useConfigMutation({ onError, onResetDraft }: UseConfigMutationOp
       queryClient.setQueryData(["config"], updated);
     },
     onError: (err: unknown) => {
-      console.error("[Settings] config update failed:", err);
+      console.error("[useConfigMutation] config update failed:", err);
       onError("Failed to save setting. Please retry.");
       onResetDraft();
+    },
+    // Safety net for out-of-order concurrent saves: if two sections mutate at
+    // once, the slower response could overwrite the cache with an older
+    // snapshot via `setQueryData`. Invalidating on settle pulls the canonical
+    // state from the backend as the source of truth.
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["config"] });
     },
   });
 }

--- a/src/components/Settings/useConfigMutation.ts
+++ b/src/components/Settings/useConfigMutation.ts
@@ -1,0 +1,25 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { setConfig } from "../../lib/tauri";
+import type { PartialAppConfig } from "../../lib/types";
+
+interface UseConfigMutationOptions {
+  readonly onError: (message: string | null) => void;
+  readonly onResetDraft: () => void;
+}
+
+export function useConfigMutation({ onError, onResetDraft }: UseConfigMutationOptions) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (partial: PartialAppConfig) => setConfig(partial),
+    onMutate: () => onError(null),
+    onSuccess: (updated) => {
+      queryClient.setQueryData(["config"], updated);
+    },
+    onError: (err: unknown) => {
+      console.error("[Settings] config update failed:", err);
+      onError("Failed to save setting. Please retry.");
+      onResetDraft();
+    },
+  });
+}


### PR DESCRIPTION
Closes #215.

## Summary
- `Settings.tsx` shrinks from **368 → 55 lines** by extracting three section components (`GitHubSettings`, `WorkspaceSettings`, `RepositorySettings`), a shared `NumberField`, a shared `useConfigMutation` hook, and a shared `styles.ts`.
- Each section owns its own config mutation through `useConfigMutation`, which hits the shared `["config"]` query cache via `queryClient.setQueryData` — no refetch loops, no prop-drilled mutations.
- Parent `Settings` holds only `saveError` and passes a single `onError: (msg | null) => void` callback. Each section clears the error on mutate and sets it on failure through the same callback.
- `NumberField` resets via React `key` prop instead of a `useEffect`-driven counter (per review). Each section owns its own local `resetKey` state, triggered by `onResetDraft` returned from the hook.

## File breakdown
| File | Lines | Role |
|---|---|---|
| `Settings.tsx` | 55 | Orchestrator |
| `GitHubSettings.tsx` | 32 | Auth + poll interval |
| `WorkspaceSettings.tsx` | 30 | Max active workspaces |
| `RepositorySettings.tsx` | 240 | Repo list, filter, batch actions |
| `NumberField.tsx` | 37 | Shared numeric input |
| `useConfigMutation.ts` | 25 | Shared config mutation |
| `styles.ts` | 1 | Shared `sectionClass` |

## Test plan
- [x] `npm test` — 577/577 tests pass (unchanged count, same assertions)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors on 124 files
- [x] `npx oxfmt --check` — clean on all modified files
- [x] Existing `Settings.test.tsx` integration tests preserved; two minor test-only adjustments:
  - `findByRole("checkbox")` instead of `getByRole` to handle async repo load in child component
  - Re-query poll-interval input after remount (since `NumberField` now uses `key={resetKey}`)
- [x] Adversarial review (typescript-reviewer): 2 HIGH + 1 MEDIUM findings, all addressed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decomposed the Settings page into focused sub-components and shared helpers, shrinking `Settings.tsx` from 368 to 55 lines and simplifying state and mutations. Implements Linear #215 by making each section own its updates and avoiding refetch loops and prop-drilling.

- **Refactors**
  - Extracted `GitHubSettings`, `WorkspaceSettings`, `RepositorySettings`, shared `NumberField`, `useConfigMutation`, and `styles`.
  - Sections use `useConfigMutation` to update the `["config"]` cache; the parent only holds `saveError` and passes `onError`.
  - `NumberField` now resets via a React `key`; each section manages a local `resetKey` via the hook’s `onResetDraft`.
  - Repository settings: debounced filter, grouped by org, select/deselect/invert batch actions, aggregated error reporting for failed updates, and `["repos"]` invalidation after mutations.

- **Bug Fixes**
  - `NumberField` syncs its draft when the committed value changes externally; keeps key-based remount for error-reset.
  - `useConfigMutation` invalidates `["config"]` on settle to avoid stale cache after concurrent saves.
  - `RepositorySettings` search input is wrapped in a label with an sr-only name for stable accessibility.

<sup>Written for commit 372f6f23d1aa4000125e05b0fcc7faac9191521e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Settings page split into dedicated GitHub, Workspace, and Repository sections
  * GitHub auth setup and editable poll interval; workspace max-active setting
  * Repository management UI with search/filter, per-repo toggles and bulk controls (Select all / Deselect all / Invert)

* **Bug Fixes**
  * Improved handling of failed saves: inputs reset and user-friendly error shown

* **Tests**
  * Updated tests for repo toggles and config-field reset behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->