### PR TITLE
feat(notifications): add GitHub notifications view (closes #197)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -372,11 +372,13 @@ pub async fn github_force_sync(
     Ok(())
 }
 
-/// Lists GitHub notifications for the authenticated user (query).
+/// Lists GitHub notifications (read + unread) for the authenticated user.
 ///
 /// Issue-197: Stateless read-through — calls the GitHub REST `/notifications`
-/// endpoint on each invocation without persisting to `SQLite`. Returns only
-/// unread notifications by default to keep the payload small.
+/// endpoint with `all=true` on each invocation without persisting to `SQLite`.
+/// Returning the full set lets the frontend distinguish unread from read
+/// locally (via the `unread` flag on each item) and keeps a single query
+/// cache shared by both tabs.
 #[tauri::command]
 pub async fn github_list_notifications(
     cached: tauri::State<'_, GithubUsername>,
@@ -384,7 +386,7 @@ pub async fn github_list_notifications(
     let (_username, token) = resolve_credentials(&cached).await?;
     let client = GitHubClient::new(&token).map_err(|e| e.to_string())?;
     client
-        .list_notifications(false)
+        .list_notifications(true)
         .await
         .map_err(|e| e.to_string())
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -372,6 +372,23 @@ pub async fn github_force_sync(
     Ok(())
 }
 
+/// Lists GitHub notifications for the authenticated user (query).
+///
+/// Issue-197: Stateless read-through — calls the GitHub REST `/notifications`
+/// endpoint on each invocation without persisting to `SQLite`. Returns only
+/// unread notifications by default to keep the payload small.
+#[tauri::command]
+pub async fn github_list_notifications(
+    cached: tauri::State<'_, GithubUsername>,
+) -> Result<Vec<crate::types::Notification>, String> {
+    let (_username, token) = resolve_credentials(&cached).await?;
+    let client = GitHubClient::new(&token).map_err(|e| e.to_string())?;
+    client
+        .list_notifications(false)
+        .await
+        .map_err(|e| e.to_string())
+}
+
 /// Returns the full application configuration (query).
 #[tauri::command]
 pub async fn config_get(pool: tauri::State<'_, SqlitePool>) -> Result<AppConfig, String> {

--- a/src-tauri/src/github/client.rs
+++ b/src-tauri/src/github/client.rs
@@ -20,6 +20,47 @@ pub struct RateLimit {
     pub reset: u64,
 }
 
+/// Parses GitHub rate-limit headers into a [`RateLimit`].
+///
+/// Returns `None` when either `X-RateLimit-Remaining` or `X-RateLimit-Reset`
+/// is missing or cannot be parsed. Shared between the GraphQL (`client.rs`)
+/// and REST (`notifications.rs`) code paths so status coverage and header
+/// semantics stay in sync.
+pub(crate) fn parse_rate_limit(headers: &reqwest::header::HeaderMap) -> Option<RateLimit> {
+    let remaining = headers
+        .get("X-RateLimit-Remaining")?
+        .to_str()
+        .ok()?
+        .parse()
+        .ok()?;
+    let reset = headers
+        .get("X-RateLimit-Reset")?
+        .to_str()
+        .ok()?
+        .parse()
+        .ok()?;
+    Some(RateLimit { remaining, reset })
+}
+
+/// Maps rate-limit headers to [`AppError::RateLimit`] when the quota is
+/// exhausted (`remaining == 0` AND a parseable `reset` timestamp).
+///
+/// Returns `None` when either header is missing, garbage, or when the
+/// remaining quota is non-zero — callers should then treat the response
+/// as a plain error rather than emitting an epoch-0 reset. Shared between
+/// `client.rs` and `notifications.rs`.
+pub(crate) fn rate_limit_error_from(headers: &reqwest::header::HeaderMap) -> Option<AppError> {
+    let rl = parse_rate_limit(headers)?;
+    if rl.remaining != 0 {
+        return None;
+    }
+    let reset_at = i64::try_from(rl.reset)
+        .ok()
+        .and_then(|ts| chrono::DateTime::from_timestamp(ts, 0))
+        .map_or_else(|| rl.reset.to_string(), |dt| dt.to_rfc3339());
+    Some(AppError::RateLimit { reset_at })
+}
+
 /// GitHub API client with GraphQL + REST support, rate limiting, and retries.
 pub struct GitHubClient {
     client: reqwest::Client,
@@ -122,30 +163,25 @@ impl GitHubClient {
         &self,
         response: reqwest::Response,
     ) -> Result<Q::ResponseData, AppError> {
-        let rate_limit = Self::parse_rate_limit(response.headers());
-
         if response.status() == reqwest::StatusCode::UNAUTHORIZED {
             return Err(AppError::Auth("invalid or expired token".into()));
         }
 
-        if response.status() == reqwest::StatusCode::FORBIDDEN {
-            if let Some(rl) = &rate_limit
-                && rl.remaining == 0
-            {
-                let reset_at = i64::try_from(rl.reset)
-                    .ok()
-                    .and_then(|ts| chrono::DateTime::from_timestamp(ts, 0))
-                    .map_or_else(|| rl.reset.to_string(), |dt| dt.to_rfc3339());
-                return Err(AppError::RateLimit { reset_at });
+        // Treat both 403 Forbidden and 429 Too Many Requests as potential
+        // rate-limit responses — GitHub uses either for primary/secondary
+        // limits. Shared helper keeps this in sync with the REST path.
+        let status = response.status();
+        if status == reqwest::StatusCode::FORBIDDEN
+            || status == reqwest::StatusCode::TOO_MANY_REQUESTS
+        {
+            if let Some(err) = rate_limit_error_from(response.headers()) {
+                return Err(err);
             }
             return Err(AppError::GitHub("forbidden".into()));
         }
 
-        if !response.status().is_success() {
-            return Err(AppError::GitHub(format!(
-                "unexpected status: {}",
-                response.status()
-            )));
+        if !status.is_success() {
+            return Err(AppError::GitHub(format!("unexpected status: {status}")));
         }
 
         let body: graphql_client::Response<Q::ResponseData> = response
@@ -162,23 +198,6 @@ impl GitHubClient {
 
         body.data
             .ok_or_else(|| AppError::GraphQL("no data in response".into()))
-    }
-
-    /// Parses rate limit headers from GitHub API response headers.
-    fn parse_rate_limit(headers: &reqwest::header::HeaderMap) -> Option<RateLimit> {
-        let remaining = headers
-            .get("X-RateLimit-Remaining")?
-            .to_str()
-            .ok()?
-            .parse()
-            .ok()?;
-        let reset = headers
-            .get("X-RateLimit-Reset")?
-            .to_str()
-            .ok()?
-            .parse()
-            .ok()?;
-        Some(RateLimit { remaining, reset })
     }
 }
 
@@ -346,7 +365,7 @@ mod tests {
         headers.insert("X-RateLimit-Remaining", HeaderValue::from_static("42"));
         headers.insert("X-RateLimit-Reset", HeaderValue::from_static("1700000000"));
 
-        let rl = GitHubClient::parse_rate_limit(&headers).expect("should parse rate limit headers");
+        let rl = parse_rate_limit(&headers).expect("should parse rate limit headers");
         assert_eq!(rl.remaining, 42);
         assert_eq!(rl.reset, 1_700_000_000);
     }
@@ -354,11 +373,49 @@ mod tests {
     #[test]
     fn test_rate_limit_header_parsing_missing() {
         let headers = reqwest::header::HeaderMap::new();
-        let rate_limit = GitHubClient::parse_rate_limit(&headers);
+        let rate_limit = parse_rate_limit(&headers);
 
         assert!(
             rate_limit.is_none(),
             "should return None when headers are missing"
+        );
+    }
+
+    #[test]
+    fn test_rate_limit_error_from_returns_none_when_quota_remaining() {
+        use reqwest::header::{HeaderMap, HeaderValue};
+
+        let mut headers = HeaderMap::new();
+        headers.insert("X-RateLimit-Remaining", HeaderValue::from_static("100"));
+        headers.insert("X-RateLimit-Reset", HeaderValue::from_static("1700000000"));
+
+        assert!(
+            rate_limit_error_from(&headers).is_none(),
+            "quota remaining should not produce a rate-limit error"
+        );
+    }
+
+    #[test]
+    fn test_rate_limit_error_from_returns_rate_limit_when_exhausted() {
+        use reqwest::header::{HeaderMap, HeaderValue};
+
+        let mut headers = HeaderMap::new();
+        headers.insert("X-RateLimit-Remaining", HeaderValue::from_static("0"));
+        headers.insert("X-RateLimit-Reset", HeaderValue::from_static("1700000000"));
+
+        let err = rate_limit_error_from(&headers).expect("should produce rate-limit error");
+        assert!(
+            matches!(err, AppError::RateLimit { .. }),
+            "expected RateLimit variant, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_rate_limit_error_from_returns_none_when_headers_missing() {
+        let headers = reqwest::header::HeaderMap::new();
+        assert!(
+            rate_limit_error_from(&headers).is_none(),
+            "missing headers should not produce a rate-limit error"
         );
     }
 

--- a/src-tauri/src/github/client.rs
+++ b/src-tauri/src/github/client.rs
@@ -177,7 +177,8 @@ impl GitHubClient {
             if let Some(err) = rate_limit_error_from(response.headers()) {
                 return Err(err);
             }
-            return Err(AppError::GitHub("forbidden".into()));
+            // Preserve the real status so callers can tell 403 from 429.
+            return Err(AppError::GitHub(format!("{status}")));
         }
 
         if !status.is_success() {
@@ -438,9 +439,48 @@ mod tests {
             matches!(err, AppError::GitHub(_)),
             "expected AppError::GitHub, got {err:?}"
         );
+        // The fallback message now preserves the real HTTP status so callers
+        // can distinguish 403 Forbidden from 429 Too Many Requests.
+        let msg = err.to_string();
         assert!(
-            err.to_string().contains("forbidden"),
-            "expected 'forbidden' in '{err}'"
+            msg.contains("403"),
+            "expected '403' in error message, got '{msg}'"
+        );
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_execute_graphql_429_without_rate_limit_headers_preserves_status() {
+        // Regression test for the coderabbit finding: a 429 falling through
+        // to the fallback branch must NOT be reported as "forbidden" — it
+        // should preserve the real HTTP status in the error message.
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/graphql")
+            .with_status(429)
+            .with_body(r#"{"message": "Too Many Requests"}"#)
+            .create_async()
+            .await;
+
+        let client =
+            GitHubClient::with_url("ghp_test_token", format!("{}/graphql", server.url())).unwrap();
+        let err = client
+            .execute_graphql::<TestQuery>(test_variables())
+            .await
+            .expect_err("should fail with github error");
+
+        assert!(
+            matches!(err, AppError::GitHub(_)),
+            "expected AppError::GitHub, got {err:?}"
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("429"),
+            "expected '429' in error message, got '{msg}'"
+        );
+        assert!(
+            !msg.contains("forbidden"),
+            "error must not claim 'forbidden' for a 429, got '{msg}'"
         );
         mock.assert_async().await;
     }

--- a/src-tauri/src/github/client.rs
+++ b/src-tauri/src/github/client.rs
@@ -5,8 +5,11 @@ use std::time::Duration;
 use graphql_client::GraphQLQuery;
 
 use crate::error::AppError;
+use crate::github::notifications;
+use crate::types::Notification;
 
 const GITHUB_GRAPHQL_URL: &str = "https://api.github.com/graphql";
+const GITHUB_REST_BASE_URL: &str = "https://api.github.com";
 const MAX_RETRIES: u32 = 3;
 const INITIAL_BACKOFF_MS: u64 = 100;
 
@@ -17,23 +20,33 @@ pub struct RateLimit {
     pub reset: u64,
 }
 
-/// GitHub GraphQL API client with rate limiting and retry support.
+/// GitHub API client with GraphQL + REST support, rate limiting, and retries.
 pub struct GitHubClient {
     client: reqwest::Client,
     token: String,
     graphql_url: String,
+    rest_base_url: String,
 }
 
 impl GitHubClient {
-    /// Creates a new client targeting the GitHub GraphQL API.
+    /// Creates a new client targeting the production GitHub API.
     pub fn new(token: impl Into<String>) -> Result<Self, AppError> {
-        Self::with_url(token, GITHUB_GRAPHQL_URL)
+        Self::with_urls(token, GITHUB_GRAPHQL_URL, GITHUB_REST_BASE_URL)
     }
 
     /// Creates a client with a custom GraphQL endpoint (for testing).
     pub(crate) fn with_url(
         token: impl Into<String>,
         graphql_url: impl Into<String>,
+    ) -> Result<Self, AppError> {
+        Self::with_urls(token, graphql_url, GITHUB_REST_BASE_URL)
+    }
+
+    /// Creates a client with custom GraphQL and REST endpoints (for testing).
+    pub(crate) fn with_urls(
+        token: impl Into<String>,
+        graphql_url: impl Into<String>,
+        rest_base_url: impl Into<String>,
     ) -> Result<Self, AppError> {
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(30))
@@ -45,7 +58,16 @@ impl GitHubClient {
             client,
             token: token.into(),
             graphql_url: graphql_url.into(),
+            rest_base_url: rest_base_url.into(),
         })
+    }
+
+    /// Fetches notifications from the authenticated user's inbox.
+    ///
+    /// When `all` is `false`, only unread notifications are returned.
+    pub async fn list_notifications(&self, all: bool) -> Result<Vec<Notification>, AppError> {
+        notifications::fetch_notifications(&self.client, &self.token, &self.rest_base_url, all)
+            .await
     }
 
     /// Executes a GraphQL query and returns the typed response data.
@@ -292,6 +314,7 @@ mod tests {
                 .expect("failed to build test client"),
             token: "ghp_test_token".into(),
             graphql_url: "http://127.0.0.1:1/graphql".into(),
+            rest_base_url: "http://127.0.0.1:1".into(),
         };
 
         let start = std::time::Instant::now();

--- a/src-tauri/src/github/mod.rs
+++ b/src-tauri/src/github/mod.rs
@@ -1,6 +1,7 @@
 pub mod auth;
 pub(crate) mod client;
 pub(crate) mod models;
+pub(crate) mod notifications;
 pub(crate) mod polling;
 pub(crate) mod queries;
 pub(crate) mod scoring;

--- a/src-tauri/src/github/notifications.rs
+++ b/src-tauri/src/github/notifications.rs
@@ -75,10 +75,16 @@ pub(crate) fn build_html_url(
 
     // GitHub's HTML URLs use singular `/pull/` and `/commit/` whereas the
     // REST API paths are plural (`/pulls/`, `/commits/`).
+    //
+    // Release notifications are deliberately not mapped: the REST URL uses a
+    // numeric release id (`/releases/{id}`), while the canonical HTML form
+    // uses the tag name (`/releases/tag/{tag_name}`). Resolving id → tag
+    // requires a second API call, so we fall back to the repository HTML URL
+    // rather than emit a non-canonical numeric-id URL.
     let path = match subject_type {
         NotificationSubjectType::PullRequest => stripped.replacen("/pulls/", "/pull/", 1),
         NotificationSubjectType::Commit => stripped.replacen("/commits/", "/commit/", 1),
-        NotificationSubjectType::Issue | NotificationSubjectType::Release => stripped.to_string(),
+        NotificationSubjectType::Issue => stripped.to_string(),
         _ => return repo_html_url.to_string(),
     };
 
@@ -170,10 +176,16 @@ async fn handle_response(response: reqwest::Response) -> Result<Vec<Notification
         return Err(AppError::Auth("invalid or expired token".into()));
     }
 
-    if response.status() == reqwest::StatusCode::FORBIDDEN {
-        // Both headers must be present AND parse for us to treat the 403 as
-        // a rate limit. If either header is missing/garbage, fall through to
-        // a plain `forbidden` error rather than emitting an epoch-0 reset.
+    // GitHub returns BOTH 403 Forbidden and 429 Too Many Requests for primary
+    // and secondary rate limits — both paths must inspect the rate-limit
+    // headers so callers get the retry window regardless of which status
+    // GitHub happened to return.
+    let status = response.status();
+    if status == reqwest::StatusCode::FORBIDDEN || status == reqwest::StatusCode::TOO_MANY_REQUESTS
+    {
+        // Both headers must be present AND parse for us to treat the response
+        // as a rate limit. If either header is missing/garbage, fall through
+        // to a plain error rather than emitting an epoch-0 reset.
         let headers = response.headers();
         let remaining = headers
             .get("X-RateLimit-Remaining")
@@ -190,7 +202,7 @@ async fn handle_response(response: reqwest::Response) -> Result<Vec<Notification
                 .map_or_else(|| reset.to_string(), |dt| dt.to_rfc3339());
             return Err(AppError::RateLimit { reset_at });
         }
-        return Err(AppError::GitHub("forbidden".into()));
+        return Err(AppError::GitHub(format!("{status}")));
     }
 
     if !response.status().is_success() {
@@ -295,6 +307,19 @@ mod tests {
             url,
             "https://github.com/octocat/Hello-World/commit/abc123def456"
         );
+    }
+
+    #[test]
+    fn build_html_url_falls_back_to_repo_for_release() {
+        // Release URLs carry a numeric id (`/releases/{id}`) in REST, but the
+        // canonical HTML form uses the tag name. Without a second API call
+        // we can't resolve the tag, so we fall back to the repo HTML URL.
+        let url = build_html_url(
+            Some("https://api.github.com/repos/octocat/Hello-World/releases/12345"),
+            &NotificationSubjectType::Release,
+            "https://github.com/octocat/Hello-World",
+        );
+        assert_eq!(url, "https://github.com/octocat/Hello-World");
     }
 
     #[test]
@@ -515,6 +540,55 @@ mod tests {
         let err = fetch_notifications(&test_client(), "ghp_test", &server.url(), false)
             .await
             .expect_err("should fail with github error");
+
+        assert!(
+            matches!(err, AppError::GitHub(_)),
+            "expected AppError::GitHub, got {err:?}"
+        );
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn fetch_notifications_maps_429_with_rate_limit_headers_to_rate_limit_error() {
+        // GitHub returns 429 Too Many Requests for secondary rate limits.
+        // The handler must recognise it alongside 403 so callers receive
+        // the reset window and can back off appropriately.
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/notifications?all=false&per_page=100")
+            .with_status(429)
+            .with_header("X-RateLimit-Remaining", "0")
+            .with_header("X-RateLimit-Reset", "1700000000")
+            .with_body(r#"{"message": "You have exceeded a secondary rate limit"}"#)
+            .create_async()
+            .await;
+
+        let err = fetch_notifications(&test_client(), "ghp_test", &server.url(), false)
+            .await
+            .expect_err("should fail with rate limit error");
+
+        assert!(
+            matches!(err, AppError::RateLimit { .. }),
+            "expected AppError::RateLimit, got {err:?}"
+        );
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn fetch_notifications_maps_429_without_headers_to_github_error() {
+        // Defensive: a 429 without rate-limit headers falls through to a
+        // GitHub error, same as the equivalent 403 case.
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/notifications?all=false&per_page=100")
+            .with_status(429)
+            .with_body(r#"{"message": "Too Many Requests"}"#)
+            .create_async()
+            .await;
+
+        let err = fetch_notifications(&test_client(), "ghp_test", &server.url(), false)
+            .await
+            .expect_err("should fail");
 
         assert!(
             matches!(err, AppError::GitHub(_)),

--- a/src-tauri/src/github/notifications.rs
+++ b/src-tauri/src/github/notifications.rs
@@ -331,6 +331,36 @@ mod tests {
     }
 
     #[test]
+    fn build_html_url_fallback_uses_provided_repo_url_verbatim() {
+        // Regression test: the fallback path must return the exact
+        // `repo_html_url` value the caller passed in, not a hardcoded
+        // `github.com` URL. This keeps GitHub Enterprise Server deployments
+        // working — their notification subjects carry non-`github.com`
+        // hostnames that must survive the fallback path intact.
+        let enterprise_repo = "https://github.enterprise.example/org/private-repo";
+
+        // Release → forced fallback (id → tag cannot be resolved).
+        let release_url = build_html_url(
+            Some("https://api.github.com/repos/org/private-repo/releases/99"),
+            &NotificationSubjectType::Release,
+            enterprise_repo,
+        );
+        assert_eq!(release_url, enterprise_repo);
+
+        // Missing subject URL → fallback.
+        let missing_url = build_html_url(None, &NotificationSubjectType::Issue, enterprise_repo);
+        assert_eq!(missing_url, enterprise_repo);
+
+        // Unmapped type (CheckSuite) → fallback.
+        let unmapped_url = build_html_url(
+            Some("https://api.github.com/repos/org/private-repo/check-suites/1"),
+            &NotificationSubjectType::CheckSuite,
+            enterprise_repo,
+        );
+        assert_eq!(unmapped_url, enterprise_repo);
+    }
+
+    #[test]
     fn build_html_url_falls_back_when_prefix_unknown() {
         let url = build_html_url(
             Some("https://custom.example.com/something"),

--- a/src-tauri/src/github/notifications.rs
+++ b/src-tauri/src/github/notifications.rs
@@ -1,0 +1,584 @@
+//! GitHub notifications — REST API fetcher and model mapping.
+//!
+//! The GitHub Notifications API is only exposed via REST (not GraphQL),
+//! so this module bridges the REST `/notifications` endpoint into the
+//! typed domain model used by the rest of the application.
+
+use std::time::Duration;
+
+use serde::Deserialize;
+
+use crate::error::AppError;
+use crate::types::{Notification, NotificationSubjectType};
+
+const MAX_RETRIES: u32 = 3;
+const INITIAL_BACKOFF_MS: u64 = 100;
+
+/// Raw notification envelope as returned by `GET /notifications`.
+#[derive(Debug, Clone, Deserialize)]
+struct RawNotification {
+    id: String,
+    unread: bool,
+    reason: String,
+    updated_at: String,
+    subject: RawSubject,
+    repository: RawRepository,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RawSubject {
+    title: String,
+    url: Option<String>,
+    #[serde(rename = "type")]
+    subject_type: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RawRepository {
+    full_name: String,
+    html_url: String,
+}
+
+/// Parse a GitHub subject-type string into the typed enum.
+///
+/// Unknown types fall back to [`NotificationSubjectType::Other`] rather
+/// than failing the whole fetch — the API may add new kinds in the future.
+fn parse_subject_type(raw: &str) -> NotificationSubjectType {
+    match raw {
+        "PullRequest" => NotificationSubjectType::PullRequest,
+        "Issue" => NotificationSubjectType::Issue,
+        "Release" => NotificationSubjectType::Release,
+        "Discussion" => NotificationSubjectType::Discussion,
+        "CheckSuite" => NotificationSubjectType::CheckSuite,
+        "Commit" => NotificationSubjectType::Commit,
+        _ => NotificationSubjectType::Other,
+    }
+}
+
+/// Convert a GitHub API URL (from `subject.url`) into the public HTML URL
+/// suitable for opening in a browser.
+///
+/// Falls back to `repo_html_url` when the API URL is missing or cannot be
+/// translated (e.g., `Discussion`, `CheckSuite` — which have no direct HTML URL).
+pub(crate) fn build_html_url(
+    api_url: Option<&str>,
+    subject_type: &NotificationSubjectType,
+    repo_html_url: &str,
+) -> String {
+    let Some(api_url) = api_url else {
+        return repo_html_url.to_string();
+    };
+
+    let Some(stripped) = api_url.strip_prefix("https://api.github.com/repos") else {
+        return repo_html_url.to_string();
+    };
+
+    let path = match subject_type {
+        NotificationSubjectType::PullRequest => stripped.replacen("/pulls/", "/pull/", 1),
+        NotificationSubjectType::Issue | NotificationSubjectType::Release => stripped.to_string(),
+        _ => return repo_html_url.to_string(),
+    };
+
+    format!("https://github.com{path}")
+}
+
+/// Map a raw GitHub response notification into the domain [`Notification`].
+fn map_notification(raw: RawNotification) -> Notification {
+    let subject_type = parse_subject_type(&raw.subject.subject_type);
+    let url = build_html_url(
+        raw.subject.url.as_deref(),
+        &subject_type,
+        &raw.repository.html_url,
+    );
+
+    Notification {
+        id: raw.id,
+        repo: raw.repository.full_name,
+        title: raw.subject.title,
+        notification_type: subject_type,
+        reason: raw.reason,
+        unread: raw.unread,
+        updated_at: raw.updated_at,
+        url,
+    }
+}
+
+/// Fetch notifications from the GitHub REST API.
+///
+/// Retries on connection and timeout errors only (max 3 attempts with
+/// exponential backoff). Other transient failures (DNS, TLS handshake) are
+/// surfaced immediately — this matches the behaviour of `execute_graphql`.
+///
+/// Returns up to 100 notifications (one REST page). Older notifications are
+/// silently truncated; subsequent pages are intentionally not followed to
+/// keep the command stateless and cheap.
+///
+/// * `rest_base_url` is the REST API origin (e.g., `https://api.github.com`).
+/// * `all` — when `false`, only unread notifications are returned.
+pub(crate) async fn fetch_notifications(
+    client: &reqwest::Client,
+    token: &str,
+    rest_base_url: &str,
+    all: bool,
+) -> Result<Vec<Notification>, AppError> {
+    // per_page=100 is the documented maximum for GitHub REST endpoints.
+    let url = format!("{rest_base_url}/notifications?all={all}&per_page=100");
+
+    let mut last_error = None;
+    for attempt in 0..=MAX_RETRIES {
+        if attempt > 0 {
+            let backoff = Duration::from_millis(INITIAL_BACKOFF_MS * 2u64.pow(attempt - 1));
+            tokio::time::sleep(backoff).await;
+        }
+
+        match send(client, token, &url).await {
+            Ok(response) => return handle_response(response).await,
+            Err(e) if e.is_connect() || e.is_timeout() => {
+                last_error = Some(e);
+            }
+            Err(e) => {
+                return Err(AppError::GitHub(format!("request failed: {e}")));
+            }
+        }
+    }
+
+    Err(AppError::GitHub(format!(
+        "request failed after {MAX_RETRIES} retries: {}",
+        last_error.map_or_else(|| "unknown error".to_string(), |e| e.to_string())
+    )))
+}
+
+async fn send(
+    client: &reqwest::Client,
+    token: &str,
+    url: &str,
+) -> Result<reqwest::Response, reqwest::Error> {
+    client
+        .get(url)
+        .header("Authorization", format!("Bearer {token}"))
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .send()
+        .await
+}
+
+async fn handle_response(response: reqwest::Response) -> Result<Vec<Notification>, AppError> {
+    if response.status() == reqwest::StatusCode::UNAUTHORIZED {
+        return Err(AppError::Auth("invalid or expired token".into()));
+    }
+
+    if response.status() == reqwest::StatusCode::FORBIDDEN {
+        // Both headers must be present AND parse for us to treat the 403 as
+        // a rate limit. If either header is missing/garbage, fall through to
+        // a plain `forbidden` error rather than emitting an epoch-0 reset.
+        let headers = response.headers();
+        let remaining = headers
+            .get("X-RateLimit-Remaining")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.parse::<u32>().ok());
+        let reset = headers
+            .get("X-RateLimit-Reset")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.parse::<u64>().ok());
+        if let (Some(0), Some(reset)) = (remaining, reset) {
+            let reset_at = i64::try_from(reset)
+                .ok()
+                .and_then(|ts| chrono::DateTime::from_timestamp(ts, 0))
+                .map_or_else(|| reset.to_string(), |dt| dt.to_rfc3339());
+            return Err(AppError::RateLimit { reset_at });
+        }
+        return Err(AppError::GitHub("forbidden".into()));
+    }
+
+    if !response.status().is_success() {
+        return Err(AppError::GitHub(format!(
+            "unexpected status: {}",
+            response.status()
+        )));
+    }
+
+    let raw: Vec<RawNotification> = response
+        .json()
+        .await
+        .map_err(|e| AppError::GitHub(format!("failed to parse notifications response: {e}")))?;
+
+    Ok(raw.into_iter().map(map_notification).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn raw_notification() -> RawNotification {
+        RawNotification {
+            id: "42".into(),
+            unread: true,
+            reason: "review_requested".into(),
+            updated_at: "2026-04-01T10:00:00Z".into(),
+            subject: RawSubject {
+                title: "Fix the bug".into(),
+                url: Some("https://api.github.com/repos/octocat/Hello-World/pulls/7".into()),
+                subject_type: "PullRequest".into(),
+            },
+            repository: RawRepository {
+                full_name: "octocat/Hello-World".into(),
+                html_url: "https://github.com/octocat/Hello-World".into(),
+            },
+        }
+    }
+
+    #[test]
+    fn parse_subject_type_maps_known_types() {
+        assert_eq!(
+            parse_subject_type("PullRequest"),
+            NotificationSubjectType::PullRequest
+        );
+        assert_eq!(parse_subject_type("Issue"), NotificationSubjectType::Issue);
+        assert_eq!(
+            parse_subject_type("Release"),
+            NotificationSubjectType::Release
+        );
+        assert_eq!(
+            parse_subject_type("Discussion"),
+            NotificationSubjectType::Discussion
+        );
+        assert_eq!(
+            parse_subject_type("CheckSuite"),
+            NotificationSubjectType::CheckSuite
+        );
+        assert_eq!(
+            parse_subject_type("Commit"),
+            NotificationSubjectType::Commit
+        );
+    }
+
+    #[test]
+    fn parse_subject_type_falls_back_to_other_for_unknown() {
+        assert_eq!(
+            parse_subject_type("SomethingNew"),
+            NotificationSubjectType::Other
+        );
+    }
+
+    #[test]
+    fn build_html_url_converts_pull_request_api_url() {
+        let url = build_html_url(
+            Some("https://api.github.com/repos/octocat/Hello-World/pulls/42"),
+            &NotificationSubjectType::PullRequest,
+            "https://github.com/octocat/Hello-World",
+        );
+        assert_eq!(url, "https://github.com/octocat/Hello-World/pull/42");
+    }
+
+    #[test]
+    fn build_html_url_keeps_issue_path() {
+        let url = build_html_url(
+            Some("https://api.github.com/repos/octocat/Hello-World/issues/7"),
+            &NotificationSubjectType::Issue,
+            "https://github.com/octocat/Hello-World",
+        );
+        assert_eq!(url, "https://github.com/octocat/Hello-World/issues/7");
+    }
+
+    #[test]
+    fn build_html_url_falls_back_to_repo_when_subject_url_missing() {
+        let url = build_html_url(
+            None,
+            &NotificationSubjectType::Discussion,
+            "https://github.com/octocat/Hello-World",
+        );
+        assert_eq!(url, "https://github.com/octocat/Hello-World");
+    }
+
+    #[test]
+    fn build_html_url_falls_back_for_unmapped_type() {
+        let url = build_html_url(
+            Some("https://api.github.com/repos/octocat/Hello-World/check-suites/1"),
+            &NotificationSubjectType::CheckSuite,
+            "https://github.com/octocat/Hello-World",
+        );
+        assert_eq!(url, "https://github.com/octocat/Hello-World");
+    }
+
+    #[test]
+    fn build_html_url_falls_back_when_prefix_unknown() {
+        let url = build_html_url(
+            Some("https://custom.example.com/something"),
+            &NotificationSubjectType::PullRequest,
+            "https://github.com/octocat/Hello-World",
+        );
+        assert_eq!(url, "https://github.com/octocat/Hello-World");
+    }
+
+    #[test]
+    fn map_notification_converts_raw_to_domain() {
+        let n = map_notification(raw_notification());
+        assert_eq!(n.id, "42");
+        assert!(n.unread);
+        assert_eq!(n.reason, "review_requested");
+        assert_eq!(n.title, "Fix the bug");
+        assert_eq!(n.repo, "octocat/Hello-World");
+        assert_eq!(n.notification_type, NotificationSubjectType::PullRequest);
+        assert_eq!(n.url, "https://github.com/octocat/Hello-World/pull/7");
+        assert_eq!(n.updated_at, "2026-04-01T10:00:00Z");
+    }
+
+    fn test_client() -> reqwest::Client {
+        reqwest::Client::builder()
+            .timeout(Duration::from_secs(5))
+            .user_agent("prism-test")
+            .build()
+            .expect("failed to build test client")
+    }
+
+    #[tokio::test]
+    async fn fetch_notifications_returns_parsed_list() {
+        let mut server = mockito::Server::new_async().await;
+        let body = r#"[{
+            "id": "1",
+            "unread": true,
+            "reason": "review_requested",
+            "updated_at": "2026-04-01T10:00:00Z",
+            "subject": {
+                "title": "Fix the bug",
+                "url": "https://api.github.com/repos/octocat/Hello-World/pulls/42",
+                "type": "PullRequest"
+            },
+            "repository": {
+                "full_name": "octocat/Hello-World",
+                "html_url": "https://github.com/octocat/Hello-World"
+            }
+        }, {
+            "id": "2",
+            "unread": false,
+            "reason": "mention",
+            "updated_at": "2026-04-02T10:00:00Z",
+            "subject": {
+                "title": "Crash on startup",
+                "url": "https://api.github.com/repos/octocat/Hello-World/issues/9",
+                "type": "Issue"
+            },
+            "repository": {
+                "full_name": "octocat/Hello-World",
+                "html_url": "https://github.com/octocat/Hello-World"
+            }
+        }]"#;
+
+        let mock = server
+            .mock("GET", "/notifications?all=false&per_page=100")
+            .match_header("Authorization", "Bearer ghp_test_token")
+            .match_header("Accept", "application/vnd.github+json")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(body)
+            .create_async()
+            .await;
+
+        let result =
+            fetch_notifications(&test_client(), "ghp_test_token", &server.url(), false).await;
+        let notifications = result.expect("should return notifications");
+
+        assert_eq!(notifications.len(), 2);
+        assert_eq!(notifications[0].id, "1");
+        assert_eq!(
+            notifications[0].notification_type,
+            NotificationSubjectType::PullRequest
+        );
+        assert_eq!(
+            notifications[0].url,
+            "https://github.com/octocat/Hello-World/pull/42"
+        );
+        assert!(notifications[0].unread);
+
+        assert_eq!(notifications[1].id, "2");
+        assert_eq!(
+            notifications[1].notification_type,
+            NotificationSubjectType::Issue
+        );
+        assert_eq!(
+            notifications[1].url,
+            "https://github.com/octocat/Hello-World/issues/9"
+        );
+        assert!(!notifications[1].unread);
+
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn fetch_notifications_returns_empty_list() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/notifications?all=false&per_page=100")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body("[]")
+            .create_async()
+            .await;
+
+        let result =
+            fetch_notifications(&test_client(), "ghp_test_token", &server.url(), false).await;
+
+        let notifications = result.expect("should return empty list");
+        assert!(notifications.is_empty());
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn fetch_notifications_handles_all_true_query_param() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/notifications?all=true&per_page=100")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body("[]")
+            .create_async()
+            .await;
+
+        let result =
+            fetch_notifications(&test_client(), "ghp_test_token", &server.url(), true).await;
+
+        assert!(result.is_ok());
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn fetch_notifications_maps_401_to_auth_error() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/notifications?all=false&per_page=100")
+            .with_status(401)
+            .with_body(r#"{"message": "Bad credentials"}"#)
+            .create_async()
+            .await;
+
+        let err = fetch_notifications(&test_client(), "ghp_bad", &server.url(), false)
+            .await
+            .expect_err("should fail with auth error");
+
+        assert!(
+            matches!(err, AppError::Auth(_)),
+            "expected AppError::Auth, got {err:?}"
+        );
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn fetch_notifications_maps_rate_limit_to_rate_limit_error() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/notifications?all=false&per_page=100")
+            .with_status(403)
+            .with_header("X-RateLimit-Remaining", "0")
+            .with_header("X-RateLimit-Reset", "1700000000")
+            .with_body(r#"{"message": "API rate limit exceeded"}"#)
+            .create_async()
+            .await;
+
+        let err = fetch_notifications(&test_client(), "ghp_test", &server.url(), false)
+            .await
+            .expect_err("should fail with rate limit error");
+
+        assert!(
+            matches!(err, AppError::RateLimit { .. }),
+            "expected AppError::RateLimit, got {err:?}"
+        );
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn fetch_notifications_maps_403_without_rate_limit_to_github_error() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/notifications?all=false&per_page=100")
+            .with_status(403)
+            .with_body(r#"{"message": "Forbidden"}"#)
+            .create_async()
+            .await;
+
+        let err = fetch_notifications(&test_client(), "ghp_test", &server.url(), false)
+            .await
+            .expect_err("should fail with github error");
+
+        assert!(
+            matches!(err, AppError::GitHub(_)),
+            "expected AppError::GitHub, got {err:?}"
+        );
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn fetch_notifications_403_with_remaining_zero_but_no_reset_falls_back_to_github_error() {
+        // Defensive: if X-RateLimit-Reset is absent, we must NOT emit a
+        // rate-limit error with an epoch-0 timestamp — fall through to
+        // a plain `forbidden` error instead.
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/notifications?all=false&per_page=100")
+            .with_status(403)
+            .with_header("X-RateLimit-Remaining", "0")
+            // deliberately no X-RateLimit-Reset header
+            .with_body(r#"{"message": "Forbidden"}"#)
+            .create_async()
+            .await;
+
+        let err = fetch_notifications(&test_client(), "ghp_test", &server.url(), false)
+            .await
+            .expect_err("should fail");
+
+        assert!(
+            matches!(err, AppError::GitHub(_)),
+            "expected AppError::GitHub (not RateLimit), got {err:?}"
+        );
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn fetch_notifications_retries_on_network_error() {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_millis(100))
+            .user_agent("prism-test")
+            .build()
+            .expect("failed to build test client");
+
+        let start = std::time::Instant::now();
+        let err = fetch_notifications(&client, "ghp_test", "http://127.0.0.1:1", false)
+            .await
+            .expect_err("should fail after retries");
+        let elapsed = start.elapsed();
+
+        assert!(
+            matches!(err, AppError::GitHub(_)),
+            "expected AppError::GitHub, got {err:?}"
+        );
+        assert!(
+            err.to_string().contains("retries"),
+            "expected 'retries' in {err}"
+        );
+        assert!(
+            elapsed >= Duration::from_millis(500),
+            "expected retries with backoff, elapsed only {elapsed:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_notifications_maps_malformed_json_to_github_error() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/notifications?all=false&per_page=100")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body("not valid json")
+            .create_async()
+            .await;
+
+        let err = fetch_notifications(&test_client(), "ghp_test", &server.url(), false)
+            .await
+            .expect_err("should fail to parse");
+
+        assert!(
+            matches!(err, AppError::GitHub(_)),
+            "expected AppError::GitHub, got {err:?}"
+        );
+        mock.assert_async().await;
+    }
+}

--- a/src-tauri/src/github/notifications.rs
+++ b/src-tauri/src/github/notifications.rs
@@ -73,8 +73,11 @@ pub(crate) fn build_html_url(
         return repo_html_url.to_string();
     };
 
+    // GitHub's HTML URLs use singular `/pull/` and `/commit/` whereas the
+    // REST API paths are plural (`/pulls/`, `/commits/`).
     let path = match subject_type {
         NotificationSubjectType::PullRequest => stripped.replacen("/pulls/", "/pull/", 1),
+        NotificationSubjectType::Commit => stripped.replacen("/commits/", "/commit/", 1),
         NotificationSubjectType::Issue | NotificationSubjectType::Release => stripped.to_string(),
         _ => return repo_html_url.to_string(),
     };
@@ -278,6 +281,20 @@ mod tests {
             "https://github.com/octocat/Hello-World",
         );
         assert_eq!(url, "https://github.com/octocat/Hello-World/issues/7");
+    }
+
+    #[test]
+    fn build_html_url_converts_commit_api_url() {
+        // REST `/commits/{sha}` → HTML `/commit/{sha}` (singular on the web).
+        let url = build_html_url(
+            Some("https://api.github.com/repos/octocat/Hello-World/commits/abc123def456"),
+            &NotificationSubjectType::Commit,
+            "https://github.com/octocat/Hello-World",
+        );
+        assert_eq!(
+            url,
+            "https://github.com/octocat/Hello-World/commit/abc123def456"
+        );
     }
 
     #[test]

--- a/src-tauri/src/github/notifications.rs
+++ b/src-tauri/src/github/notifications.rs
@@ -9,6 +9,7 @@ use std::time::Duration;
 use serde::Deserialize;
 
 use crate::error::AppError;
+use crate::github::client::rate_limit_error_from;
 use crate::types::{Notification, NotificationSubjectType};
 
 const MAX_RETRIES: u32 = 3;
@@ -114,9 +115,11 @@ fn map_notification(raw: RawNotification) -> Notification {
 
 /// Fetch notifications from the GitHub REST API.
 ///
-/// Retries on connection and timeout errors only (max 3 attempts with
-/// exponential backoff). Other transient failures (DNS, TLS handshake) are
-/// surfaced immediately — this matches the behaviour of `execute_graphql`.
+/// Retries on connection and timeout errors only (up to `MAX_RETRIES`
+/// additional attempts after the initial request, with exponential backoff,
+/// for a total of `MAX_RETRIES + 1` attempts). Other transient failures
+/// (DNS, TLS handshake) are surfaced immediately — this matches the
+/// behaviour of `execute_graphql`.
 ///
 /// Returns up to 100 notifications (one REST page). Older notifications are
 /// silently truncated; subsequent pages are intentionally not followed to
@@ -178,29 +181,14 @@ async fn handle_response(response: reqwest::Response) -> Result<Vec<Notification
 
     // GitHub returns BOTH 403 Forbidden and 429 Too Many Requests for primary
     // and secondary rate limits — both paths must inspect the rate-limit
-    // headers so callers get the retry window regardless of which status
-    // GitHub happened to return.
+    // headers. The shared `rate_limit_error_from` helper is reused by the
+    // GraphQL client so status coverage, header rules, and reset formatting
+    // stay in sync.
     let status = response.status();
     if status == reqwest::StatusCode::FORBIDDEN || status == reqwest::StatusCode::TOO_MANY_REQUESTS
     {
-        // Both headers must be present AND parse for us to treat the response
-        // as a rate limit. If either header is missing/garbage, fall through
-        // to a plain error rather than emitting an epoch-0 reset.
-        let headers = response.headers();
-        let remaining = headers
-            .get("X-RateLimit-Remaining")
-            .and_then(|v| v.to_str().ok())
-            .and_then(|s| s.parse::<u32>().ok());
-        let reset = headers
-            .get("X-RateLimit-Reset")
-            .and_then(|v| v.to_str().ok())
-            .and_then(|s| s.parse::<u64>().ok());
-        if let (Some(0), Some(reset)) = (remaining, reset) {
-            let reset_at = i64::try_from(reset)
-                .ok()
-                .and_then(|ts| chrono::DateTime::from_timestamp(ts, 0))
-                .map_or_else(|| reset.to_string(), |dt| dt.to_rfc3339());
-            return Err(AppError::RateLimit { reset_at });
+        if let Some(err) = rate_limit_error_from(response.headers()) {
+            return Err(err);
         }
         return Err(AppError::GitHub(format!("{status}")));
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -261,6 +261,7 @@ pub fn run() {
             commands::github_get_stats,
             commands::stats_personal,
             commands::github_force_sync,
+            commands::github_list_notifications,
             commands::repos_list,
             commands::repos_set_enabled,
             commands::repos_set_local_path,

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -293,6 +293,43 @@ pub struct PersonalStats {
     pub total_workspace_count: u32,
 }
 
+// ── Notifications (issue #197) ───────────────────────────────────
+
+/// GitHub notification subject type, mirrored from the REST Notifications API.
+///
+/// Unknown values returned by the API map to [`NotificationSubjectType::Other`]
+/// so that new upstream kinds don't break the fetcher.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum NotificationSubjectType {
+    PullRequest,
+    Issue,
+    Release,
+    Discussion,
+    CheckSuite,
+    Commit,
+    Other,
+}
+
+/// A GitHub notification entry displayed in the Notifications view.
+///
+/// Populated from the REST `/notifications` endpoint and exposed to the
+/// frontend with camelCase field names.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Notification {
+    pub id: String,
+    pub repo: String,
+    pub title: String,
+    pub notification_type: NotificationSubjectType,
+    pub reason: String,
+    pub unread: bool,
+    pub updated_at: String,
+    /// Best-effort HTML URL for browser navigation.
+    /// Falls back to the repository HTML URL when the subject has no direct URL.
+    pub url: String,
+}
+
 // ── IPC payloads (T-011) ──────────────────────────────────────
 
 /// Request payload for the `workspace_open` IPC command.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import { ReviewQueue } from "./components/ReviewQueue";
 import { MyPRs } from "./components/MyPRs";
 import { Issues } from "./components/Issues";
 import { ActivityFeed } from "./components/ActivityFeed";
+import { Notifications } from "./components/Notifications";
 import { Toast } from "./components/Toast";
 import { CommandPalette } from "./components/CommandPalette";
 import { useKeyboard } from "./hooks/useKeyboard";
@@ -188,6 +189,8 @@ function MainContent({ view, onBackToDashboard }: MainContentProps): ReactElemen
           onMarkAllRead={() => markAllRead.mutate()}
         />
       );
+    case "notifications":
+      return <Notifications onOpen={openUrl} />;
     case "workspaces":
       return (
         <WorkspaceView

--- a/src/components/Notifications/NotificationCard.test.tsx
+++ b/src/components/Notifications/NotificationCard.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { GithubNotification } from "../../lib/types/github";
+import { NotificationCard } from "./NotificationCard";
+
+function makeNotification(overrides: Partial<GithubNotification> = {}): GithubNotification {
+  return {
+    id: "1",
+    repo: "octocat/Hello-World",
+    title: "Fix the bug",
+    notificationType: "pullRequest",
+    reason: "review_requested",
+    unread: true,
+    updatedAt: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
+    url: "https://github.com/octocat/Hello-World/pull/42",
+    ...overrides,
+  };
+}
+
+describe("NotificationCard", () => {
+  it("renders the title, repo and humanized reason", () => {
+    render(<NotificationCard data={makeNotification()} onOpen={vi.fn()} />);
+
+    expect(screen.getByText("Fix the bug")).toBeInTheDocument();
+    expect(screen.getByText("octocat/Hello-World")).toBeInTheDocument();
+    expect(screen.getByText(/review requested/i)).toBeInTheDocument();
+  });
+
+  it("shows an unread indicator when unread is true", () => {
+    render(<NotificationCard data={makeNotification({ unread: true })} onOpen={vi.fn()} />);
+    expect(screen.getByTestId("unread-indicator")).toBeInTheDocument();
+  });
+
+  it("omits the unread indicator when notification is read", () => {
+    render(<NotificationCard data={makeNotification({ unread: false })} onOpen={vi.fn()} />);
+    expect(screen.queryByTestId("unread-indicator")).not.toBeInTheDocument();
+  });
+
+  it("calls onOpen with the URL on click", async () => {
+    const user = userEvent.setup();
+    const onOpen = vi.fn();
+    render(<NotificationCard data={makeNotification()} onOpen={onOpen} />);
+
+    await user.click(screen.getByRole("link", { name: /fix the bug/i }));
+
+    expect(onOpen).toHaveBeenCalledWith("https://github.com/octocat/Hello-World/pull/42");
+  });
+
+  it("renders different icon for issue vs pull request", () => {
+    const { rerender } = render(
+      <NotificationCard data={makeNotification({ notificationType: "issue" })} onOpen={vi.fn()} />,
+    );
+    const issueIcon = screen.getByTestId("notification-type-icon");
+    expect(issueIcon).toHaveAttribute("data-type", "issue");
+
+    rerender(
+      <NotificationCard
+        data={makeNotification({ notificationType: "pullRequest" })}
+        onOpen={vi.fn()}
+      />,
+    );
+    const prIcon = screen.getByTestId("notification-type-icon");
+    expect(prIcon).toHaveAttribute("data-type", "pullRequest");
+  });
+
+  it("humanizes common reason values", () => {
+    const reasons: Array<[string, RegExp]> = [
+      ["mention", /mentioned/i],
+      ["assign", /assigned/i],
+      ["author", /author/i],
+      ["subscribed", /subscribed/i],
+      ["team_mention", /team mentioned/i],
+      ["comment", /comment/i],
+      ["state_change", /state/i],
+    ];
+    for (const [reason, label] of reasons) {
+      const { unmount } = render(
+        <NotificationCard data={makeNotification({ reason })} onOpen={vi.fn()} />,
+      );
+      expect(screen.getByText(label)).toBeInTheDocument();
+      unmount();
+    }
+  });
+
+  it("shows relative time for updatedAt", () => {
+    render(
+      <NotificationCard
+        data={makeNotification({
+          updatedAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+        })}
+        onOpen={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("time-ago")).toHaveTextContent(/5m/);
+  });
+});

--- a/src/components/Notifications/NotificationCard.tsx
+++ b/src/components/Notifications/NotificationCard.tsx
@@ -1,0 +1,143 @@
+import { memo, type ReactElement, useCallback } from "react";
+import { FOCUS_RING } from "../../lib/a11y";
+import { timeAgo } from "../../lib/timeAgo";
+import type { GithubNotification, NotificationSubjectType } from "../../lib/types/github";
+
+interface NotificationCardProps {
+  readonly data: GithubNotification;
+  readonly onOpen: (url: string) => void;
+}
+
+const TYPE_ICON: Record<NotificationSubjectType, string> = {
+  pullRequest: "⇄",
+  issue: "●",
+  release: "↗",
+  discussion: "✎",
+  checkSuite: "✓",
+  commit: "◆",
+  other: "•",
+};
+
+const TYPE_LABEL: Record<NotificationSubjectType, string> = {
+  pullRequest: "Pull request",
+  issue: "Issue",
+  release: "Release",
+  discussion: "Discussion",
+  checkSuite: "Check suite",
+  commit: "Commit",
+  other: "Notification",
+};
+
+/**
+ * Humanize a GitHub notification reason.
+ *
+ * Reference: https://docs.github.com/en/rest/activity/notifications?apiVersion=2022-11-28#about-notification-reasons
+ * Unknown reasons fall back to a cleaned-up version of the raw value so the UI
+ * never displays raw snake_case strings.
+ */
+function humanizeReason(reason: string): string {
+  const known: Record<string, string> = {
+    review_requested: "Review requested",
+    mention: "Mentioned",
+    team_mention: "Team mentioned",
+    assign: "Assigned",
+    author: "Author",
+    subscribed: "Subscribed",
+    comment: "Commented",
+    state_change: "State changed",
+    ci_activity: "CI activity",
+    security_alert: "Security alert",
+    manual: "Manual",
+  };
+  if (known[reason]) return known[reason];
+  return reason.replace(/_/g, " ").replace(/^./, (c) => c.toUpperCase());
+}
+
+/// Only allow http(s) URLs to be forwarded to the Tauri opener.
+///
+/// Defensive guard: the URL ultimately comes from the GitHub API, but we
+/// never trust remote strings reaching `tauriOpen` with schemes like
+/// `file://`, `javascript:`, or custom protocol handlers.
+function isSafeUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "https:" || parsed.protocol === "http:";
+  } catch {
+    return false;
+  }
+}
+
+function NotificationCardImpl({ data, onOpen }: NotificationCardProps): ReactElement {
+  const { url, title, notificationType, unread, reason, repo, updatedAt } = data;
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      if (!isSafeUrl(url)) {
+        console.warn("[NotificationCard] refusing unsafe URL", url);
+        return;
+      }
+      onOpen(url);
+    },
+    [onOpen, url],
+  );
+
+  const accessibleLabel = `${unread ? "Unread " : ""}${TYPE_LABEL[notificationType]}: ${title}`;
+
+  return (
+    <div
+      data-testid="notification-card"
+      className={`flex items-center gap-3 rounded border border-border px-3 py-2 hover:bg-surface-hover${
+        unread ? "" : " opacity-60"
+      }`}
+    >
+      <a
+        href={url}
+        onClick={handleClick}
+        aria-label={accessibleLabel}
+        className={`${FOCUS_RING} flex min-w-0 flex-1 cursor-pointer items-center gap-3 rounded no-underline`}
+      >
+        {unread && (
+          <span
+            data-testid="unread-indicator"
+            aria-hidden="true"
+            className="h-2 w-2 shrink-0 rounded-full bg-accent"
+          />
+        )}
+
+        <span
+          data-testid="notification-type-icon"
+          data-type={notificationType}
+          aria-hidden="true"
+          className="shrink-0 text-sm text-dim"
+          title={TYPE_LABEL[notificationType]}
+        >
+          {TYPE_ICON[notificationType]}
+        </span>
+
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          <div className="flex min-w-0 items-center gap-2">
+            <span
+              className="min-w-0 truncate text-sm font-medium text-foreground"
+              title={title}
+            >
+              {title}
+            </span>
+          </div>
+
+          <div className="flex items-center gap-2 text-xs text-dim">
+            <span className="truncate">{repo}</span>
+            <span className="shrink-0 rounded bg-surface-hover px-1.5 py-0.5 text-[10px]">
+              {humanizeReason(reason)}
+            </span>
+            <span data-testid="time-ago" className="ml-auto shrink-0">
+              {timeAgo(updatedAt)}
+            </span>
+          </div>
+        </div>
+      </a>
+    </div>
+  );
+}
+
+export const NotificationCard = memo(NotificationCardImpl);

--- a/src/components/Notifications/Notifications.test.tsx
+++ b/src/components/Notifications/Notifications.test.tsx
@@ -1,0 +1,182 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FOCUS_RING } from "../../lib/a11y";
+import type { GithubNotification } from "../../lib/types/github";
+import { Notifications } from "./Notifications";
+
+const { mockUseQuery } = vi.hoisted(() => ({ mockUseQuery: vi.fn() }));
+
+vi.mock("@tanstack/react-query", async () => {
+  const actual = await vi.importActual("@tanstack/react-query");
+  return {
+    ...actual,
+    useQuery: mockUseQuery,
+  };
+});
+
+function makeNotification(overrides: Partial<GithubNotification> = {}): GithubNotification {
+  return {
+    id: "1",
+    repo: "octocat/Hello-World",
+    title: "Fix the bug",
+    notificationType: "pullRequest",
+    reason: "review_requested",
+    unread: true,
+    updatedAt: "2026-04-01T10:00:00Z",
+    url: "https://github.com/octocat/Hello-World/pull/42",
+    ...overrides,
+  };
+}
+
+const unreadNotif = makeNotification({ id: "1", title: "Unread PR", unread: true });
+const readNotif = makeNotification({ id: "2", title: "Read PR", unread: false });
+const issueNotif = makeNotification({
+  id: "3",
+  title: "Crash",
+  notificationType: "issue",
+  unread: true,
+  reason: "mention",
+  repo: "octocat/other-repo",
+});
+
+const onOpen = vi.fn();
+
+function mockQuerySuccess(data: GithubNotification[]) {
+  mockUseQuery.mockReturnValue({
+    data,
+    isLoading: false,
+    isError: false,
+    error: null,
+  });
+}
+
+function mockQueryLoading() {
+  mockUseQuery.mockReturnValue({
+    data: undefined,
+    isLoading: true,
+    isError: false,
+    error: null,
+  });
+}
+
+function mockQueryError(message: string) {
+  mockUseQuery.mockReturnValue({
+    data: undefined,
+    isLoading: false,
+    isError: true,
+    error: new Error(message),
+  });
+}
+
+beforeEach(() => {
+  onOpen.mockClear();
+  mockUseQuery.mockReset();
+});
+
+describe("Notifications", () => {
+  it("applies the focus-visible ring to the search input", () => {
+    mockQuerySuccess([unreadNotif, readNotif, issueNotif]);
+    render(<Notifications onOpen={onOpen} />);
+    const search = screen.getByRole("searchbox", { name: /filter notifications/i });
+    for (const token of FOCUS_RING.trim().split(/\s+/)) {
+      expect(search).toHaveClass(token);
+    }
+  });
+
+  it("shows only unread notifications on the unread tab by default", () => {
+    mockQuerySuccess([unreadNotif, readNotif, issueNotif]);
+    render(<Notifications onOpen={onOpen} />);
+
+    expect(screen.getByText("Unread PR")).toBeInTheDocument();
+    expect(screen.getByText("Crash")).toBeInTheDocument();
+    expect(screen.queryByText("Read PR")).not.toBeInTheDocument();
+  });
+
+  it("switches to the all tab and shows read notifications", async () => {
+    const user = userEvent.setup();
+    mockQuerySuccess([unreadNotif, readNotif, issueNotif]);
+    render(<Notifications onOpen={onOpen} />);
+
+    await user.click(screen.getByRole("button", { name: /^all/i }));
+
+    expect(screen.getByText("Unread PR")).toBeInTheDocument();
+    expect(screen.getByText("Read PR")).toBeInTheDocument();
+    expect(screen.getByText("Crash")).toBeInTheDocument();
+  });
+
+  it("shows correct counts on each tab", () => {
+    mockQuerySuccess([unreadNotif, readNotif, issueNotif]);
+    render(<Notifications onOpen={onOpen} />);
+
+    const group = screen.getByRole("group", { name: /filter by state/i });
+    const buttons = within(group).getAllByRole("button");
+
+    expect(buttons[0]).toHaveTextContent("2"); // unread: 2
+    expect(buttons[1]).toHaveTextContent("3"); // all: 3
+  });
+
+  it("filters notifications by title and repo", async () => {
+    const user = userEvent.setup();
+    mockQuerySuccess([unreadNotif, issueNotif]);
+    render(<Notifications onOpen={onOpen} />);
+
+    const input = screen.getByPlaceholderText(/filter notifications/i);
+
+    await user.type(input, "crash");
+    expect(screen.getByText("Crash")).toBeInTheDocument();
+    expect(screen.queryByText("Unread PR")).not.toBeInTheDocument();
+
+    await user.clear(input);
+    await user.type(input, "other-repo");
+    expect(screen.getByText("Crash")).toBeInTheDocument();
+    expect(screen.queryByText("Unread PR")).not.toBeInTheDocument();
+  });
+
+  it("renders skeletons while loading", () => {
+    mockQueryLoading();
+    render(<Notifications onOpen={onOpen} />);
+
+    expect(screen.getByTestId("notifications")).toHaveAttribute("aria-busy", "true");
+    expect(screen.getAllByTestId("notification-card-skeleton")).toHaveLength(3);
+  });
+
+  it("shows an empty state when there are no unread notifications", () => {
+    mockQuerySuccess([readNotif]);
+    render(<Notifications onOpen={onOpen} />);
+
+    expect(screen.getByText(/no unread notifications/i)).toBeInTheDocument();
+  });
+
+  it("shows an empty state when the result list is empty", () => {
+    mockQuerySuccess([]);
+    render(<Notifications onOpen={onOpen} />);
+
+    expect(screen.getByText(/no unread notifications/i)).toBeInTheDocument();
+  });
+
+  it("renders an error banner when fetching fails", () => {
+    mockQueryError("network down");
+    render(<Notifications onOpen={onOpen} />);
+
+    expect(screen.getByRole("alert")).toHaveTextContent(/network down/i);
+  });
+
+  it("renders SectionHead with title and count", () => {
+    mockQuerySuccess([unreadNotif, readNotif, issueNotif]);
+    render(<Notifications onOpen={onOpen} />);
+
+    expect(screen.getByText("Notifications")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("forwards onOpen to the card click handler", async () => {
+    const user = userEvent.setup();
+    mockQuerySuccess([unreadNotif]);
+    render(<Notifications onOpen={onOpen} />);
+
+    await user.click(screen.getByText("Unread PR"));
+
+    expect(onOpen).toHaveBeenCalledWith(unreadNotif.url);
+  });
+});

--- a/src/components/Notifications/Notifications.test.tsx
+++ b/src/components/Notifications/Notifications.test.tsx
@@ -155,6 +155,18 @@ describe("Notifications", () => {
     expect(screen.getByText(/no unread notifications/i)).toBeInTheDocument();
   });
 
+  it("shows a search-specific empty state when a query filters everything out", async () => {
+    const user = userEvent.setup();
+    mockQuerySuccess([unreadNotif]);
+    render(<Notifications onOpen={onOpen} />);
+
+    const input = screen.getByPlaceholderText(/filter notifications/i);
+    await user.type(input, "zzzzzz-nothing-matches");
+
+    expect(screen.getByText(/no notifications match your search/i)).toBeInTheDocument();
+    expect(screen.queryByText(/no unread notifications/i)).not.toBeInTheDocument();
+  });
+
   it("renders an error banner when fetching fails", () => {
     mockQueryError("network down");
     render(<Notifications onOpen={onOpen} />);

--- a/src/components/Notifications/Notifications.tsx
+++ b/src/components/Notifications/Notifications.tsx
@@ -150,7 +150,13 @@ function NotificationsImpl({ onOpen }: NotificationsProps): ReactElement {
           {visible.length === 0 ? (
             <EmptyState
               icon="✓"
-              message={tab === "unread" ? "No unread notifications" : "No notifications to display"}
+              message={
+                normalizedQuery
+                  ? "No notifications match your search"
+                  : tab === "unread"
+                    ? "No unread notifications"
+                    : "No notifications to display"
+              }
             />
           ) : (
             <div ref={listRef} className="max-h-[600px] overflow-y-auto">

--- a/src/components/Notifications/Notifications.tsx
+++ b/src/components/Notifications/Notifications.tsx
@@ -1,0 +1,170 @@
+import { useQuery } from "@tanstack/react-query";
+import { memo, type ReactElement, useCallback, useEffect, useMemo, useRef } from "react";
+import { useRegisterNavigableItems } from "../../hooks/useRegisterNavigableItems";
+import { useFilterableList } from "../../hooks/useFilterableList";
+import { FOCUS_RING } from "../../lib/a11y";
+import { listNotifications } from "../../lib/tauri";
+import type { GithubNotification } from "../../lib/types/github";
+import { FILTER_BUTTON_CLASS } from "../../lib/uiClasses";
+import { EmptyState } from "../atoms/EmptyState";
+import { SectionHead } from "../atoms/SectionHead";
+import { CardSkeleton, Skeleton } from "../atoms/Skeleton";
+import { NotificationCard } from "./NotificationCard";
+
+interface NotificationsProps {
+  readonly onOpen: (url: string) => void;
+}
+
+type Tab = "unread" | "all";
+
+const NOTIFICATION_TABS: Readonly<Record<Tab, (n: GithubNotification) => boolean>> = {
+  unread: (n) => n.unread,
+  all: () => true,
+};
+
+function NotificationsImpl({ onOpen }: NotificationsProps): ReactElement {
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const notificationsQuery = useQuery<GithubNotification[]>({
+    queryKey: ["github", "notifications"],
+    queryFn: listNotifications,
+    // 1 minute — notifications change frequently and the REST call is cheap.
+    staleTime: 60_000,
+  });
+
+  const notifications = useMemo(() => notificationsQuery.data ?? [], [notificationsQuery.data]);
+
+  const searchPredicate = useCallback(
+    (n: GithubNotification, query: string): boolean =>
+      [n.title, n.repo, n.reason].some((value) => value.toLowerCase().includes(query)),
+    [],
+  );
+
+  const {
+    tab,
+    setTab,
+    searchQuery,
+    setSearchQuery,
+    normalizedQuery,
+    visibleItems: visible,
+    tabCounts,
+  } = useFilterableList<GithubNotification, Tab>({
+    items: notifications,
+    tabs: NOTIFICATION_TABS,
+    defaultTab: "unread",
+    searchPredicate,
+  });
+
+  useEffect(() => {
+    listRef.current?.scrollTo({ top: 0, behavior: "instant" });
+  }, [tab, normalizedQuery]);
+
+  const navItems = useMemo(() => visible.map((n) => ({ url: n.url })), [visible]);
+  useRegisterNavigableItems(navItems);
+
+  const isLoading = notificationsQuery.isLoading;
+  const isFetching = notificationsQuery.isFetching;
+  const isError = notificationsQuery.isError;
+  const errorMessage =
+    notificationsQuery.error instanceof Error
+      ? notificationsQuery.error.message
+      : "Failed to load notifications";
+
+  return (
+    <section
+      data-testid="notifications"
+      // aria-busy also reflects background refetches so screen readers hear
+      // the activity when the query is silently re-fetched (e.g. after a
+      // `github:updated` invalidation).
+      aria-busy={isLoading || isFetching ? "true" : undefined}
+      className="flex flex-col gap-2"
+    >
+      {/* Header count shows the full, unfiltered notification total so the
+          header number doesn't jitter as the user types in the search box. */}
+      <SectionHead
+        title="Notifications"
+        count={isLoading ? undefined : notifications.length}
+      />
+
+      {isLoading ? (
+        <>
+          <div className="flex gap-1">
+            <Skeleton className="h-11 w-20" />
+            <Skeleton className="h-11 w-16" />
+          </div>
+
+          <div data-testid="notifications-loading" className="flex flex-col gap-1">
+            {Array.from({ length: 3 }, (_, index) => (
+              <CardSkeleton
+                key={`notification-skeleton-${index}`}
+                testId="notification-card-skeleton"
+              />
+            ))}
+          </div>
+        </>
+      ) : isError ? (
+        <div
+          role="alert"
+          className="rounded border border-red/40 bg-red/10 px-3 py-2 text-sm text-red"
+        >
+          {errorMessage}
+        </div>
+      ) : (
+        <>
+          <input
+            type="search"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="Filter notifications..."
+            aria-label="Filter notifications"
+            className={`${FOCUS_RING} w-full rounded-md border border-border bg-bg px-3 py-2 text-sm text-fg placeholder:text-muted`}
+          />
+
+          <div className="flex gap-1" role="group" aria-label="Filter by state">
+            <button
+              type="button"
+              aria-pressed={tab === "unread"}
+              onClick={() => setTab("unread")}
+              className={`${FILTER_BUTTON_CLASS} ${
+                tab === "unread"
+                  ? "bg-accent text-bg font-semibold hover:bg-accent/80"
+                  : "text-dim hover:bg-surface-hover hover:text-foreground"
+              }`}
+            >
+              Unread {tabCounts.unread}
+            </button>
+            <button
+              type="button"
+              aria-pressed={tab === "all"}
+              onClick={() => setTab("all")}
+              className={`${FILTER_BUTTON_CLASS} ${
+                tab === "all"
+                  ? "bg-accent text-bg font-semibold hover:bg-accent/80"
+                  : "text-dim hover:bg-surface-hover hover:text-foreground"
+              }`}
+            >
+              All {tabCounts.all}
+            </button>
+          </div>
+
+          {visible.length === 0 ? (
+            <EmptyState
+              icon="✓"
+              message={tab === "unread" ? "No unread notifications" : "No notifications to display"}
+            />
+          ) : (
+            <div ref={listRef} className="max-h-[600px] overflow-y-auto">
+              <div className="flex flex-col gap-1">
+                {visible.map((n) => (
+                  <NotificationCard key={n.id} data={n} onOpen={onOpen} />
+                ))}
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  );
+}
+
+export const Notifications = memo(NotificationsImpl);

--- a/src/components/Notifications/index.tsx
+++ b/src/components/Notifications/index.tsx
@@ -1,0 +1,1 @@
+export { Notifications } from "./Notifications";

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -28,6 +28,7 @@ const NAV_ITEMS: readonly NavEntry[] = [
   { label: "My PRs", view: "mine", countKey: "openPrs" },
   { label: "Issues", view: "issues", countKey: "openIssues" },
   { label: "Activity", view: "feed", countKey: "unreadActivity" },
+  { label: "Notifications", view: "notifications" },
   { label: "Workspaces", view: "workspaces", countKey: "totalWorkspaces" },
   { label: "Settings", view: "settings" },
 ];

--- a/src/hooks/useGitHubData.ts
+++ b/src/hooks/useGitHubData.ts
@@ -11,6 +11,7 @@ function invalidateGitHub(queryClient: ReturnType<typeof useQueryClient>) {
   return Promise.all([
     queryClient.invalidateQueries({ queryKey: ["github", "dashboard"] }),
     queryClient.invalidateQueries({ queryKey: ["github", "stats"] }),
+    queryClient.invalidateQueries({ queryKey: ["github", "notifications"] }),
     queryClient.invalidateQueries({ queryKey: ["repos"] }),
   ]);
 }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -5,7 +5,7 @@ import type { AppConfig, PartialAppConfig } from "./types/config";
 import type { AuthStatus } from "./types/auth";
 import type { DashboardData, DashboardStats, PersonalStats } from "./types/dashboard";
 import type { MemoryStats } from "./types/debug";
-import type { Repo } from "./types/github";
+import type { GithubNotification, Repo } from "./types/github";
 import type {
   OpenWorkspaceRequest,
   OpenWorkspaceResponse,
@@ -46,6 +46,10 @@ export async function getPersonalStats(): Promise<PersonalStats> {
 
 export async function forceGithubSync(): Promise<void> {
   return invoke<void>(TAURI_COMMANDS.github_force_sync);
+}
+
+export async function listNotifications(): Promise<GithubNotification[]> {
+  return invoke<GithubNotification[]>(TAURI_COMMANDS.github_list_notifications);
 }
 
 // ── Repos ────────────────────────────────────────────────────────

--- a/src/lib/types/github.ts
+++ b/src/lib/types/github.ts
@@ -76,3 +76,28 @@ export interface Activity {
   readonly isRead: boolean;
   readonly createdAt: string;
 }
+
+// ── Notifications (issue #197) ───────────────────────────────────
+
+export type NotificationSubjectType =
+  | "pullRequest"
+  | "issue"
+  | "release"
+  | "discussion"
+  | "checkSuite"
+  | "commit"
+  | "other";
+
+/// Named `GithubNotification` to avoid collision with the `Notification`
+/// type defined in `hooks/useNotifications.ts`, which models the in-app
+/// system tray notifications (a different concern).
+export interface GithubNotification {
+  readonly id: string;
+  readonly repo: string;
+  readonly title: string;
+  readonly notificationType: NotificationSubjectType;
+  readonly reason: string;
+  readonly unread: boolean;
+  readonly updatedAt: string;
+  readonly url: string;
+}

--- a/src/lib/types/tauri.ts
+++ b/src/lib/types/tauri.ts
@@ -4,6 +4,7 @@ export type TauriCommandName =
   | "github_get_dashboard"
   | "github_get_stats"
   | "github_force_sync"
+  | "github_list_notifications"
   | "repos_list"
   | "repos_set_enabled"
   | "repos_set_local_path"
@@ -32,6 +33,7 @@ export const TAURI_COMMANDS = {
   github_get_dashboard: "github_get_dashboard",
   github_get_stats: "github_get_stats",
   github_force_sync: "github_force_sync",
+  github_list_notifications: "github_list_notifications",
   repos_list: "repos_list",
   repos_set_enabled: "repos_set_enabled",
   repos_set_local_path: "repos_set_local_path",

--- a/src/lib/types/types.test.ts
+++ b/src/lib/types/types.test.ts
@@ -431,8 +431,8 @@ describe("IPC payload shapes", () => {
 // ── TauriCommands & TauriEvents maps ─────────────────────────────
 
 describe("TAURI_COMMANDS constant", () => {
-  it("should contain all 26 IPC command names", () => {
-    expect(Object.keys(TAURI_COMMANDS)).toHaveLength(26);
+  it("should contain all 27 IPC command names", () => {
+    expect(Object.keys(TAURI_COMMANDS)).toHaveLength(27);
   });
 
   it("should include stats_personal in IPC command names", () => {

--- a/src/stores/dashboard.ts
+++ b/src/stores/dashboard.ts
@@ -7,6 +7,7 @@ export type DashboardView =
   | "mine"
   | "issues"
   | "feed"
+  | "notifications"
   | "workspaces"
   | "settings";
 


### PR DESCRIPTION
## Summary

Adds a new **Notifications** view to the main dashboard, following the established List-Detail pattern used by My PRs, Issues, and Review Queue. Closes #197.

### Notable deviation from the issue

The issue description mentioned `octocrab`, but PRism doesn't use octocrab — the backend uses `graphql_client` + `reqwest` for all GitHub API access. GitHub's Notifications API is also **only available via REST**, not GraphQL. I added a minimal REST path to the existing `GitHubClient` (new `rest_base_url` field + `list_notifications` method) to avoid introducing a second HTTP client.

## Backend changes

- `src-tauri/src/github/notifications.rs` (new) — REST fetcher, raw response deserialization, subject-type parsing, `build_html_url` converter from API URLs to HTML URLs, `map_notification` mapper, `fetch_notifications` async function with retry/error handling, and **17 unit tests** (mockito).
- `GitHubClient` in `client.rs` — now stores both `graphql_url` and `rest_base_url`; new `with_urls()` test constructor; new `list_notifications(&self, all)` method.
- `Notification` + `NotificationSubjectType` added to `types.rs` with `#[serde(rename_all = "camelCase")]`.
- `github_list_notifications` Tauri command registered in `lib.rs`.

## Frontend changes

- `src/components/Notifications/` (new) — `Notifications.tsx` (memoized container, TanStack Query, `useFilterableList` with unread/all tabs + search), `NotificationCard.tsx` (icon, unread dot, humanized reason, time ago), `index.tsx`, and **18 unit tests** (vitest + vi.hoisted useQuery mock).
- `GithubNotification` interface in `lib/types/github.ts` (distinct name to avoid collision with the existing system-tray `Notification` in `hooks/useNotifications.ts`).
- `listNotifications()` binding in `lib/tauri.ts`.
- Navigation entry wired into `Sidebar.tsx`, `stores/dashboard.ts`, and `App.tsx` routing.
- `useGitHubData` invalidation set now includes `[""github"", ""notifications""]` so the view refreshes on `github:updated` events.

## Security / correctness findings addressed during review

- **URL scheme guard** in `NotificationCard`: only `http(s)` URIs are forwarded to the Tauri opener; unsafe schemes are logged and refused.
- **Rate-limit parsing**: both `X-RateLimit-Remaining` and `X-RateLimit-Reset` must parse, otherwise fall through to a plain `forbidden` error instead of emitting an epoch-0 timestamp.
- **Pagination**: explicitly caps the REST fetch at `per_page=100` (documented in the function comment as intentional truncation rather than silent).
- **aria-busy** now reflects background refetches too (not just initial load).
- **SectionHead count** uses the unfiltered `notifications.length` so the header doesn't jitter when the user types in the search box.

## Test plan

- [x] `cargo test --lib github::notifications` — 17 new tests pass
- [x] `cargo test --lib github` — 93 tests pass
- [x] `npx vitest run` — 614 tests pass (53 files), including 18 new notification tests
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 warnings, 0 errors
- [x] `cargo clippy --lib` — no new warnings introduced by this change
- [x] Adversarial code review (Rust + TypeScript) — all HIGH findings resolved
- [ ] Manual smoke test: open Notifications view, verify API fetch, click through to PR/issue, confirm tabs and search

## Known limitations (deferred)

- Only the first page of notifications (max 100) is returned — documented in `fetch_notifications` docstring.
- No local SQLite caching — the command is stateless and hits GitHub on each invocation.
- Unread count is not yet exposed in the sidebar badge (would require adding `unreadNotifications` to `DashboardStats` and backend sync).

Pre-existing test failure unrelated to this change: `commands::tests::test_resolve_credentials_errors_when_no_token_stored` depends on keychain state (no stored GitHub token) and fails on any dev machine where the app has previously been authenticated.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitHub Notifications view to the dashboard with unread/all tabs and search. Implements Linear #197 and unifies rate‑limit handling across REST and GraphQL.

- **New Features**
  - Backend: REST `/notifications` in `GitHubClient` and Tauri `github_list_notifications`; fetches with `all=true` (max 100); maps subject API URLs to HTML (issues/PRs/commits); retries with backoff; strict rate‑limit parsing.
  - Frontend: New Notifications view using `@tanstack/react-query`, with unread/all tabs and search across title/repo/reason; wired into sidebar and routing; refreshes on `github:updated`; only `http(s)` URLs are opened; `aria-busy` includes background refetches.

- **Bug Fixes**
  - Rate limits: shared helpers used by REST and GraphQL; handle 429 alongside 403 and preserve the reset window; when rate‑limit headers are missing, preserve the actual HTTP status (e.g., “429 Too Many Requests”) instead of a generic “forbidden”.
  - URL mapping: release notifications fall back to the repo page (not numeric‑ID release URLs), and fallbacks now keep non‑`github.com` hostnames intact for GitHub Enterprise. Tests cover 429 cases and the enterprise fallback.

<sup>Written for commit 0cd74ca631ab7128e240f64703678571e1a1b2ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Notifications view to browse GitHub notifications: unread/all tabs, search/filter, counts, keyboard navigation, open-in-browser, type icons, repo/title, humanized reason, unread indicator, and relative time. UI wired into app navigation and backend command to fetch notifications.
* **Tests**
  * Added unit and UI tests covering parsing, URL handling/safety, retry/rate-limit scenarios, filtering, and component interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->