### PR TITLE
feat(ui): pause toast auto-dismiss timer on hover

### DIFF
--- a/src/components/Toast/Toast.test.tsx
+++ b/src/components/Toast/Toast.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from "vitest";
-import { render, screen, act } from "@testing-library/react";
+import { render, screen, act, fireEvent } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import { Toast } from "./Toast";
 
@@ -196,5 +196,89 @@ describe("Toast", () => {
     const { container } = render(<Toast />);
 
     expect(container.querySelector("[data-testid='toast-container']")?.children).toHaveLength(0);
+  });
+
+  it("should pause timer on mouse enter", () => {
+    (useNotifications as Mock).mockReturnValue({
+      notifications: [makeNotification()],
+      clearNotification: mockClearNotification,
+    });
+
+    render(<Toast />);
+
+    const toast = screen.getByRole("button");
+
+    // Advance 2s, then hover
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    fireEvent.mouseEnter(toast);
+
+    // Advance well past the original 5s — should NOT dismiss while hovered
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+
+    expect(mockClearNotification).not.toHaveBeenCalled();
+  });
+
+  it("should resume timer with remaining time on mouse leave", () => {
+    (useNotifications as Mock).mockReturnValue({
+      notifications: [makeNotification()],
+      clearNotification: mockClearNotification,
+    });
+
+    render(<Toast />);
+
+    const toast = screen.getByRole("button");
+
+    // Advance 3s (2s remaining), then hover
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    fireEvent.mouseEnter(toast);
+
+    // Wait a long time while hovered — no dismiss
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+    expect(mockClearNotification).not.toHaveBeenCalled();
+
+    // Leave hover — timer resumes with ~2s remaining
+    fireEvent.mouseLeave(toast);
+
+    // At 1.9s after leave — still not dismissed
+    act(() => {
+      vi.advanceTimersByTime(1900);
+    });
+    expect(mockClearNotification).not.toHaveBeenCalled();
+
+    // At 2.1s after leave — should be dismissed
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(mockClearNotification).toHaveBeenCalledWith("notif-1");
+  });
+
+  it("should dismiss manually while hovered", async () => {
+    vi.useRealTimers();
+
+    (useNotifications as Mock).mockReturnValue({
+      notifications: [makeNotification()],
+      clearNotification: mockClearNotification,
+    });
+
+    render(<Toast />);
+
+    const toast = screen.getByRole("button");
+    fireEvent.mouseEnter(toast);
+
+    const user = userEvent.setup();
+    await user.click(toast);
+
+    expect(mockSetView).toHaveBeenCalledWith("reviews");
+    expect(mockClearNotification).toHaveBeenCalledWith("notif-1");
   });
 });

--- a/src/components/Toast/Toast.test.tsx
+++ b/src/components/Toast/Toast.test.tsx
@@ -260,6 +260,7 @@ describe("Toast", () => {
       vi.advanceTimersByTime(200);
     });
     expect(mockClearNotification).toHaveBeenCalledWith("notif-1");
+    expect(mockClearNotification).toHaveBeenCalledTimes(1);
   });
 
   it("should dismiss manually while hovered", async () => {

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -68,9 +68,13 @@ function ToastItem({ notification, onDismiss, onNavigate }: ToastItemProps): Rea
       timerRef.current = null;
     }
     remainingRef.current = Math.max(0, remainingRef.current - (Date.now() - startRef.current));
+    startRef.current = Date.now();
   }, []);
 
   const handleMouseLeave = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+    }
     startRef.current = Date.now();
     timerRef.current = setTimeout(() => {
       onDismiss(notification.id);

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -42,11 +42,15 @@ function extractPayloadSummary(payload: unknown): string | undefined {
 
 function ToastItem({ notification, onDismiss, onNavigate }: ToastItemProps): ReactElement {
   const timerRef = useRef<ReturnType<typeof setTimeout>>(null);
+  const remainingRef = useRef(AUTO_DISMISS_MS);
+  const startRef = useRef(0);
   const meta = NOTIFICATION_META[notification.type];
   const Icon = meta.Icon;
   const summary = extractPayloadSummary(notification.payload);
 
   useEffect(() => {
+    remainingRef.current = AUTO_DISMISS_MS;
+    startRef.current = Date.now();
     timerRef.current = setTimeout(() => {
       onDismiss(notification.id);
     }, AUTO_DISMISS_MS);
@@ -56,6 +60,21 @@ function ToastItem({ notification, onDismiss, onNavigate }: ToastItemProps): Rea
         clearTimeout(timerRef.current);
       }
     };
+  }, [notification.id, onDismiss]);
+
+  const handleMouseEnter = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    remainingRef.current = Math.max(0, remainingRef.current - (Date.now() - startRef.current));
+  }, []);
+
+  const handleMouseLeave = useCallback(() => {
+    startRef.current = Date.now();
+    timerRef.current = setTimeout(() => {
+      onDismiss(notification.id);
+    }, remainingRef.current);
   }, [notification.id, onDismiss]);
 
   const handleClick = useCallback(() => {
@@ -71,6 +90,8 @@ function ToastItem({ notification, onDismiss, onNavigate }: ToastItemProps): Rea
       type="button"
       aria-label={`${meta.label}${summary ? ` ${summary}` : ""} — click to navigate`}
       onClick={handleClick}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
       className={`${FOCUS_RING} flex w-72 items-center gap-3 rounded-lg border border-border bg-bg-secondary p-3 shadow-lg transition-opacity hover:opacity-80`}
     >
       <span className="flex h-5 w-5 items-center justify-center text-fg" aria-hidden="true">


### PR DESCRIPTION
## Summary

- Add `onMouseEnter`/`onMouseLeave` handlers to `ToastItem` that pause and resume the 5s auto-dismiss countdown
- Uses `useRef` for remaining time and start timestamp to avoid unnecessary re-renders and stale closures
- 3 new tests covering pause, resume-with-remaining-time, and manual-dismiss-while-hovered

Closes #208

## Test plan

- [x] Toast still auto-dismisses after 5s when never hovered
- [x] Timer pauses on mouse enter (no dismiss while hovered)
- [x] Timer resumes with remaining time on mouse leave
- [x] Manual click dismiss still works while hovered
- [x] Full test suite passes (624/624)
- [x] oxlint: 0 warnings, 0 errors
- [x] TypeScript: compiles clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pauses toast auto-dismiss on hover and resumes with the remaining time on mouse leave, preventing accidental dismiss; manual dismiss still works. Aligns with #208.

- **New Features**
  - Added `onMouseEnter`/`onMouseLeave` to `ToastItem` to pause/resume the 5s timer.
  - Tracked remaining time with `useRef` to avoid re-renders and stale closures.
  - Added tests for pause, resume with remaining time, and manual dismiss while hovered.

- **Bug Fixes**
  - Clear existing timeout on mouse leave before scheduling a new one to avoid duplicate timers.
  - Reset `startRef` after computing remaining time; tightened test with `toHaveBeenCalledTimes(1)`.

<sup>Written for commit 3bd82bfc5973e6be6bbe3f194bf37644af0d9a8d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Toast notifications now pause their auto-dismiss countdown while hovered and resume when the pointer leaves.
  * Manual dismissal via click still clears the toast and triggers navigation even while hovered.

* **Tests**
  * Added tests covering hover-based pause/resume behavior and manual click dismissal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->