### PR TITLE
refactor(lint): enforce typescript/no-explicit-any rule

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -7,7 +7,8 @@
     "perf": "warn"
   },
   "rules": {
-    "react/react-in-jsx-scope": "off"
+    "react/react-in-jsx-scope": "off",
+    "typescript/no-explicit-any": "error"
   },
   "settings": {
     "jsx-a11y": {

--- a/src/lib/lint-config.test.ts
+++ b/src/lib/lint-config.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import oxlintConfig from "../../.oxlintrc.json";
+
+/**
+ * Garde-fou contre la régression de la configuration de linting.
+ *
+ * Voir issue #217 — la règle `typescript/no-explicit-any` doit rester active
+ * au niveau `error` dans `.oxlintrc.json` pour préserver la sûreté de type.
+ *
+ * Ne couvre pas les suppressions locales `// oxlint-disable-next-line` :
+ * à la date de cet écrit, aucune n'existe dans `src/`. Si le besoin
+ * apparaît, ajouter un test qui grep le tree.
+ */
+describe(".oxlintrc.json", () => {
+  it("should enforce typescript/no-explicit-any as error", () => {
+    expect(oxlintConfig.rules["typescript/no-explicit-any"]).toBe("error");
+  });
+});

--- a/src/lib/lint-config.test.ts
+++ b/src/lib/lint-config.test.ts
@@ -13,6 +13,8 @@ import oxlintConfig from "../../.oxlintrc.json";
  */
 describe(".oxlintrc.json", () => {
   it("should enforce typescript/no-explicit-any as error", () => {
-    expect(oxlintConfig.rules["typescript/no-explicit-any"]).toBe("error");
+    const rule = oxlintConfig.rules["typescript/no-explicit-any"];
+    const severity = Array.isArray(rule) ? rule[0] : rule;
+    expect(severity).toBe("error");
   });
 });


### PR DESCRIPTION
## Summary

Closes #217.

- Active la règle `typescript/no-explicit-any` au niveau `error` dans `.oxlintrc.json`
- Ajoute `src/lib/lint-config.test.ts` comme garde-fou qui importe la config JSON et vérifie la présence de la règle

## Contexte

L'issue demandait d'activer la règle **et** de refactorer les usages `any` existants. L'exploration a montré que le codebase n'avait aucun usage réel de `any` (seulement des `expect.any()` Vitest et le mot anglais dans les commentaires), grâce à `strict: true`, `noUncheckedIndexedAccess: true` et la discipline de l'équipe.

Le changement se limite donc à verrouiller cet état propre dans la config lint, sans refactor applicatif.

## Test plan

- [x] `./node_modules/.bin/oxlint .` → 0 warning / 0 error sur 144 fichiers (avec la nouvelle règle active)
- [x] `./node_modules/.bin/tsc --noEmit` → compilation OK
- [x] `npx vitest run` → 616 tests passent (dont le nouveau garde-fou)
- [x] Revue adversariale via `typescript-reviewer` — cast de type retiré, tests redondants fusionnés
- [x] Aucune désactivation locale `oxlint-disable typescript/no-explicit-any` introduite

## Notes d'implémentation

Le test utilise `import oxlintConfig from "../../.oxlintrc.json"` plutôt que `fs.readFileSync`. Cela évite d'ajouter `@types/node` comme dépendance et bénéficie de l'inférence de type littéral de TS (`resolveJsonModule` actif via `moduleResolution: bundler`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforce `typescript/no-explicit-any: error` in `.oxlintrc.json` and add a test (`src/lib/lint-config.test.ts`) that fails if the rule is removed or downgraded. Completes Linear #217; no app refactor needed since there are no `any` usages.

<sup>Written for commit e596aa619467d793616242d2f0f7347b9588659b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Linting tightened to treat usage of explicit TypeScript `any` as an error.

* **Tests**
  * Added a verification test to ensure the lint rule for explicit `any` is present and enforced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->