### PR TITLE
perf(github): increase staleTime to 5min for event-driven hooks

### DIFF
--- a/src/hooks/useGitHubData.ts
+++ b/src/hooks/useGitHubData.ts
@@ -1,14 +1,11 @@
 import { useEffect, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import {
-  getGithubDashboard,
-  getGithubStats,
-  forceGithubSync,
-  onEvent,
-} from "../lib/tauri";
+import { getGithubDashboard, getGithubStats, forceGithubSync, onEvent } from "../lib/tauri";
 import { TAURI_EVENTS } from "../lib/types/tauri";
 
-const STALE_TIME = 30_000;
+// 5 minutes: desktop app relies on Tauri event-based invalidation
+// (github:updated) for real-time freshness, so time-based polling can be relaxed.
+const STALE_TIME = 300_000;
 
 function invalidateGitHub(queryClient: ReturnType<typeof useQueryClient>) {
   return Promise.all([
@@ -57,52 +54,60 @@ export function useGitHubData(refetchInterval?: number) {
     onEvent(TAURI_EVENTS["github:updated"], async () => {
       setSyncError(null);
       await invalidateGitHub(queryClient);
-    }).then((fn) => {
-      if (cancelled) {
-        fn();
-      } else {
-        unlisteners.push(fn);
-      }
-    }).catch((err: unknown) => {
-      console.error("[useGitHubData] failed to register github:updated listener:", err);
-    });
+    })
+      .then((fn) => {
+        if (cancelled) {
+          fn();
+        } else {
+          unlisteners.push(fn);
+        }
+      })
+      .catch((err: unknown) => {
+        console.error("[useGitHubData] failed to register github:updated listener:", err);
+      });
 
     onEvent<string>(TAURI_EVENTS["auth:expired"], () => {
       setAuthExpired(true);
-    }).then((fn) => {
-      if (cancelled) {
-        fn();
-      } else {
-        unlisteners.push(fn);
-      }
-    }).catch((err: unknown) => {
-      console.error("[useGitHubData] failed to register auth:expired listener:", err);
-    });
+    })
+      .then((fn) => {
+        if (cancelled) {
+          fn();
+        } else {
+          unlisteners.push(fn);
+        }
+      })
+      .catch((err: unknown) => {
+        console.error("[useGitHubData] failed to register auth:expired listener:", err);
+      });
 
     onEvent<string>(TAURI_EVENTS["auth:restored"], async () => {
       setAuthExpired(false);
       await invalidateGitHub(queryClient);
-    }).then((fn) => {
-      if (cancelled) {
-        fn();
-      } else {
-        unlisteners.push(fn);
-      }
-    }).catch((err: unknown) => {
-      console.error("[useGitHubData] failed to register auth:restored listener:", err);
-    });
+    })
+      .then((fn) => {
+        if (cancelled) {
+          fn();
+        } else {
+          unlisteners.push(fn);
+        }
+      })
+      .catch((err: unknown) => {
+        console.error("[useGitHubData] failed to register auth:restored listener:", err);
+      });
 
     onEvent<string>(TAURI_EVENTS["github:sync_error"], (errorMsg) => {
       setSyncError(typeof errorMsg === "string" ? errorMsg : "Sync failed");
-    }).then((fn) => {
-      if (cancelled) {
-        fn();
-      } else {
-        unlisteners.push(fn);
-      }
-    }).catch((err: unknown) => {
-      console.error("[useGitHubData] failed to register github:sync_error listener:", err);
-    });
+    })
+      .then((fn) => {
+        if (cancelled) {
+          fn();
+        } else {
+          unlisteners.push(fn);
+        }
+      })
+      .catch((err: unknown) => {
+        console.error("[useGitHubData] failed to register github:sync_error listener:", err);
+      });
 
     return () => {
       cancelled = true;

--- a/src/hooks/useWorkspaceEnriched.ts
+++ b/src/hooks/useWorkspaceEnriched.ts
@@ -4,7 +4,9 @@ import { listWorkspacesEnriched, onEvent } from "../lib/tauri";
 import { TAURI_EVENTS } from "../lib/types/tauri";
 import type { WorkspaceListEntry, WorkspaceStatusInfo } from "../lib/types/workspace";
 
-const STALE_TIME = 30_000;
+// 5 minutes: workspace freshness is driven by the workspace:state_changed
+// Tauri event, so time-based polling can be relaxed.
+const STALE_TIME = 300_000;
 
 export function useWorkspaceEnriched(enabled = true) {
   const queryClient = useQueryClient();
@@ -61,10 +63,7 @@ export function useWorkspaceEnriched(enabled = true) {
     return map;
   }, [query.data]);
 
-  const entries: readonly WorkspaceListEntry[] = useMemo(
-    () => query.data ?? [],
-    [query.data],
-  );
+  const entries: readonly WorkspaceListEntry[] = useMemo(() => query.data ?? [], [query.data]);
 
   return { statusInfo, entries, isLoading: query.isLoading };
 }


### PR DESCRIPTION
## Summary

- Raise `STALE_TIME` from `30_000` (30s) to `300_000` (5min) in `useGitHubData.ts` and `useWorkspaceEnriched.ts`
- Rely on existing Tauri event-based invalidation (`github:updated`, `workspace:state_changed`) for real-time freshness
- Reduce redundant background fetches triggered by window focus on a desktop app

## Why

The app already has a robust push-based invalidation system via Tauri events. A 30-second `staleTime` on top of that caused frequent refetches each time the window regained focus, wasting network bandwidth, CPU, and power — with no freshness benefit since events already invalidate the cache immediately on backend changes.

## Trade-off

If a Tauri event is missed (e.g. backend crash, subscription bug), data could stay visibly stale for up to 5 minutes instead of 30 seconds. Mitigations already in place:

- Manual `forceSync` button in `useGitHubData`
- Error logging on event-listener registration failures
- `invalidateGitHub` called on every successful event

## Test plan

- [x] `npx tsc --noEmit` — no type errors
- [x] `oxlint` — 0 warnings, 0 errors
- [x] `oxfmt` — formatting applied
- [x] `vitest run` — 577 tests pass
- [ ] Manual smoke test: open app, verify dashboard/workspaces still update on backend sync events

Closes #211

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Addresses #211 by raising `STALE_TIME` to 5 minutes in `useGitHubData` and `useWorkspaceEnriched`, relying on Tauri events (`github:updated`, `workspace:state_changed`) for real-time freshness and preventing refetches on window focus. This reduces network/CPU usage; in rare missed-event cases, data may stay stale for up to 5 minutes.

<sup>Written for commit f5ca3b40392856568588a1b2aa98e556e2e9f054. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated data caching behavior for GitHub dashboard and workspace information to reduce refresh frequency, allowing data to persist longer before being refetched.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->