### PR TITLE
perf(ui): memoize view components to prevent unnecessary re-renders

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,15 @@ import { useWorkspaceEnriched } from "./hooks/useWorkspaceEnriched";
 import { useWorkspacesStore } from "./stores/workspaces";
 import { openUrl } from "./lib/open";
 import type { DashboardView } from "./stores/dashboard";
+import type { PullRequestWithReview } from "./lib/types/dashboard";
+import type { Issue } from "./lib/types/github";
+
+// Module-level empty fallbacks preserve referential stability across renders
+// when `dashboard` is undefined. Inline `?? []` would defeat React.memo on the
+// consuming view components by producing a fresh array each render.
+const EMPTY_REVIEWS: readonly PullRequestWithReview[] = [];
+const EMPTY_MY_PRS: readonly PullRequestWithReview[] = [];
+const EMPTY_ISSUES: readonly Issue[] = [];
 
 const WorkspaceView = lazy(() =>
   import("./components/Workspace").then((m) => ({ default: m.WorkspaceView })),
@@ -155,11 +164,23 @@ function MainContent({ view, onBackToDashboard }: MainContentProps): ReactElemen
     case "overview":
       return <Overview />;
     case "reviews":
-      return <ReviewQueue reviews={dashboard?.reviewRequests ?? []} onOpen={openUrl} onWorkspaceAction={handleWorkspaceAction} />;
+      return (
+        <ReviewQueue
+          reviews={dashboard?.reviewRequests ?? EMPTY_REVIEWS}
+          onOpen={openUrl}
+          onWorkspaceAction={handleWorkspaceAction}
+        />
+      );
     case "mine":
-      return <MyPRs prs={dashboard?.myPullRequests ?? []} onOpen={openUrl} onWorkspaceAction={handleWorkspaceAction} />;
+      return (
+        <MyPRs
+          prs={dashboard?.myPullRequests ?? EMPTY_MY_PRS}
+          onOpen={openUrl}
+          onWorkspaceAction={handleWorkspaceAction}
+        />
+      );
     case "issues":
-      return <Issues issues={dashboard?.assignedIssues ?? []} onOpen={openUrl} />;
+      return <Issues issues={dashboard?.assignedIssues ?? EMPTY_ISSUES} onOpen={openUrl} />;
     case "feed":
       return (
         <ActivityFeed

--- a/src/components/Issues/Issues.memo.test.tsx
+++ b/src/components/Issues/Issues.memo.test.tsx
@@ -1,0 +1,111 @@
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Issue, Repo } from "../../lib/types/github";
+
+// Hoisted spies so the `vi.mock` factories (hoisted) can reference them.
+const { issueCardSpy, mockUseQuery } = vi.hoisted(() => ({
+  issueCardSpy: vi.fn(),
+  mockUseQuery: vi.fn(),
+}));
+
+// Mock useVirtualizer so every item is always in the virtual window (deterministic).
+vi.mock("@tanstack/react-virtual", () => ({
+  useVirtualizer: (opts: { count: number; estimateSize: (i: number) => number }) => ({
+    getVirtualItems: () =>
+      Array.from({ length: opts.count }, (_, i) => ({
+        index: i,
+        key: i,
+        start: i * opts.estimateSize(i),
+        size: opts.estimateSize(i),
+      })),
+    getTotalSize: () => opts.count * opts.estimateSize(0),
+  }),
+}));
+
+// Mock useQuery for the `listRepos` call inside Issues.
+vi.mock("@tanstack/react-query", async () => {
+  const actual = await vi.importActual("@tanstack/react-query");
+  return {
+    ...actual,
+    useQuery: mockUseQuery,
+  };
+});
+
+// Replace IssueCard with a light stub that counts render calls.
+vi.mock("./IssueCard", () => ({
+  IssueCard: (props: Record<string, unknown>) => {
+    issueCardSpy(props);
+    return null;
+  },
+}));
+
+// Import AFTER the mocks so the hoisted mocks win.
+import { Issues } from "./Issues";
+
+function makeRepo(): Repo {
+  return {
+    id: "repo-1",
+    org: "org",
+    name: "repo",
+    fullName: "org/repo",
+    url: "https://github.com/org/repo",
+    defaultBranch: "main",
+    isArchived: false,
+    enabled: true,
+    localPath: null,
+    lastSyncAt: null,
+  };
+}
+
+function makeIssue(number: number): Issue {
+  return {
+    id: `issue-${number}`,
+    number,
+    title: `Issue ${number}`,
+    author: "alice",
+    state: "open",
+    priority: "medium",
+    repoId: "repo-1",
+    url: `https://github.com/org/repo/issues/${number}`,
+    labels: [],
+    createdAt: "2026-04-11T10:00:00Z",
+    updatedAt: "2026-04-11T10:00:00Z",
+  };
+}
+
+describe("Issues memoization", () => {
+  beforeEach(() => {
+    issueCardSpy.mockClear();
+    mockUseQuery.mockReturnValue({ data: [makeRepo()] });
+  });
+
+  it("should skip re-rendering child cards when props references are stable", () => {
+    // Behavioural check for React.memo: mount once, then re-render with the
+    // exact same prop references. A memoized component bails out of the
+    // update, so IssueCard is not invoked again.
+    const issues: readonly Issue[] = [makeIssue(1), makeIssue(2)];
+    const onOpen = vi.fn();
+
+    const { rerender } = render(<Issues issues={issues} onOpen={onOpen} />);
+    const callsAfterMount = issueCardSpy.mock.calls.length;
+    expect(callsAfterMount).toBe(2);
+
+    rerender(<Issues issues={issues} onOpen={onOpen} />);
+
+    expect(issueCardSpy.mock.calls.length).toBe(callsAfterMount);
+  });
+
+  it("should re-render child cards when props change", () => {
+    // Sanity check: without stable refs, the component must still update.
+    const initial: readonly Issue[] = [makeIssue(1)];
+    const updated: readonly Issue[] = [makeIssue(1), makeIssue(2)];
+    const onOpen = vi.fn();
+
+    const { rerender } = render(<Issues issues={initial} onOpen={onOpen} />);
+    const callsAfterMount = issueCardSpy.mock.calls.length;
+
+    rerender(<Issues issues={updated} onOpen={onOpen} />);
+
+    expect(issueCardSpy.mock.calls.length).toBeGreaterThan(callsAfterMount);
+  });
+});

--- a/src/components/Issues/Issues.test.tsx
+++ b/src/components/Issues/Issues.test.tsx
@@ -3,7 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { FOCUS_RING } from "../../lib/a11y";
 import type { Issue, Repo } from "../../lib/types/github";
-import { Issues, IssuesImpl } from "./Issues";
+import { Issues } from "./Issues";
 
 vi.mock("@tanstack/react-virtual", () => ({
   useVirtualizer: (opts: { count: number; estimateSize: (i: number) => number }) => ({
@@ -251,10 +251,4 @@ describe("Issues", () => {
     expect(screen.getByText("unknown-repo")).toBeInTheDocument();
   });
 
-  it("should export a memoized component distinct from the raw implementation", () => {
-    // The exported `Issues` is `memo(IssuesImpl)`, so it must not be
-    // referentially equal to the raw function. This guards the memo wrapping
-    // without relying on React-internal symbols like `$$typeof`.
-    expect(Issues).not.toBe(IssuesImpl);
-  });
 });

--- a/src/components/Issues/Issues.test.tsx
+++ b/src/components/Issues/Issues.test.tsx
@@ -3,7 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { FOCUS_RING } from "../../lib/a11y";
 import type { Issue, Repo } from "../../lib/types/github";
-import { Issues } from "./Issues";
+import { Issues, IssuesImpl } from "./Issues";
 
 vi.mock("@tanstack/react-virtual", () => ({
   useVirtualizer: (opts: { count: number; estimateSize: (i: number) => number }) => ({
@@ -251,10 +251,10 @@ describe("Issues", () => {
     expect(screen.getByText("unknown-repo")).toBeInTheDocument();
   });
 
-  it("should be wrapped in React.memo to bail out of re-renders on stable props", () => {
-    // React.memo sets `$$typeof` to Symbol.for("react.memo") on the exported value.
-    // This structural check guarantees the optimization cannot be accidentally removed.
-    const memoSymbol = (Issues as unknown as { readonly $$typeof?: symbol }).$$typeof;
-    expect(memoSymbol).toBe(Symbol.for("react.memo"));
+  it("should export a memoized component distinct from the raw implementation", () => {
+    // The exported `Issues` is `memo(IssuesImpl)`, so it must not be
+    // referentially equal to the raw function. This guards the memo wrapping
+    // without relying on React-internal symbols like `$$typeof`.
+    expect(Issues).not.toBe(IssuesImpl);
   });
 });

--- a/src/components/Issues/Issues.test.tsx
+++ b/src/components/Issues/Issues.test.tsx
@@ -250,4 +250,11 @@ describe("Issues", () => {
 
     expect(screen.getByText("unknown-repo")).toBeInTheDocument();
   });
+
+  it("should be wrapped in React.memo to bail out of re-renders on stable props", () => {
+    // React.memo sets `$$typeof` to Symbol.for("react.memo") on the exported value.
+    // This structural check guarantees the optimization cannot be accidentally removed.
+    const memoSymbol = (Issues as unknown as { readonly $$typeof?: symbol }).$$typeof;
+    expect(memoSymbol).toBe(Symbol.for("react.memo"));
+  });
 });

--- a/src/components/Issues/Issues.tsx
+++ b/src/components/Issues/Issues.tsx
@@ -25,8 +25,7 @@ const ISSUE_TABS: Readonly<Record<Tab, (issue: Issue) => boolean>> = {
   closed: (issue) => issue.state === "closed",
 };
 
-// Exported for testing only — the memoized `Issues` below is the public API.
-export function IssuesImpl({ issues, isLoading = false, onOpen }: IssuesProps): ReactElement {
+function IssuesImpl({ issues, isLoading = false, onOpen }: IssuesProps): ReactElement {
   const parentRef = useRef<HTMLDivElement>(null);
   const { data: repos } = useQuery({ queryKey: ["repos"], queryFn: listRepos });
 

--- a/src/components/Issues/Issues.tsx
+++ b/src/components/Issues/Issues.tsx
@@ -1,6 +1,6 @@
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { useQuery } from "@tanstack/react-query";
-import { type ReactElement, useCallback, useEffect, useMemo, useRef } from "react";
+import { memo, type ReactElement, useCallback, useEffect, useMemo, useRef } from "react";
 import { FOCUS_RING } from "../../lib/a11y";
 import { listRepos } from "../../lib/tauri";
 import { FILTER_BUTTON_CLASS } from "../../lib/uiClasses";
@@ -25,7 +25,7 @@ const ISSUE_TABS: Readonly<Record<Tab, (issue: Issue) => boolean>> = {
   closed: (issue) => issue.state === "closed",
 };
 
-export function Issues({ issues, isLoading = false, onOpen }: IssuesProps): ReactElement {
+function IssuesImpl({ issues, isLoading = false, onOpen }: IssuesProps): ReactElement {
   const parentRef = useRef<HTMLDivElement>(null);
   const { data: repos } = useQuery({ queryKey: ["repos"], queryFn: listRepos });
 
@@ -179,3 +179,5 @@ export function Issues({ issues, isLoading = false, onOpen }: IssuesProps): Reac
     </section>
   );
 }
+
+export const Issues = memo(IssuesImpl);

--- a/src/components/Issues/Issues.tsx
+++ b/src/components/Issues/Issues.tsx
@@ -25,7 +25,8 @@ const ISSUE_TABS: Readonly<Record<Tab, (issue: Issue) => boolean>> = {
   closed: (issue) => issue.state === "closed",
 };
 
-function IssuesImpl({ issues, isLoading = false, onOpen }: IssuesProps): ReactElement {
+// Exported for testing only — the memoized `Issues` below is the public API.
+export function IssuesImpl({ issues, isLoading = false, onOpen }: IssuesProps): ReactElement {
   const parentRef = useRef<HTMLDivElement>(null);
   const { data: repos } = useQuery({ queryKey: ["repos"], queryFn: listRepos });
 

--- a/src/components/MyPRs/MyPRs.memo.test.tsx
+++ b/src/components/MyPRs/MyPRs.memo.test.tsx
@@ -1,0 +1,113 @@
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PullRequestWithReview } from "../../lib/types/dashboard";
+import type { Repo } from "../../lib/types/github";
+
+// Hoisted spies so the `vi.mock` factories (hoisted) can reference them.
+const { myPrCardSpy, mockUseQuery } = vi.hoisted(() => ({
+  myPrCardSpy: vi.fn(),
+  mockUseQuery: vi.fn(),
+}));
+
+// Mock the `useQuery` used by MyPRs for listRepos so the component renders
+// synchronously with a stable empty result.
+vi.mock("@tanstack/react-query", async () => {
+  const actual = await vi.importActual("@tanstack/react-query");
+  return {
+    ...actual,
+    useQuery: mockUseQuery,
+  };
+});
+
+// Replace MyPrCard with a light stub that counts render calls.
+vi.mock("./MyPrCard", () => ({
+  MyPrCard: (props: Record<string, unknown>) => {
+    myPrCardSpy(props);
+    return null;
+  },
+}));
+
+// Import AFTER the mocks so the hoisted mocks win.
+import { MyPRs } from "./MyPRs";
+
+function makeRepo(): Repo {
+  return {
+    id: "repo-1",
+    org: "org",
+    name: "repo",
+    fullName: "org/repo",
+    url: "https://github.com/org/repo",
+    defaultBranch: "main",
+    isArchived: false,
+    enabled: true,
+    localPath: null,
+    lastSyncAt: null,
+  };
+}
+
+function makePr(number: number): PullRequestWithReview {
+  return {
+    pullRequest: {
+      id: `pr-${number}`,
+      number,
+      title: `PR ${number}`,
+      author: "me",
+      state: "open",
+      ciStatus: "success",
+      priority: "medium",
+      repoId: "repo-1",
+      url: `https://github.com/org/repo/pull/${number}`,
+      headRefName: `fix/test-${number}`,
+      labels: [],
+      additions: 0,
+      deletions: 0,
+      createdAt: "2026-04-11T10:00:00Z",
+      updatedAt: "2026-04-11T10:00:00Z",
+    },
+    reviewSummary: {
+      totalReviews: 0,
+      approved: 0,
+      changesRequested: 0,
+      pending: 0,
+      reviewers: [],
+    },
+    workspace: null,
+  };
+}
+
+describe("MyPRs memoization", () => {
+  beforeEach(() => {
+    myPrCardSpy.mockClear();
+    mockUseQuery.mockReturnValue({ data: [makeRepo()] });
+  });
+
+  it("should skip re-rendering child cards when props references are stable", () => {
+    // Behavioural check for React.memo: mount once, then re-render with the
+    // exact same prop references. A memoized component bails out of the
+    // update, so MyPrCard is not invoked again.
+    const prs: readonly PullRequestWithReview[] = [makePr(1), makePr(2)];
+    const onOpen = vi.fn();
+
+    const { rerender } = render(<MyPRs prs={prs} onOpen={onOpen} />);
+    const callsAfterMount = myPrCardSpy.mock.calls.length;
+    expect(callsAfterMount).toBe(2);
+
+    rerender(<MyPRs prs={prs} onOpen={onOpen} />);
+
+    expect(myPrCardSpy.mock.calls.length).toBe(callsAfterMount);
+  });
+
+  it("should re-render child cards when props change", () => {
+    // Sanity check: without stable refs, the component must still update.
+    const initial: readonly PullRequestWithReview[] = [makePr(1)];
+    const updated: readonly PullRequestWithReview[] = [makePr(1), makePr(2)];
+    const onOpen = vi.fn();
+
+    const { rerender } = render(<MyPRs prs={initial} onOpen={onOpen} />);
+    const callsAfterMount = myPrCardSpy.mock.calls.length;
+
+    rerender(<MyPRs prs={updated} onOpen={onOpen} />);
+
+    expect(myPrCardSpy.mock.calls.length).toBeGreaterThan(callsAfterMount);
+  });
+});

--- a/src/components/MyPRs/MyPRs.test.tsx
+++ b/src/components/MyPRs/MyPRs.test.tsx
@@ -220,4 +220,11 @@ describe("MyPRs", () => {
 
     expect(onOpen).toHaveBeenCalledWith(openPr1.pullRequest.url);
   });
+
+  it("should be wrapped in React.memo to bail out of re-renders on stable props", () => {
+    // React.memo sets `$$typeof` to Symbol.for("react.memo") on the exported value.
+    // This structural check guarantees the optimization cannot be accidentally removed.
+    const memoSymbol = (MyPRs as unknown as { readonly $$typeof?: symbol }).$$typeof;
+    expect(memoSymbol).toBe(Symbol.for("react.memo"));
+  });
 });

--- a/src/components/MyPRs/MyPRs.test.tsx
+++ b/src/components/MyPRs/MyPRs.test.tsx
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { FOCUS_RING } from "../../lib/a11y";
 import type { PullRequestWithReview } from "../../lib/types/dashboard";
 import type { Repo } from "../../lib/types/github";
-import { MyPRs } from "./MyPRs";
+import { MyPRs, MyPRsImpl } from "./MyPRs";
 
 const { mockUseQuery } = vi.hoisted(() => ({ mockUseQuery: vi.fn() }));
 
@@ -221,10 +221,10 @@ describe("MyPRs", () => {
     expect(onOpen).toHaveBeenCalledWith(openPr1.pullRequest.url);
   });
 
-  it("should be wrapped in React.memo to bail out of re-renders on stable props", () => {
-    // React.memo sets `$$typeof` to Symbol.for("react.memo") on the exported value.
-    // This structural check guarantees the optimization cannot be accidentally removed.
-    const memoSymbol = (MyPRs as unknown as { readonly $$typeof?: symbol }).$$typeof;
-    expect(memoSymbol).toBe(Symbol.for("react.memo"));
+  it("should export a memoized component distinct from the raw implementation", () => {
+    // The exported `MyPRs` is `memo(MyPRsImpl)`, so it must not be
+    // referentially equal to the raw function. This guards the memo wrapping
+    // without relying on React-internal symbols like `$$typeof`.
+    expect(MyPRs).not.toBe(MyPRsImpl);
   });
 });

--- a/src/components/MyPRs/MyPRs.test.tsx
+++ b/src/components/MyPRs/MyPRs.test.tsx
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { FOCUS_RING } from "../../lib/a11y";
 import type { PullRequestWithReview } from "../../lib/types/dashboard";
 import type { Repo } from "../../lib/types/github";
-import { MyPRs, MyPRsImpl } from "./MyPRs";
+import { MyPRs } from "./MyPRs";
 
 const { mockUseQuery } = vi.hoisted(() => ({ mockUseQuery: vi.fn() }));
 
@@ -221,10 +221,4 @@ describe("MyPRs", () => {
     expect(onOpen).toHaveBeenCalledWith(openPr1.pullRequest.url);
   });
 
-  it("should export a memoized component distinct from the raw implementation", () => {
-    // The exported `MyPRs` is `memo(MyPRsImpl)`, so it must not be
-    // referentially equal to the raw function. This guards the memo wrapping
-    // without relying on React-internal symbols like `$$typeof`.
-    expect(MyPRs).not.toBe(MyPRsImpl);
-  });
 });

--- a/src/components/MyPRs/MyPRs.tsx
+++ b/src/components/MyPRs/MyPRs.tsx
@@ -36,8 +36,7 @@ const PR_TABS: Readonly<Record<Tab, (pr: PullRequestWithReview) => boolean>> = {
   merged: (pr) => pr.pullRequest.state === "merged",
 };
 
-// Exported for testing only — the memoized `MyPRs` below is the public API.
-export function MyPRsImpl({
+function MyPRsImpl({
   prs,
   isLoading = false,
   onOpen,

--- a/src/components/MyPRs/MyPRs.tsx
+++ b/src/components/MyPRs/MyPRs.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { type ReactElement, useCallback, useEffect, useMemo, useRef } from "react";
+import { memo, type ReactElement, useCallback, useEffect, useMemo, useRef } from "react";
 import { FOCUS_RING } from "../../lib/a11y";
 import { listRepos } from "../../lib/tauri";
 import { FILTER_BUTTON_CLASS } from "../../lib/uiClasses";
@@ -36,7 +36,7 @@ const PR_TABS: Readonly<Record<Tab, (pr: PullRequestWithReview) => boolean>> = {
   merged: (pr) => pr.pullRequest.state === "merged",
 };
 
-export function MyPRs({
+function MyPRsImpl({
   prs,
   isLoading = false,
   onOpen,
@@ -174,3 +174,5 @@ export function MyPRs({
     </section>
   );
 }
+
+export const MyPRs = memo(MyPRsImpl);

--- a/src/components/MyPRs/MyPRs.tsx
+++ b/src/components/MyPRs/MyPRs.tsx
@@ -36,7 +36,8 @@ const PR_TABS: Readonly<Record<Tab, (pr: PullRequestWithReview) => boolean>> = {
   merged: (pr) => pr.pullRequest.state === "merged",
 };
 
-function MyPRsImpl({
+// Exported for testing only — the memoized `MyPRs` below is the public API.
+export function MyPRsImpl({
   prs,
   isLoading = false,
   onOpen,

--- a/src/components/ReviewQueue/ReviewQueue.memo.test.tsx
+++ b/src/components/ReviewQueue/ReviewQueue.memo.test.tsx
@@ -1,0 +1,85 @@
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PullRequestWithReview } from "../../lib/types/dashboard";
+import { useDashboardStore } from "../../stores/dashboard";
+
+// Hoisted spy so the `vi.mock` factory (which is hoisted) can reference it.
+const { reviewCardSpy } = vi.hoisted(() => ({ reviewCardSpy: vi.fn() }));
+
+// Replace ReviewCard with a light stub that counts render calls.
+vi.mock("./ReviewCard", () => ({
+  ReviewCard: (props: Record<string, unknown>) => {
+    reviewCardSpy(props);
+    return null;
+  },
+}));
+
+// Import AFTER the mock so the hoisted mock wins.
+import { ReviewQueue } from "./ReviewQueue";
+
+function makePr(number: number): PullRequestWithReview {
+  return {
+    pullRequest: {
+      id: `pr-${number}`,
+      number,
+      title: `PR ${number}`,
+      author: "test",
+      state: "open",
+      ciStatus: "success",
+      priority: "medium",
+      repoId: "repo-1",
+      url: `https://github.com/org/repo/pull/${number}`,
+      headRefName: `fix/test-${number}`,
+      labels: [],
+      additions: 0,
+      deletions: 0,
+      createdAt: "2026-04-11T10:00:00Z",
+      updatedAt: "2026-04-11T10:00:00Z",
+    },
+    reviewSummary: {
+      totalReviews: 0,
+      approved: 0,
+      changesRequested: 0,
+      pending: 0,
+      reviewers: [],
+    },
+    workspace: null,
+  };
+}
+
+describe("ReviewQueue memoization", () => {
+  beforeEach(() => {
+    reviewCardSpy.mockClear();
+    useDashboardStore.setState({ activeFilters: {}, focusMode: false });
+  });
+
+  it("should skip re-rendering child cards when props references are stable", () => {
+    // Behavioural check for React.memo: mount once, then re-render with the
+    // exact same prop references. A memoized component bails out of the
+    // update, so its children (here: ReviewCard) are not invoked again.
+    const reviews: readonly PullRequestWithReview[] = [makePr(1), makePr(2)];
+    const onOpen = vi.fn();
+
+    const { rerender } = render(<ReviewQueue reviews={reviews} onOpen={onOpen} />);
+    const callsAfterMount = reviewCardSpy.mock.calls.length;
+    expect(callsAfterMount).toBe(2);
+
+    rerender(<ReviewQueue reviews={reviews} onOpen={onOpen} />);
+
+    expect(reviewCardSpy.mock.calls.length).toBe(callsAfterMount);
+  });
+
+  it("should re-render child cards when props change", () => {
+    // Sanity check: without stable refs, the component must still update.
+    const initial: readonly PullRequestWithReview[] = [makePr(1)];
+    const updated: readonly PullRequestWithReview[] = [makePr(1), makePr(2)];
+    const onOpen = vi.fn();
+
+    const { rerender } = render(<ReviewQueue reviews={initial} onOpen={onOpen} />);
+    const callsAfterMount = reviewCardSpy.mock.calls.length;
+
+    rerender(<ReviewQueue reviews={updated} onOpen={onOpen} />);
+
+    expect(reviewCardSpy.mock.calls.length).toBeGreaterThan(callsAfterMount);
+  });
+});

--- a/src/components/ReviewQueue/ReviewQueue.test.tsx
+++ b/src/components/ReviewQueue/ReviewQueue.test.tsx
@@ -3,7 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { PullRequestWithReview } from "../../lib/types/dashboard";
 import { useDashboardStore } from "../../stores/dashboard";
-import { ReviewQueue } from "./ReviewQueue";
+import { ReviewQueue, ReviewQueueImpl } from "./ReviewQueue";
 
 function makePr(
   overrides: Partial<PullRequestWithReview["pullRequest"]> = {},
@@ -331,11 +331,10 @@ describe("ReviewQueue", () => {
     });
   });
 
-  it("should be wrapped in React.memo to bail out of re-renders on stable props", () => {
-    // React.memo sets `$$typeof` to Symbol.for("react.memo") on the exported value.
-    // This structural check guarantees the optimization cannot be accidentally removed.
-    const memoSymbol = (ReviewQueue as unknown as { readonly $$typeof?: symbol })
-      .$$typeof;
-    expect(memoSymbol).toBe(Symbol.for("react.memo"));
+  it("should export a memoized component distinct from the raw implementation", () => {
+    // The exported `ReviewQueue` is `memo(ReviewQueueImpl)`, so it must not
+    // be referentially equal to the raw function. This guards the memo
+    // wrapping without relying on React-internal symbols like `$$typeof`.
+    expect(ReviewQueue).not.toBe(ReviewQueueImpl);
   });
 });

--- a/src/components/ReviewQueue/ReviewQueue.test.tsx
+++ b/src/components/ReviewQueue/ReviewQueue.test.tsx
@@ -3,7 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { PullRequestWithReview } from "../../lib/types/dashboard";
 import { useDashboardStore } from "../../stores/dashboard";
-import { ReviewQueue, ReviewQueueImpl } from "./ReviewQueue";
+import { ReviewQueue } from "./ReviewQueue";
 
 function makePr(
   overrides: Partial<PullRequestWithReview["pullRequest"]> = {},
@@ -331,10 +331,4 @@ describe("ReviewQueue", () => {
     });
   });
 
-  it("should export a memoized component distinct from the raw implementation", () => {
-    // The exported `ReviewQueue` is `memo(ReviewQueueImpl)`, so it must not
-    // be referentially equal to the raw function. This guards the memo
-    // wrapping without relying on React-internal symbols like `$$typeof`.
-    expect(ReviewQueue).not.toBe(ReviewQueueImpl);
-  });
 });

--- a/src/components/ReviewQueue/ReviewQueue.test.tsx
+++ b/src/components/ReviewQueue/ReviewQueue.test.tsx
@@ -330,4 +330,12 @@ describe("ReviewQueue", () => {
       workspaceState: "active",
     });
   });
+
+  it("should be wrapped in React.memo to bail out of re-renders on stable props", () => {
+    // React.memo sets `$$typeof` to Symbol.for("react.memo") on the exported value.
+    // This structural check guarantees the optimization cannot be accidentally removed.
+    const memoSymbol = (ReviewQueue as unknown as { readonly $$typeof?: symbol })
+      .$$typeof;
+    expect(memoSymbol).toBe(Symbol.for("react.memo"));
+  });
 });

--- a/src/components/ReviewQueue/ReviewQueue.tsx
+++ b/src/components/ReviewQueue/ReviewQueue.tsx
@@ -1,4 +1,4 @@
-import { type ReactElement, useEffect, useMemo } from "react";
+import { memo, type ReactElement, useEffect, useMemo } from "react";
 import { FOCUS_RING } from "../../lib/a11y";
 import { FILTER_BUTTON_CLASS } from "../../lib/uiClasses";
 import type { Priority } from "../../lib/types/enums";
@@ -54,7 +54,7 @@ function getUniqueRepos(reviews: readonly PullRequestWithReview[]): readonly str
   return [...new Set(reviews.map((r) => r.pullRequest.repoId))].sort();
 }
 
-export function ReviewQueue({
+function ReviewQueueImpl({
   reviews,
   isLoading = false,
   onOpen,
@@ -195,3 +195,5 @@ export function ReviewQueue({
     </section>
   );
 }
+
+export const ReviewQueue = memo(ReviewQueueImpl);

--- a/src/components/ReviewQueue/ReviewQueue.tsx
+++ b/src/components/ReviewQueue/ReviewQueue.tsx
@@ -54,8 +54,7 @@ function getUniqueRepos(reviews: readonly PullRequestWithReview[]): readonly str
   return [...new Set(reviews.map((r) => r.pullRequest.repoId))].sort();
 }
 
-// Exported for testing only — the memoized `ReviewQueue` below is the public API.
-export function ReviewQueueImpl({
+function ReviewQueueImpl({
   reviews,
   isLoading = false,
   onOpen,

--- a/src/components/ReviewQueue/ReviewQueue.tsx
+++ b/src/components/ReviewQueue/ReviewQueue.tsx
@@ -54,7 +54,8 @@ function getUniqueRepos(reviews: readonly PullRequestWithReview[]): readonly str
   return [...new Set(reviews.map((r) => r.pullRequest.repoId))].sort();
 }
 
-function ReviewQueueImpl({
+// Exported for testing only — the memoized `ReviewQueue` below is the public API.
+export function ReviewQueueImpl({
   reviews,
   isLoading = false,
   onOpen,


### PR DESCRIPTION
## Summary

- Wrap `ReviewQueue`, `MyPRs`, and `Issues` exports in `React.memo` so they bail out of re-renders when props are referentially stable
- Extract module-level `EMPTY_REVIEWS`, `EMPTY_MY_PRS`, `EMPTY_ISSUES` constants in `App.tsx`; inline `?? []` fallbacks would otherwise create new arrays each render and defeat memoization
- Add a structural test per component asserting the export is wrapped in `React.memo` (via `$$typeof === Symbol.for("react.memo")`) so the optimization can't be accidentally removed

## Why

`MainContent` re-runs whenever `useGitHubData()` returns new data, and every background GitHub refresh cascades through the active view. With no memo barrier, `ReviewQueue` / `MyPRs` / `Issues` re-execute their `useMemo` sorting/filtering pipelines even when nothing relevant changed.

The existing function-prop wiring was already stable (`openUrl` is a module import, `handleWorkspaceAction` is `useCallback`), so the only remaining obstacle was:
1. The view components themselves not being memoized
2. Fresh `[]` literals from `?? []` defeating shallow compare when `dashboard` is undefined

Both are fixed here. TanStack Query v5's default `structuralSharing` already keeps `dashboard.reviewRequests` referentially equal between identical query results, so memo will now actually bail out in the steady state.

## Test plan

- [x] `npx vitest run` — 580/580 tests pass (includes 3 new structural memo tests)
- [x] `npx tsc --noEmit` — clean
- [x] `./node_modules/.bin/oxlint src/` — 0 warnings, 0 errors
- [ ] Manual: run the app and confirm React DevTools Profiler shows `ReviewQueue`/`MyPRs`/`Issues` as "Did not render" during background `github:updated` refreshes when data is unchanged

Closes #210

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Memoized the main view components to prevent unnecessary re-renders during background GitHub refreshes. Stabilized empty-array fallbacks so memoization bails out when data is unchanged.

- **Refactors**
  - Wrapped `ReviewQueue`, `MyPRs`, and `Issues` in `React.memo` and exported them as memoized consts.
  - Replaced inline `?? []` with module-level `EMPTY_*` constants in `App.tsx` to keep prop references stable.
  - Added behavior-based tests (`*.memo.test.tsx`) to verify components skip re-rendering when props are unchanged and re-render when they change.

<sup>Written for commit 7a3c0a256d69876f8935fd5525746c4dafbbcb96. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Key UI list components wrapped with memoization to reduce unnecessary re-renders and improve responsiveness.
  * Consolidated empty-array fallbacks to avoid redundant allocations and improve memory efficiency.
* **Tests**
  * Added several memoization-focused tests to verify render stability and guard render optimizations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->