### PR TITLE
feat(settings): add Keyboard Shortcuts section (#198)

### DIFF
--- a/src/components/Settings/KeyboardShortcuts.test.tsx
+++ b/src/components/Settings/KeyboardShortcuts.test.tsx
@@ -139,6 +139,27 @@ describe("KeyboardShortcuts", () => {
     expect(kbds.length).toBe(22);
   });
 
+  it("should render alternative bindings with '/' and chord bindings with '+'", () => {
+    setUserAgent(WINDOWS_UA);
+    const { container } = render(<KeyboardShortcuts />);
+
+    // Alternative bindings (↑/↓, Home/End) must render "/" separators so
+    // users don't read them as simultaneous key combos.
+    const slashSeparators = Array.from(container.querySelectorAll("span")).filter(
+      (el) => el.getAttribute("aria-hidden") === "true" && el.textContent === "/",
+    );
+    // 3 alternative rows: "Navigate sidebar up/down", "Jump to first / last",
+    // "Navigate results" (Command Palette) → 3 separators total.
+    expect(slashSeparators.length).toBe(3);
+
+    // Chord bindings (Mod+K, Mod+1/2/3, Mod+Enter) must still render "+".
+    const plusSeparators = Array.from(container.querySelectorAll("span")).filter(
+      (el) => el.getAttribute("aria-hidden") === "true" && el.textContent === "+",
+    );
+    // 5 chord rows: Mod+K, Mod+1, Mod+2, Mod+3, Mod+Enter → 5 separators.
+    expect(plusSeparators.length).toBe(5);
+  });
+
   it("should render shortcuts inside a definition list structure", () => {
     setUserAgent(WINDOWS_UA);
     const { container } = render(<KeyboardShortcuts />);

--- a/src/components/Settings/KeyboardShortcuts.test.tsx
+++ b/src/components/Settings/KeyboardShortcuts.test.tsx
@@ -1,0 +1,152 @@
+import { type ReactElement } from "react";
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+
+const ORIGINAL_USER_AGENT = window.navigator.userAgent;
+
+function setUserAgent(userAgent: string): void {
+  Object.defineProperty(window.navigator, "userAgent", {
+    value: userAgent,
+    configurable: true,
+  });
+}
+
+const WINDOWS_UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36";
+const MAC_UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15";
+
+let KeyboardShortcuts: () => ReactElement;
+
+beforeEach(async () => {
+  const mod = await import("./KeyboardShortcuts");
+  KeyboardShortcuts = mod.KeyboardShortcuts;
+});
+
+afterEach(() => {
+  Object.defineProperty(window.navigator, "userAgent", {
+    value: ORIGINAL_USER_AGENT,
+    configurable: true,
+  });
+});
+
+describe("KeyboardShortcuts", () => {
+  it("should render section with settings-keyboard-shortcuts test id", () => {
+    setUserAgent(WINDOWS_UA);
+    render(<KeyboardShortcuts />);
+
+    expect(screen.getByTestId("settings-keyboard-shortcuts")).toBeInTheDocument();
+  });
+
+  it("should render the section header", () => {
+    setUserAgent(WINDOWS_UA);
+    render(<KeyboardShortcuts />);
+
+    const section = screen.getByTestId("settings-keyboard-shortcuts");
+    expect(
+      within(section).getByRole("heading", { name: /keyboard shortcuts/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("should render all three shortcut groups", () => {
+    setUserAgent(WINDOWS_UA);
+    render(<KeyboardShortcuts />);
+
+    expect(screen.getByRole("heading", { name: /global/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /list navigation/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /command palette/i })).toBeInTheDocument();
+  });
+
+  it("should display Ctrl label on non-Mac platforms", () => {
+    setUserAgent(WINDOWS_UA);
+    render(<KeyboardShortcuts />);
+
+    const ctrlTokens = screen.getAllByText("Ctrl");
+    expect(ctrlTokens.length).toBeGreaterThan(0);
+    expect(screen.queryByText("⌘")).toBeNull();
+  });
+
+  it("should display ⌘ symbol on Mac platforms", () => {
+    setUserAgent(MAC_UA);
+    render(<KeyboardShortcuts />);
+
+    const cmdTokens = screen.getAllByText("⌘");
+    expect(cmdTokens.length).toBeGreaterThan(0);
+    expect(screen.queryByText("Ctrl")).toBeNull();
+  });
+
+  it("should display Open Command Palette action paired with K key", () => {
+    setUserAgent(WINDOWS_UA);
+    render(<KeyboardShortcuts />);
+
+    expect(screen.getByText(/open command palette/i)).toBeInTheDocument();
+    expect(screen.getByText("K")).toBeInTheDocument();
+  });
+
+  it("should display list navigation shortcuts (j and k)", () => {
+    setUserAgent(WINDOWS_UA);
+    const { container } = render(<KeyboardShortcuts />);
+
+    expect(screen.getByText(/navigate list down/i)).toBeInTheDocument();
+    expect(screen.getByText(/navigate list up/i)).toBeInTheDocument();
+    expect(screen.getByText("j")).toBeInTheDocument();
+    // The "k" lowercase shortcut for navigate-up is distinct from "K" capital for Command Palette
+    const kKbds = Array.from(container.querySelectorAll("kbd")).filter(
+      (el) => el.textContent === "k",
+    );
+    expect(kKbds.length).toBe(1);
+  });
+
+  it("should display Back to overview shortcut", () => {
+    setUserAgent(WINDOWS_UA);
+    render(<KeyboardShortcuts />);
+
+    expect(screen.getByText(/back to overview/i)).toBeInTheDocument();
+    // Esc appears at least twice (back to overview + close palette)
+    const escTokens = screen.getAllByText("Esc");
+    expect(escTokens.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("should display the three workspace-switching shortcuts", () => {
+    setUserAgent(WINDOWS_UA);
+    render(<KeyboardShortcuts />);
+
+    expect(screen.getByText(/switch to workspace 1/i)).toBeInTheDocument();
+    expect(screen.getByText(/switch to workspace 2/i)).toBeInTheDocument();
+    expect(screen.getByText(/switch to workspace 3/i)).toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("should display Command Palette specific shortcuts", () => {
+    setUserAgent(WINDOWS_UA);
+    render(<KeyboardShortcuts />);
+
+    expect(screen.getByText(/navigate results/i)).toBeInTheDocument();
+    expect(screen.getByText(/open result in browser/i)).toBeInTheDocument();
+    expect(screen.getByText(/close palette/i)).toBeInTheDocument();
+  });
+
+  it("should wrap every key token in a <kbd> element", () => {
+    setUserAgent(WINDOWS_UA);
+    const { container } = render(<KeyboardShortcuts />);
+
+    const kbds = container.querySelectorAll("kbd");
+    // 14 shortcuts total across 3 groups producing 22 <kbd> tokens:
+    //   Global (5): Ctrl+K, Esc, Ctrl+1, Ctrl+2, Ctrl+3 = 9 kbds
+    //   List Navigation (6): j, k, ↑/↓, Home/End, Enter, w = 8 kbds
+    //   Command Palette (3): ↑/↓, Ctrl+Enter, Esc = 5 kbds
+    // Locking the exact count catches accidental catalog drift.
+    expect(kbds.length).toBe(22);
+  });
+
+  it("should render shortcuts inside a definition list structure", () => {
+    setUserAgent(WINDOWS_UA);
+    const { container } = render(<KeyboardShortcuts />);
+
+    // Each group uses a <dl> with <dt> action / <dd> keys
+    const dls = container.querySelectorAll("dl");
+    expect(dls.length).toBe(3);
+    const dts = container.querySelectorAll("dt");
+    expect(dts.length).toBeGreaterThanOrEqual(13);
+  });
+});

--- a/src/components/Settings/KeyboardShortcuts.tsx
+++ b/src/components/Settings/KeyboardShortcuts.tsx
@@ -1,0 +1,108 @@
+import type { ReactElement } from "react";
+
+interface ShortcutRow {
+  readonly action: string;
+  readonly keys: readonly string[];
+}
+
+interface ShortcutGroup {
+  readonly title: string;
+  readonly shortcuts: readonly ShortcutRow[];
+}
+
+/**
+ * Source of truth for the static shortcut catalog surfaced in Settings.
+ * Keep this list aligned with the actual handlers in:
+ * - src/hooks/useKeyboard.ts (global + list navigation)
+ * - src/components/Sidebar/Sidebar.tsx (sidebar arrow navigation)
+ * - src/components/CommandPalette/CommandPalette.tsx (palette-specific)
+ *
+ * The literal token "Mod" is rendered as ⌘ on macOS and Ctrl elsewhere.
+ */
+const SHORTCUT_GROUPS: readonly ShortcutGroup[] = [
+  {
+    title: "Global",
+    shortcuts: [
+      { action: "Open Command Palette", keys: ["Mod", "K"] },
+      { action: "Back to overview", keys: ["Esc"] },
+      { action: "Switch to Workspace 1", keys: ["Mod", "1"] },
+      { action: "Switch to Workspace 2", keys: ["Mod", "2"] },
+      { action: "Switch to Workspace 3", keys: ["Mod", "3"] },
+    ],
+  },
+  {
+    title: "List Navigation",
+    shortcuts: [
+      { action: "Navigate list down", keys: ["j"] },
+      { action: "Navigate list up", keys: ["k"] },
+      { action: "Navigate sidebar up/down", keys: ["↑", "↓"] },
+      { action: "Jump to first / last sidebar item", keys: ["Home", "End"] },
+      { action: "Open selected item", keys: ["Enter"] },
+      { action: "Open workspace for item", keys: ["w"] },
+    ],
+  },
+  {
+    title: "Command Palette",
+    shortcuts: [
+      { action: "Navigate results", keys: ["↑", "↓"] },
+      { action: "Open result in browser", keys: ["Mod", "Enter"] },
+      { action: "Close palette", keys: ["Esc"] },
+    ],
+  },
+];
+
+// Evaluated lazily on each render so tests can mutate navigator.userAgent
+// between renders without needing `vi.resetModules()`. PRism is a Tauri
+// desktop app, so we match the macOS "Macintosh" UA token specifically and
+// ignore mobile Apple platforms the app never ships on.
+function isMacPlatform(): boolean {
+  if (typeof navigator === "undefined") return false;
+  return /Macintosh/i.test(navigator.userAgent);
+}
+
+function displayKey(key: string, mac: boolean): string {
+  if (key === "Mod") return mac ? "⌘" : "Ctrl";
+  return key;
+}
+
+const kbdClass =
+  "bg-surface border-border rounded border px-1.5 py-0.5 font-mono text-xs text-white";
+
+export function KeyboardShortcuts(): ReactElement {
+  const mac = isMacPlatform();
+
+  return (
+    <div data-testid="settings-keyboard-shortcuts" className="flex flex-col gap-3">
+      <h2 className="text-accent text-sm font-semibold uppercase tracking-wider">
+        Keyboard Shortcuts
+      </h2>
+      {SHORTCUT_GROUPS.map((group) => (
+        <div key={group.title} className="flex flex-col gap-2">
+          <h3 className="text-dim text-xs font-semibold uppercase tracking-wider">{group.title}</h3>
+          <dl className="flex flex-col gap-1">
+            {group.shortcuts.map((shortcut) => (
+              <div
+                key={shortcut.action}
+                className="flex items-center justify-between gap-4 text-sm"
+              >
+                <dt className="text-white">{shortcut.action}</dt>
+                <dd className="flex items-center gap-1">
+                  {shortcut.keys.map((key, index) => (
+                    <span key={`${shortcut.action}-${key}`} className="flex items-center gap-1">
+                      {index > 0 ? (
+                        <span className="text-dim" aria-hidden="true">
+                          +
+                        </span>
+                      ) : null}
+                      <kbd className={kbdClass}>{displayKey(key, mac)}</kbd>
+                    </span>
+                  ))}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/Settings/KeyboardShortcuts.tsx
+++ b/src/components/Settings/KeyboardShortcuts.tsx
@@ -3,6 +3,12 @@ import type { ReactElement } from "react";
 interface ShortcutRow {
   readonly action: string;
   readonly keys: readonly string[];
+  /**
+   * Visual separator between consecutive keys. Defaults to "+" (chord —
+   * press both simultaneously). Use "/" to indicate alternatives (press
+   * either one), e.g. arrow keys or Home/End pairs.
+   */
+  readonly separator?: "+" | "/";
 }
 
 interface ShortcutGroup {
@@ -35,8 +41,12 @@ const SHORTCUT_GROUPS: readonly ShortcutGroup[] = [
     shortcuts: [
       { action: "Navigate list down", keys: ["j"] },
       { action: "Navigate list up", keys: ["k"] },
-      { action: "Navigate sidebar up/down", keys: ["↑", "↓"] },
-      { action: "Jump to first / last sidebar item", keys: ["Home", "End"] },
+      { action: "Navigate sidebar up/down", keys: ["↑", "↓"], separator: "/" },
+      {
+        action: "Jump to first / last sidebar item",
+        keys: ["Home", "End"],
+        separator: "/",
+      },
       { action: "Open selected item", keys: ["Enter"] },
       { action: "Open workspace for item", keys: ["w"] },
     ],
@@ -44,7 +54,7 @@ const SHORTCUT_GROUPS: readonly ShortcutGroup[] = [
   {
     title: "Command Palette",
     shortcuts: [
-      { action: "Navigate results", keys: ["↑", "↓"] },
+      { action: "Navigate results", keys: ["↑", "↓"], separator: "/" },
       { action: "Open result in browser", keys: ["Mod", "Enter"] },
       { action: "Close palette", keys: ["Esc"] },
     ],
@@ -91,7 +101,7 @@ export function KeyboardShortcuts(): ReactElement {
                     <span key={`${shortcut.action}-${key}`} className="flex items-center gap-1">
                       {index > 0 ? (
                         <span className="text-dim" aria-hidden="true">
-                          +
+                          {shortcut.separator ?? "+"}
                         </span>
                       ) : null}
                       <kbd className={kbdClass}>{displayKey(key, mac)}</kbd>

--- a/src/components/Settings/Settings.test.tsx
+++ b/src/components/Settings/Settings.test.tsx
@@ -133,6 +133,7 @@ describe("Settings", () => {
     expect(await screen.findByTestId("settings-github")).toBeInTheDocument();
     expect(screen.getByTestId("settings-workspaces")).toBeInTheDocument();
     expect(screen.getByTestId("settings-repos")).toBeInTheDocument();
+    expect(screen.getByTestId("settings-keyboard-shortcuts")).toBeInTheDocument();
   });
 
   it("should show loading state while config is fetching", () => {

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -4,6 +4,7 @@ import { getConfig } from "../../lib/tauri";
 import { GitHubSettings } from "./GitHubSettings";
 import { WorkspaceSettings } from "./WorkspaceSettings";
 import { RepositorySettings } from "./RepositorySettings";
+import { KeyboardShortcuts } from "./KeyboardShortcuts";
 import { Stats } from "./Stats";
 import { DebugInfo } from "./DebugInfo";
 
@@ -46,6 +47,8 @@ export function Settings(): ReactElement {
       <GitHubSettings config={config} onError={setSaveError} />
       <WorkspaceSettings config={config} onError={setSaveError} />
       <RepositorySettings onError={setSaveError} />
+
+      <KeyboardShortcuts />
 
       <Stats />
 


### PR DESCRIPTION
## Summary

Adds a read-only **Keyboard Shortcuts** section to the Settings page that surfaces all existing app shortcuts in one place. Closes #198.

- 14 shortcuts across **Global**, **List Navigation**, and **Command Palette** groups — catalog derived from the actual handlers in `useKeyboard.ts`, `Sidebar.tsx`, and `CommandPalette.tsx` rather than a speculative subset.
- Platform-aware rendering: the `Mod` token resolves to `Ctrl` on non-Mac and `⌘` on macOS via a lazy `navigator.userAgent` check (kept lazy on purpose so tests can mutate UA between renders without `vi.resetModules()`).
- Follows the existing read-only section pattern (`Stats.tsx`, `DebugInfo.tsx`): same `text-accent ... uppercase tracking-wider` header, same `flex flex-col gap-3` container, same `settings-{slug}` testid convention.
- Uses semantic `<dl>` / `<dt>` / `<dd>` with `<kbd>` tokens for accessibility.

## Shortcut catalog

**Global**
- Open Command Palette — `Mod+K`
- Back to overview — `Esc`
- Switch to Workspace 1 / 2 / 3 — `Mod+1/2/3`

**List Navigation**
- Navigate list down / up — `j` / `k`
- Navigate sidebar up/down — `↑` / `↓`
- Jump to first / last sidebar item — `Home` / `End`
- Open selected item — `Enter`
- Open workspace for item — `w`

**Command Palette**
- Navigate results — `↑` / `↓`
- Open result in browser — `Mod+Enter`
- Close palette — `Esc`

## Design decisions

- **Inline static data** — per the issue's "Static data first" guidance, the catalog lives as a `const SHORTCUT_GROUPS` inside the component. A future iteration can pull from a central registry once a second consumer (onboarding tour, cheatsheet, etc.) exists.
- **Lazy platform detection** — `isMacPlatform()` is called on each render rather than hoisted to module scope so `beforeEach`-style UA mutations in tests pick up the new value without needing module cache resets. A comment in the source documents this.
- **Regex narrowed to `/Macintosh/i`** — Tauri desktop never ships on iOS, so `iPhone`/`iPad` branches were noise.
- **Exact `<kbd>` count assertion (22)** — locks the catalog size as a regression tripwire for accidental additions or removals.

## Test plan

- [x] `npx vitest run src/components/Settings/` — 51 tests pass (12 new in `KeyboardShortcuts.test.tsx`, 1 assertion added to `Settings.test.tsx`)
- [x] `npx vitest run` — full suite, 595/595 pass
- [x] `npx tsc --noEmit` — clean
- [x] `oxlint` + `oxfmt` — 0 warnings, 0 errors
- [ ] Manual: open Settings, verify Keyboard Shortcuts section renders between Repositories and Stats, keys show `Ctrl` on Linux/Windows and `⌘` on macOS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-only Keyboard Shortcuts section in Settings that lists all app shortcuts in one place, with platform-aware labels. Closes #198.

- **New Features**
  - Static catalog of 14 shortcuts across Global, List Navigation, and Command Palette, sourced from handlers in `useKeyboard.ts`, `Sidebar.tsx`, and `CommandPalette.tsx`.
  - `Mod` renders as `Ctrl` on Windows/Linux and `⌘` on macOS via a lazy `navigator.userAgent` check.
  - Matches existing read-only Settings pattern with test id `settings-keyboard-shortcuts` and uses semantic `dl/dt/dd` and `kbd` for accessibility.

- **Bug Fixes**
  - Alternative-key shortcuts now use "/" (e.g., ↑/↓, Home/End) instead of "+", clarifying they are alternatives; adds a regression test to lock this behavior.

<sup>Written for commit 2e90f47370fb3943511e9f8ed3d751a2bcb2cc3b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Keyboard Shortcuts section in Settings showing shortcuts grouped by category (Global, List Navigation, Command Palette).
  * Modifier key labels adapt to platform (⌘ on macOS, Ctrl on Windows/Linux); shortcuts are shown as key tokens with visible separators.

* **Tests**
  * Added comprehensive tests verifying layout, platform-specific labels, and displayed shortcut entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->