### PR TITLE
feat(ui): add static actions to Command Palette

### DIFF
--- a/src/components/CommandPalette/CommandPalette.test.tsx
+++ b/src/components/CommandPalette/CommandPalette.test.tsx
@@ -301,8 +301,7 @@ describe("CommandPalette", () => {
     const onOpenChange = vi.fn();
     renderPalette({ open: true, onOpenChange });
 
-    // Navigate to item via keyboard (arrow down selects first item)
-    await user.keyboard("{ArrowDown}");
+    // cmdk auto-selects the first item (the PR) on open
     await user.keyboard("{Meta>}{Enter}{/Meta}");
 
     expect(mockedOpenUrl).toHaveBeenCalledWith(
@@ -330,7 +329,7 @@ describe("CommandPalette", () => {
     const onOpenChange = vi.fn();
     renderPalette({ open: true, onOpenChange });
 
-    await user.keyboard("{ArrowDown}");
+    // cmdk auto-selects the first item (the PR) on open
     await user.keyboard("{Control>}{Enter}{/Control}");
 
     expect(mockedOpenUrl).toHaveBeenCalledWith(
@@ -462,5 +461,60 @@ describe("CommandPalette", () => {
 
     const titleSpan = screen.getByText("Fix login bug");
     expect(titleSpan).toHaveAttribute("title", "Fix login bug");
+  });
+
+  it("should display Actions group heading", () => {
+    renderPalette({ open: true, onOpenChange: () => {} });
+    expect(screen.getByText("Actions")).toBeInTheDocument();
+  });
+
+  it("should navigate to settings when selecting Settings action", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    renderPalette({ open: true, onOpenChange });
+
+    const item = screen.getByText("Settings");
+    await user.click(item);
+
+    expect(mockSetView).toHaveBeenCalledWith("settings");
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("should open documentation URL when selecting Open Documentation action", async () => {
+    const { openUrl: mockedOpenUrl } = await import("../../lib/open");
+    vi.mocked(mockedOpenUrl).mockClear();
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    renderPalette({ open: true, onOpenChange });
+
+    const item = screen.getByText("Open Documentation");
+    await user.click(item);
+
+    expect(mockedOpenUrl).toHaveBeenCalledWith("https://github.com/mpiton/prism");
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("should open releases URL when selecting Check for Updates action", async () => {
+    const { openUrl: mockedOpenUrl } = await import("../../lib/open");
+    vi.mocked(mockedOpenUrl).mockClear();
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    renderPalette({ open: true, onOpenChange });
+
+    const item = screen.getByText("Check for Updates");
+    await user.click(item);
+
+    expect(mockedOpenUrl).toHaveBeenCalledWith("https://github.com/mpiton/prism/releases");
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("should find actions via search", async () => {
+    const user = userEvent.setup();
+    renderPalette({ open: true, onOpenChange: () => {} });
+
+    const input = screen.getByPlaceholderText(/search/i);
+    await user.type(input, "settings");
+
+    expect(screen.getByText("Settings")).toBeInTheDocument();
   });
 });

--- a/src/components/CommandPalette/CommandPalette.tsx
+++ b/src/components/CommandPalette/CommandPalette.tsx
@@ -62,6 +62,9 @@ function deduplicateItems(items: readonly PaletteItem[]): readonly PaletteItem[]
   });
 }
 
+const ITEM_CLASS =
+  "flex cursor-pointer items-center gap-2 rounded-md px-3 py-2 text-sm text-fg aria-selected:bg-fg/10";
+
 function PaletteItemRow({ item }: { readonly item: PaletteItem }): ReactElement {
   return (
     <>
@@ -167,7 +170,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
                   value={item.id}
                   keywords={[String(item.number), item.title, item.repoName]}
                   onSelect={() => handleSelect(item)}
-                  className="flex cursor-pointer items-center gap-2 rounded-md px-3 py-2 text-sm text-fg aria-selected:bg-fg/10"
+                  className={ITEM_CLASS}
                 >
                   <PaletteItemRow item={item} />
                 </Command.Item>
@@ -183,13 +186,49 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
                   value={item.id}
                   keywords={[String(item.number), item.title, item.repoName]}
                   onSelect={() => handleSelect(item)}
-                  className="flex cursor-pointer items-center gap-2 rounded-md px-3 py-2 text-sm text-fg aria-selected:bg-fg/10"
+                  className={ITEM_CLASS}
                 >
                   <PaletteItemRow item={item} />
                 </Command.Item>
               ))}
             </Command.Group>
           )}
+
+          <Command.Group heading="Actions">
+            <Command.Item
+              value="action-settings"
+              keywords={["settings", "preferences", "config"]}
+              onSelect={() => {
+                useDashboardStore.getState().setView("settings");
+                onOpenChange(false);
+              }}
+              className={ITEM_CLASS}
+            >
+              Settings
+            </Command.Item>
+            <Command.Item
+              value="action-docs"
+              keywords={["documentation", "docs", "help", "guide"]}
+              onSelect={() => {
+                openUrl("https://github.com/mpiton/prism");
+                onOpenChange(false);
+              }}
+              className={ITEM_CLASS}
+            >
+              Open Documentation
+            </Command.Item>
+            <Command.Item
+              value="action-updates"
+              keywords={["update", "updates", "version", "release"]}
+              onSelect={() => {
+                openUrl("https://github.com/mpiton/prism/releases");
+                onOpenChange(false);
+              }}
+              className={ITEM_CLASS}
+            >
+              Check for Updates
+            </Command.Item>
+          </Command.Group>
         </Command.List>
       </div>
     </Command.Dialog>


### PR DESCRIPTION
## Summary
- Add always-visible "Actions" group to the command palette with three static entries: **Settings**, **Open Documentation**, and **Check for Updates**
- Extract repeated `className` string into `ITEM_CLASS` constant (5 occurrences deduplicated)
- Add 5 new tests covering the actions group (heading, navigation, URL opening, search)

Closes #195

## Test plan
- [x] 22/22 tests pass (`npx vitest run CommandPalette`)
- [x] oxlint: 0 warnings, 0 errors
- [x] TypeScript: no type errors
- [ ] Manual: open command palette (Cmd+K), verify Actions group visible
- [ ] Manual: click "Settings" → navigates to settings view
- [ ] Manual: click "Open Documentation" → opens GitHub repo in browser
- [ ] Manual: click "Check for Updates" → opens releases page in browser
- [ ] Manual: search "settings" → filters to show Settings action

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an always-visible Actions group to the Command Palette with Settings, Open Documentation, and Check for Updates. This makes common actions easy to find and searchable.

- New Features
  - Actions group with three entries:
    - Settings → navigates to settings view
    - Open Documentation → opens repo URL
    - Check for Updates → opens releases URL
  - Actions are searchable with relevant keywords

- Refactors
  - Consolidated repeated item styles into `ITEM_CLASS` to reduce duplication

<sup>Written for commit 1365792079d7aca7f06d8f0841760d1757391714. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded Command Palette with a new "Actions" section containing quick-access commands
  * Added Settings action to switch to settings view directly from the palette
  * Added "Open Documentation" action to access GitHub documentation
  * Added "Check for Updates" action to view the latest release information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->