### PR TITLE
feat(ui): add CTA button to EmptyState component

### DIFF
--- a/src/components/atoms/EmptyState.test.tsx
+++ b/src/components/atoms/EmptyState.test.tsx
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { EmptyState } from "./EmptyState";
 
 describe("EmptyState", () => {
@@ -16,5 +17,57 @@ describe("EmptyState", () => {
   it("should have role=status for screen readers", () => {
     render(<EmptyState message="No reviews pending" />);
     expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+
+  it("should not render a button when no cta prop is provided", () => {
+    render(<EmptyState message="Empty" />);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("should render a button with cta text when cta is provided", () => {
+    render(
+      <EmptyState
+        message="No repos"
+        cta={{ text: "Add a repository", onClick: () => {} }}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Add a repository" })).toBeInTheDocument();
+  });
+
+  it("should call cta.onClick when the button is clicked", async () => {
+    const handleClick = vi.fn();
+    render(
+      <EmptyState
+        message="No repos"
+        cta={{ text: "Sync now", onClick: handleClick }}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Sync now" }));
+    expect(handleClick).toHaveBeenCalledOnce();
+  });
+
+  it("should call cta.onClick when activated via keyboard", async () => {
+    const handleClick = vi.fn();
+    render(
+      <EmptyState
+        message="No repos"
+        cta={{ text: "Sync now", onClick: handleClick }}
+      />,
+    );
+
+    screen.getByRole("button", { name: "Sync now" }).focus();
+    await userEvent.keyboard("{Enter}");
+    expect(handleClick).toHaveBeenCalledOnce();
+  });
+
+  it("should render a button with type='button'", () => {
+    render(
+      <EmptyState
+        message="No repos"
+        cta={{ text: "Sync", onClick: () => {} }}
+      />,
+    );
+    expect(screen.getByRole("button")).toHaveAttribute("type", "button");
   });
 });

--- a/src/components/atoms/EmptyState.test.tsx
+++ b/src/components/atoms/EmptyState.test.tsx
@@ -61,6 +61,20 @@ describe("EmptyState", () => {
     expect(handleClick).toHaveBeenCalledOnce();
   });
 
+  it("should call cta.onClick when activated with Space", async () => {
+    const handleClick = vi.fn();
+    render(
+      <EmptyState
+        message="No repos"
+        cta={{ text: "Sync now", onClick: handleClick }}
+      />,
+    );
+
+    screen.getByRole("button", { name: "Sync now" }).focus();
+    await userEvent.keyboard(" ");
+    expect(handleClick).toHaveBeenCalledOnce();
+  });
+
   it("should render a button with type='button'", () => {
     render(
       <EmptyState

--- a/src/components/atoms/EmptyState.tsx
+++ b/src/components/atoms/EmptyState.tsx
@@ -1,15 +1,31 @@
 import type { ReactElement } from "react";
+import { FOCUS_RING } from "../../lib/a11y";
+
+interface EmptyStateCTA {
+  readonly text: string;
+  readonly onClick: () => void;
+}
 
 interface EmptyStateProps {
   readonly message: string;
   readonly icon?: string;
+  readonly cta?: EmptyStateCTA;
 }
 
-export function EmptyState({ message, icon }: EmptyStateProps): ReactElement {
+export function EmptyState({ message, icon, cta }: EmptyStateProps): ReactElement {
   return (
     <div role="status" className="flex flex-col items-center justify-center gap-1 py-8 text-center">
       {icon && <span aria-hidden="true" className="text-lg">{icon}</span>}
       <span className="text-sm text-dim">{message}</span>
+      {cta && (
+        <button
+          type="button"
+          onClick={cta.onClick}
+          className={`${FOCUS_RING} mt-2 rounded border border-border px-2 py-1 text-xs font-medium text-dim transition-colors hover:border-accent hover:text-white`}
+        >
+          {cta.text}
+        </button>
+      )}
     </div>
   );
 }

--- a/src/components/atoms/EmptyState.tsx
+++ b/src/components/atoms/EmptyState.tsx
@@ -14,14 +14,16 @@ interface EmptyStateProps {
 
 export function EmptyState({ message, icon, cta }: EmptyStateProps): ReactElement {
   return (
-    <div role="status" className="flex flex-col items-center justify-center gap-1 py-8 text-center">
-      {icon && <span aria-hidden="true" className="text-lg">{icon}</span>}
-      <span className="text-sm text-dim">{message}</span>
+    <div className="flex flex-col items-center justify-center gap-1 py-8 text-center">
+      <div role="status" className="flex flex-col items-center gap-1">
+        {icon && <span aria-hidden="true" className="text-lg">{icon}</span>}
+        <span className="text-sm text-dim">{message}</span>
+      </div>
       {cta && (
         <button
           type="button"
           onClick={cta.onClick}
-          className={`${FOCUS_RING} mt-2 rounded border border-border px-2 py-1 text-xs font-medium text-dim transition-colors hover:border-accent hover:text-white`}
+          className={`${FOCUS_RING} mt-2 inline-flex min-h-11 items-center rounded border border-border px-3 text-xs font-medium text-dim transition-colors hover:border-accent hover:text-white`}
         >
           {cta.text}
         </button>


### PR DESCRIPTION
## Summary

- Add optional `cta` prop to `EmptyState` component with `text` and `onClick` fields
- Render a keyboard-accessible button below the message when `cta` is provided
- Style consistent with existing `controlButtonClass` pattern (border, hover states, FOCUS_RING)
- Add 5 new tests covering rendering, click handling, keyboard activation, and accessibility

Closes #205

## Test plan

- [x] Button not rendered without `cta` prop
- [x] Button renders with correct text when `cta` provided
- [x] `onClick` called on mouse click
- [x] `onClick` called on keyboard Enter
- [x] Button has `type="button"` for accessibility
- [x] All 634 tests pass, 0 lint errors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an optional CTA button to `EmptyState` so users can trigger an action from empty screens, addressing #205. The button matches existing styles, is keyboard accessible, and meets WCAG touch-target size.

- New Features
  - `cta` prop: `{ text, onClick }`; renders a button below the message with `FOCUS_RING`, hover/border styles, and `min-h-11` (44px)
  - Accessibility: `type="button"`, `role="status"` scoped to non-interactive content, supports Enter and Space activation
  - Tests cover render, click/keyboard (Enter + Space), and no-cta case

<sup>Written for commit a3fa620b89957cf069af758401883b0d128ae1eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * EmptyState component now supports an optional call-to-action button with customizable text and click handler, enabling richer user interactions in empty states.
  * CTA button is fully keyboard accessible, supporting activation via mouse clicks, Enter key, and Space key presses.
  * Enhanced focus styling provides improved accessibility and visual feedback for keyboard users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->