### PR TITLE
perf(workspace): co-locate useWorkspaceEnriched hook with WorkspaceView

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,6 @@ import { Toast } from "./components/Toast";
 import { CommandPalette } from "./components/CommandPalette";
 import { useKeyboard } from "./hooks/useKeyboard";
 import { useDashboardStore } from "./stores/dashboard";
-import { useWorkspaceEnriched } from "./hooks/useWorkspaceEnriched";
 import { useWorkspacesStore } from "./stores/workspaces";
 import { openUrl } from "./lib/open";
 import type { DashboardView } from "./stores/dashboard";
@@ -109,7 +108,6 @@ interface MainContentProps {
 
 function MainContent({ view, onBackToDashboard }: MainContentProps): ReactElement {
   const { dashboard } = useGitHubData();
-  const { statusInfo, entries } = useWorkspaceEnriched(view === "workspaces");
   const queryClient = useQueryClient();
 
   const markAllRead = useMutation({
@@ -195,8 +193,6 @@ function MainContent({ view, onBackToDashboard }: MainContentProps): ReactElemen
       return (
         <WorkspaceView
           workspaces={dashboard?.workspaces ?? []}
-          statusInfo={statusInfo}
-          entries={entries}
           onBackToDashboard={onBackToDashboard}
         />
       );

--- a/src/components/Workspace/WorkspaceView.test.tsx
+++ b/src/components/Workspace/WorkspaceView.test.tsx
@@ -159,12 +159,23 @@ const STATUS_INFO = {
 function mockEnriched(
   statusInfo: Readonly<Record<string, WorkspaceStatusInfo>> = {},
   entries: readonly WorkspaceListEntry[] = [],
+  isLoading = false,
 ): void {
   vi.mocked(useWorkspaceEnriched).mockReturnValue({
     statusInfo,
     entries,
-    isLoading: false,
+    isLoading,
   });
+}
+
+function renderWithEnriched(
+  statusInfo: Readonly<Record<string, WorkspaceStatusInfo>> = {},
+  entries: readonly WorkspaceListEntry[] = [],
+): ReturnType<typeof render> {
+  mockEnriched(statusInfo, entries);
+  return renderWithQuery(
+    <WorkspaceView workspaces={WORKSPACES} onBackToDashboard={vi.fn()} />,
+  );
 }
 
 describe("WorkspaceView", () => {
@@ -175,10 +186,7 @@ describe("WorkspaceView", () => {
   });
 
   it("should render switcher, terminal, and status bar", () => {
-    mockEnriched(STATUS_INFO, []);
-    renderWithQuery(
-      <WorkspaceView workspaces={WORKSPACES} onBackToDashboard={vi.fn()} />,
-    );
+    renderWithEnriched(STATUS_INFO);
 
     expect(screen.getByTestId("workspace-switcher")).toBeInTheDocument();
     expect(screen.getByTestId("workspace-statusbar")).toBeInTheDocument();
@@ -186,19 +194,13 @@ describe("WorkspaceView", () => {
   });
 
   it("should render the terminal after the chunk loads", async () => {
-    mockEnriched(STATUS_INFO, []);
-    renderWithQuery(
-      <WorkspaceView workspaces={WORKSPACES} onBackToDashboard={vi.fn()} />,
-    );
+    renderWithEnriched(STATUS_INFO);
 
     expect(await screen.findByTestId("terminal-ws-1")).toBeInTheDocument();
   });
 
   it("should switch terminal on workspace change", async () => {
-    mockEnriched(STATUS_INFO, []);
-    renderWithQuery(
-      <WorkspaceView workspaces={WORKSPACES} onBackToDashboard={vi.fn()} />,
-    );
+    renderWithEnriched(STATUS_INFO);
 
     expect(await screen.findByTestId("terminal-ws-1")).toBeInTheDocument();
 
@@ -211,10 +213,7 @@ describe("WorkspaceView", () => {
   });
 
   it("should render terminal without status bar when status info is missing", async () => {
-    mockEnriched({}, []);
-    renderWithQuery(
-      <WorkspaceView workspaces={WORKSPACES} onBackToDashboard={vi.fn()} />,
-    );
+    renderWithEnriched();
 
     expect(screen.getByTestId("workspace-switcher")).toBeInTheDocument();
     expect(await screen.findByTestId("terminal-ws-1")).toBeInTheDocument();
@@ -223,11 +222,7 @@ describe("WorkspaceView", () => {
 
   it("should show empty state when active workspace not in list", () => {
     useWorkspacesStore.setState({ activeWorkspaceId: "ws-unknown" });
-    mockEnriched(STATUS_INFO, []);
-
-    renderWithQuery(
-      <WorkspaceView workspaces={WORKSPACES} onBackToDashboard={vi.fn()} />,
-    );
+    renderWithEnriched(STATUS_INFO);
 
     expect(screen.getByTestId("workspace-switcher")).toBeInTheDocument();
     expect(screen.queryByTestId("workspace-statusbar")).not.toBeInTheDocument();
@@ -239,11 +234,7 @@ describe("WorkspaceView", () => {
 
     const activeEntry = makeEntry({ workspaceOverrides: { id: "ws-a", state: "active", pullRequestNumber: 10 } });
     const suspendedEntry = makeEntry({ workspaceOverrides: { id: "ws-b", state: "suspended", pullRequestNumber: 20 } });
-    mockEnriched({}, [activeEntry, suspendedEntry]);
-
-    renderWithQuery(
-      <WorkspaceView workspaces={WORKSPACES} onBackToDashboard={vi.fn()} />,
-    );
+    renderWithEnriched({}, [activeEntry, suspendedEntry]);
 
     expect(screen.getByTestId("workspace-list")).toBeInTheDocument();
     expect(screen.queryByTestId("terminal-ws-1")).not.toBeInTheDocument();
@@ -254,11 +245,7 @@ describe("WorkspaceView", () => {
 
     const activeEntry = makeEntry({ workspaceOverrides: { id: "ws-active", state: "active", pullRequestNumber: 1 } });
     const archivedEntry = makeEntry({ workspaceOverrides: { id: "ws-archived", state: "archived", pullRequestNumber: 2 } });
-    mockEnriched({}, [activeEntry, archivedEntry]);
-
-    renderWithQuery(
-      <WorkspaceView workspaces={WORKSPACES} onBackToDashboard={vi.fn()} />,
-    );
+    renderWithEnriched({}, [activeEntry, archivedEntry]);
 
     expect(screen.getByTestId("workspace-item-ws-active")).toBeInTheDocument();
     expect(screen.getByTestId("workspace-item-ws-archived")).toBeInTheDocument();
@@ -268,11 +255,7 @@ describe("WorkspaceView", () => {
     useWorkspacesStore.setState({ activeWorkspaceId: null });
 
     const archivedEntry = makeEntry({ workspaceOverrides: { id: "ws-archived", state: "archived", pullRequestNumber: 2 } });
-    mockEnriched({}, [archivedEntry]);
-
-    renderWithQuery(
-      <WorkspaceView workspaces={WORKSPACES} onBackToDashboard={vi.fn()} />,
-    );
+    renderWithEnriched({}, [archivedEntry]);
 
     fireEvent.click(screen.getByTestId("workspace-item-ws-archived"));
 
@@ -286,11 +269,7 @@ describe("WorkspaceView", () => {
     useWorkspacesStore.setState({ setActiveWorkspace } as Partial<ReturnType<typeof useWorkspacesStore.getState>>);
 
     const activeEntry = makeEntry({ workspaceOverrides: { id: "ws-click", state: "active", pullRequestNumber: 5 } });
-    mockEnriched({}, [activeEntry]);
-
-    renderWithQuery(
-      <WorkspaceView workspaces={WORKSPACES} onBackToDashboard={vi.fn()} />,
-    );
+    renderWithEnriched({}, [activeEntry]);
 
     fireEvent.click(screen.getByTestId("workspace-item-ws-click"));
 
@@ -304,11 +283,7 @@ describe("WorkspaceView", () => {
     act(() => {
       useWorkspacesStore.setState({ activeWorkspaceId: "ws-2" });
     });
-    mockEnriched(STATUS_INFO, []);
-
-    renderWithQuery(
-      <WorkspaceView workspaces={WORKSPACES} onBackToDashboard={vi.fn()} />,
-    );
+    renderWithEnriched(STATUS_INFO);
 
     expect(screen.getByTestId("workspace-suspended-placeholder")).toBeInTheDocument();
     expect(screen.queryByTestId("terminal-ws-2")).not.toBeInTheDocument();
@@ -319,13 +294,10 @@ describe("WorkspaceView", () => {
     act(() => {
       useWorkspacesStore.setState({ activeWorkspaceId: "ws-2" });
     });
-    mockEnriched(STATUS_INFO, []);
 
     vi.mocked(resumeWorkspace).mockResolvedValue(undefined);
 
-    renderWithQuery(
-      <WorkspaceView workspaces={WORKSPACES} onBackToDashboard={vi.fn()} />,
-    );
+    renderWithEnriched(STATUS_INFO);
 
     fireEvent.click(screen.getByTestId("btn-wake-workspace"));
 
@@ -347,11 +319,7 @@ describe("WorkspaceView", () => {
     });
 
     const suspendedEntry = makeEntry({ workspaceOverrides: { id: "ws-suspended", state: "suspended", pullRequestNumber: 7 } });
-    mockEnriched({}, [suspendedEntry]);
-
-    renderWithQuery(
-      <WorkspaceView workspaces={WORKSPACES} onBackToDashboard={vi.fn()} />,
-    );
+    renderWithEnriched({}, [suspendedEntry]);
 
     fireEvent.click(screen.getByTestId("workspace-item-ws-suspended"));
 

--- a/src/components/Workspace/WorkspaceView.test.tsx
+++ b/src/components/Workspace/WorkspaceView.test.tsx
@@ -58,8 +58,13 @@ vi.mock("../../lib/tauri", () => ({
   resumeWorkspace: vi.fn(),
 }));
 
+vi.mock("../../hooks/useWorkspaceEnriched", () => ({
+  useWorkspaceEnriched: vi.fn(),
+}));
+
 import { WorkspaceView } from "./WorkspaceView";
 import { resumeWorkspace } from "../../lib/tauri";
+import { useWorkspaceEnriched } from "../../hooks/useWorkspaceEnriched";
 
 // ── Test helpers ─────────────────────────────────────────────────
 
@@ -151,20 +156,28 @@ const STATUS_INFO = {
   },
 } satisfies Readonly<Record<string, WorkspaceStatusInfo>>;
 
+function mockEnriched(
+  statusInfo: Readonly<Record<string, WorkspaceStatusInfo>> = {},
+  entries: readonly WorkspaceListEntry[] = [],
+): void {
+  vi.mocked(useWorkspaceEnriched).mockReturnValue({
+    statusInfo,
+    entries,
+    isLoading: false,
+  });
+}
+
 describe("WorkspaceView", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     useWorkspacesStore.setState({ activeWorkspaceId: "ws-1" });
+    mockEnriched();
   });
 
   it("should render switcher, terminal, and status bar", () => {
+    mockEnriched(STATUS_INFO, []);
     renderWithQuery(
-      <WorkspaceView
-        workspaces={WORKSPACES}
-        statusInfo={STATUS_INFO}
-        entries={[]}
-        onBackToDashboard={vi.fn()}
-      />,
+      <WorkspaceView workspaces={WORKSPACES} onBackToDashboard={vi.fn()} />,
     );
 
     expect(screen.getByTestId("workspace-switcher")).toBeInTheDocument();
@@ -173,26 +186,18 @@ describe("WorkspaceView", () => {
   });
 
   it("should render the terminal after the chunk loads", async () => {
+    mockEnriched(STATUS_INFO, []);
     renderWithQuery(
-      <WorkspaceView
-        workspaces={WORKSPACES}
-        statusInfo={STATUS_INFO}
-        entries={[]}
-        onBackToDashboard={vi.fn()}
-      />,
+      <WorkspaceView workspaces={WORKSPACES} onBackToDashboard={vi.fn()} />,
     );
 
     expect(await screen.findByTestId("terminal-ws-1")).toBeInTheDocument();
   });
 
   it("should switch terminal on workspace change", async () => {
+    mockEnriched(STATUS_INFO, []);
     renderWithQuery(
-      <WorkspaceView
-        workspaces={WORKSPACES}
-        statusInfo={STATUS_INFO}
-        entries={[]}
-        onBackToDashboard={vi.fn()}
-      />,
+      <WorkspaceView workspaces={WORKSPACES} onBackToDashboard={vi.fn()} />,
     );
 
     expect(await screen.findByTestId("terminal-ws-1")).toBeInTheDocument();
@@ -206,13 +211,9 @@ describe("WorkspaceView", () => {
   });
 
   it("should render terminal without status bar when status info is missing", async () => {
+    mockEnriched({}, []);
     renderWithQuery(
-      <WorkspaceView
-        workspaces={WORKSPACES}
-        statusInfo={{}}
-        entries={[]}
-        onBackToDashboard={vi.fn()}
-      />,
+      <WorkspaceView workspaces={WORKSPACES} onBackToDashboard={vi.fn()} />,
     );
 
     expect(screen.getByTestId("workspace-switcher")).toBeInTheDocument();
@@ -222,14 +223,10 @@ describe("WorkspaceView", () => {
 
   it("should show empty state when active workspace not in list", () => {
     useWorkspacesStore.setState({ activeWorkspaceId: "ws-unknown" });
+    mockEnriched(STATUS_INFO, []);
 
     renderWithQuery(
-      <WorkspaceView
-        workspaces={WORKSPACES}
-        statusInfo={STATUS_INFO}
-        entries={[]}
-        onBackToDashboard={vi.fn()}
-      />,
+      <WorkspaceView workspaces={WORKSPACES} onBackToDashboard={vi.fn()} />,
     );
 
     expect(screen.getByTestId("workspace-switcher")).toBeInTheDocument();
@@ -242,14 +239,10 @@ describe("WorkspaceView", () => {
 
     const activeEntry = makeEntry({ workspaceOverrides: { id: "ws-a", state: "active", pullRequestNumber: 10 } });
     const suspendedEntry = makeEntry({ workspaceOverrides: { id: "ws-b", state: "suspended", pullRequestNumber: 20 } });
+    mockEnriched({}, [activeEntry, suspendedEntry]);
 
     renderWithQuery(
-      <WorkspaceView
-        workspaces={WORKSPACES}
-        statusInfo={{}}
-        entries={[activeEntry, suspendedEntry]}
-        onBackToDashboard={vi.fn()}
-      />,
+      <WorkspaceView workspaces={WORKSPACES} onBackToDashboard={vi.fn()} />,
     );
 
     expect(screen.getByTestId("workspace-list")).toBeInTheDocument();
@@ -261,14 +254,10 @@ describe("WorkspaceView", () => {
 
     const activeEntry = makeEntry({ workspaceOverrides: { id: "ws-active", state: "active", pullRequestNumber: 1 } });
     const archivedEntry = makeEntry({ workspaceOverrides: { id: "ws-archived", state: "archived", pullRequestNumber: 2 } });
+    mockEnriched({}, [activeEntry, archivedEntry]);
 
     renderWithQuery(
-      <WorkspaceView
-        workspaces={WORKSPACES}
-        statusInfo={{}}
-        entries={[activeEntry, archivedEntry]}
-        onBackToDashboard={vi.fn()}
-      />,
+      <WorkspaceView workspaces={WORKSPACES} onBackToDashboard={vi.fn()} />,
     );
 
     expect(screen.getByTestId("workspace-item-ws-active")).toBeInTheDocument();
@@ -279,14 +268,10 @@ describe("WorkspaceView", () => {
     useWorkspacesStore.setState({ activeWorkspaceId: null });
 
     const archivedEntry = makeEntry({ workspaceOverrides: { id: "ws-archived", state: "archived", pullRequestNumber: 2 } });
+    mockEnriched({}, [archivedEntry]);
 
     renderWithQuery(
-      <WorkspaceView
-        workspaces={WORKSPACES}
-        statusInfo={{}}
-        entries={[archivedEntry]}
-        onBackToDashboard={vi.fn()}
-      />,
+      <WorkspaceView workspaces={WORKSPACES} onBackToDashboard={vi.fn()} />,
     );
 
     fireEvent.click(screen.getByTestId("workspace-item-ws-archived"));
@@ -301,14 +286,10 @@ describe("WorkspaceView", () => {
     useWorkspacesStore.setState({ setActiveWorkspace } as Partial<ReturnType<typeof useWorkspacesStore.getState>>);
 
     const activeEntry = makeEntry({ workspaceOverrides: { id: "ws-click", state: "active", pullRequestNumber: 5 } });
+    mockEnriched({}, [activeEntry]);
 
     renderWithQuery(
-      <WorkspaceView
-        workspaces={WORKSPACES}
-        statusInfo={{}}
-        entries={[activeEntry]}
-        onBackToDashboard={vi.fn()}
-      />,
+      <WorkspaceView workspaces={WORKSPACES} onBackToDashboard={vi.fn()} />,
     );
 
     fireEvent.click(screen.getByTestId("workspace-item-ws-click"));
@@ -323,14 +304,10 @@ describe("WorkspaceView", () => {
     act(() => {
       useWorkspacesStore.setState({ activeWorkspaceId: "ws-2" });
     });
+    mockEnriched(STATUS_INFO, []);
 
     renderWithQuery(
-      <WorkspaceView
-        workspaces={WORKSPACES}
-        statusInfo={STATUS_INFO}
-        entries={[]}
-        onBackToDashboard={vi.fn()}
-      />,
+      <WorkspaceView workspaces={WORKSPACES} onBackToDashboard={vi.fn()} />,
     );
 
     expect(screen.getByTestId("workspace-suspended-placeholder")).toBeInTheDocument();
@@ -342,16 +319,12 @@ describe("WorkspaceView", () => {
     act(() => {
       useWorkspacesStore.setState({ activeWorkspaceId: "ws-2" });
     });
+    mockEnriched(STATUS_INFO, []);
 
     vi.mocked(resumeWorkspace).mockResolvedValue(undefined);
 
     renderWithQuery(
-      <WorkspaceView
-        workspaces={WORKSPACES}
-        statusInfo={STATUS_INFO}
-        entries={[]}
-        onBackToDashboard={vi.fn()}
-      />,
+      <WorkspaceView workspaces={WORKSPACES} onBackToDashboard={vi.fn()} />,
     );
 
     fireEvent.click(screen.getByTestId("btn-wake-workspace"));
@@ -374,14 +347,10 @@ describe("WorkspaceView", () => {
     });
 
     const suspendedEntry = makeEntry({ workspaceOverrides: { id: "ws-suspended", state: "suspended", pullRequestNumber: 7 } });
+    mockEnriched({}, [suspendedEntry]);
 
     renderWithQuery(
-      <WorkspaceView
-        workspaces={WORKSPACES}
-        statusInfo={{}}
-        entries={[suspendedEntry]}
-        onBackToDashboard={vi.fn()}
-      />,
+      <WorkspaceView workspaces={WORKSPACES} onBackToDashboard={vi.fn()} />,
     );
 
     fireEvent.click(screen.getByTestId("workspace-item-ws-suspended"));

--- a/src/components/Workspace/WorkspaceView.tsx
+++ b/src/components/Workspace/WorkspaceView.tsx
@@ -1,9 +1,10 @@
 import { lazy, Suspense, useCallback, useState, type ReactElement } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { FOCUS_RING } from "../../lib/a11y";
-import type { Workspace, WorkspaceListEntry, WorkspaceStatusInfo } from "../../lib/types/workspace";
+import type { Workspace } from "../../lib/types/workspace";
 import { resumeWorkspace } from "../../lib/tauri";
 import { useWorkspacesStore } from "../../stores/workspaces";
+import { useWorkspaceEnriched } from "../../hooks/useWorkspaceEnriched";
 import { WorkspaceSwitcher } from "./WorkspaceSwitcher";
 import { WorkspaceStatusBar } from "./WorkspaceStatusBar";
 import { WorkspaceListPage } from "./WorkspaceListPage";
@@ -25,18 +26,15 @@ function TerminalLoadingFallback(): ReactElement {
 
 interface WorkspaceViewProps {
   readonly workspaces: readonly Workspace[];
-  readonly statusInfo: Readonly<Record<string, WorkspaceStatusInfo>>;
-  readonly entries: readonly WorkspaceListEntry[];
   readonly onBackToDashboard: () => void;
 }
 
 export function WorkspaceView({
   workspaces,
-  statusInfo,
-  entries,
   onBackToDashboard,
 }: WorkspaceViewProps): ReactElement {
   const queryClient = useQueryClient();
+  const { statusInfo, entries } = useWorkspaceEnriched();
   const activeWorkspaceId = useWorkspacesStore((s) => s.activeWorkspaceId);
   const setActiveWorkspace = useWorkspacesStore((s) => s.setActiveWorkspace);
   const active = workspaces.find((w) => w.id === activeWorkspaceId);

--- a/src/hooks/useWorkspaceEnriched.ts
+++ b/src/hooks/useWorkspaceEnriched.ts
@@ -8,19 +8,16 @@ import type { WorkspaceListEntry, WorkspaceStatusInfo } from "../lib/types/works
 // Tauri event, so time-based polling can be relaxed.
 const STALE_TIME = 300_000;
 
-export function useWorkspaceEnriched(enabled = true) {
+export function useWorkspaceEnriched() {
   const queryClient = useQueryClient();
 
   const query = useQuery({
     queryKey: ["workspaces", "enriched"],
     queryFn: listWorkspacesEnriched,
     staleTime: STALE_TIME,
-    enabled,
   });
 
   useEffect(() => {
-    if (!enabled) return;
-
     let cancelled = false;
     const unlisteners: (() => void)[] = [];
 
@@ -44,7 +41,7 @@ export function useWorkspaceEnriched(enabled = true) {
         unlisten();
       }
     };
-  }, [queryClient, enabled]);
+  }, [queryClient]);
 
   const statusInfo: Record<string, WorkspaceStatusInfo> = useMemo(() => {
     const data = query.data ?? [];


### PR DESCRIPTION
## Summary

- Moves `useWorkspaceEnriched` out of `MainContent` (App.tsx) and into `WorkspaceView`, where its data is actually consumed
- Removes the `statusInfo` / `entries` prop drilling from App → WorkspaceView
- Updates tests to mock `useWorkspaceEnriched` at the module level rather than injecting data via props

## Why

`WorkspaceView` is lazy-loaded and only mounted when the workspaces view is active. The hook's query was already gated via `enabled: view === "workspaces"`, but the hook's body (state, `useMemo`, event listener registration) still ran on every `MainContent` render for every non-workspace view. Co-locating the hook with its only consumer avoids that wasted work entirely, and removes the need for the `enabled` flag inside the view.

Closes #213

## Test plan

- [x] `npx vitest run src/components/Workspace/WorkspaceView.test.tsx` — 12/12 green
- [x] `npx vitest run` — full suite 616/616 green
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 warnings, 0 errors
- [ ] Manual: navigate dashboard views; confirm workspace data still loads when switching to Workspaces; confirm suspended/active/archived flows unchanged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move `useWorkspaceEnriched` into `WorkspaceView` to run only when the Workspaces view mounts, avoiding wasted work and prop drilling. Aligns with #213 and removes the dead `enabled` flag in the hook.

- **Refactors**
  - Co-located `useWorkspaceEnriched` inside `WorkspaceView`; removed `enabled` param and related checks.
  - Removed `statusInfo` and `entries` props and drilling from `App.tsx`.
  - Tests now mock `useWorkspaceEnriched` at the module level; added `mockEnriched`/`renderWithEnriched` helpers with optional `isLoading`.

<sup>Written for commit 4affe08b6a08a23d6cae6870c23743491aef752f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated workspace data sourcing so the workspace view now derives its own enriched metadata and list entries internally; overall data flow simplified.
  * Background workspace state updates now run consistently (removes conditional disabling).
* **Tests**
  * Updated tests to reflect the internalized data sourcing and simplified component interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->