### PR TITLE
feat(ui): add repo and label filters to list views

### DIFF
--- a/src/components/Issues/Issues.test.tsx
+++ b/src/components/Issues/Issues.test.tsx
@@ -234,8 +234,8 @@ describe("Issues", () => {
 
     render(<Issues issues={[issue1, issue2]} onOpen={onOpen} />);
 
-    expect(screen.getByText("org-a/shared")).toBeInTheDocument();
-    expect(screen.getByText("org-b/shared")).toBeInTheDocument();
+    expect(screen.getAllByText("org-a/shared").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("org-b/shared").length).toBeGreaterThan(0);
   });
 
   it("should fallback to repoId when repo not found in map", () => {
@@ -249,6 +249,127 @@ describe("Issues", () => {
     render(<Issues issues={[orphanIssue]} onOpen={onOpen} />);
 
     expect(screen.getByText("unknown-repo")).toBeInTheDocument();
+  });
+
+  it("should show repo dropdown when multiple repos exist", () => {
+    const issue1 = makeIssue({ number: 1, title: "Issue in repo 1", state: "open", repoId: "repo-1" });
+    const issue2 = makeIssue({ number: 2, title: "Issue in repo 2", state: "open", repoId: "repo-2" });
+    mockUseQuery.mockReturnValue({
+      data: [
+        makeRepo(),
+        makeRepo({ id: "repo-2", org: "acme", name: "console", fullName: "acme/console" }),
+      ],
+    });
+
+    render(<Issues issues={[issue1, issue2]} onOpen={onOpen} />);
+
+    const select = screen.getByRole("combobox", { name: /filter by repo/i });
+    expect(select).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "All repos" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "acme/console" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "org/repo" })).toBeInTheDocument();
+  });
+
+  it("should hide repo dropdown when single repo", () => {
+    render(<Issues issues={[openIssue1, openIssue2]} onOpen={onOpen} />);
+
+    expect(screen.queryByRole("combobox", { name: /filter by repo/i })).toBeNull();
+  });
+
+  it("should filter issues by selected repo", async () => {
+    const issue1 = makeIssue({ number: 1, title: "Repo 1 issue", state: "open", repoId: "repo-1" });
+    const issue2 = makeIssue({ number: 2, title: "Repo 2 issue", state: "open", repoId: "repo-2" });
+    mockUseQuery.mockReturnValue({
+      data: [
+        makeRepo(),
+        makeRepo({ id: "repo-2", org: "acme", name: "console", fullName: "acme/console" }),
+      ],
+    });
+
+    render(<Issues issues={[issue1, issue2]} onOpen={onOpen} />);
+
+    const select = screen.getByRole("combobox", { name: /filter by repo/i });
+    await userEvent.selectOptions(select, "repo-2");
+
+    expect(screen.getByText("Repo 2 issue")).toBeInTheDocument();
+    expect(screen.queryByText("Repo 1 issue")).not.toBeInTheDocument();
+  });
+
+  it("should show label filter buttons when labels exist", () => {
+    const labeledIssue = makeIssue({ number: 5, title: "Bug issue", state: "open", labels: ["bug", "help wanted"] });
+
+    render(<Issues issues={[labeledIssue]} onOpen={onOpen} />);
+
+    const group = screen.getByRole("group", { name: /filter by label/i });
+    expect(group).toBeInTheDocument();
+    expect(within(group).getByRole("button", { name: "bug" })).toBeInTheDocument();
+    expect(within(group).getByRole("button", { name: "help wanted" })).toBeInTheDocument();
+  });
+
+  it("should hide label filters when no labels", () => {
+    render(<Issues issues={[openIssue1]} onOpen={onOpen} />);
+
+    expect(screen.queryByRole("group", { name: /filter by label/i })).toBeNull();
+  });
+
+  it("should filter issues by selected label", async () => {
+    const user = userEvent.setup();
+    const bugIssue = makeIssue({ number: 1, title: "Bug issue", state: "open", labels: ["bug"] });
+    const featureIssue = makeIssue({ number: 2, title: "Feature issue", state: "open", labels: ["feature"] });
+
+    render(<Issues issues={[bugIssue, featureIssue]} onOpen={onOpen} />);
+
+    await user.click(screen.getByRole("button", { name: "bug" }));
+
+    expect(screen.getByText("Bug issue")).toBeInTheDocument();
+    expect(screen.queryByText("Feature issue")).not.toBeInTheDocument();
+  });
+
+  it("should deselect label filter on second click", async () => {
+    const user = userEvent.setup();
+    const bugIssue = makeIssue({ number: 1, title: "Bug issue", state: "open", labels: ["bug"] });
+    const featureIssue = makeIssue({ number: 2, title: "Feature issue", state: "open", labels: ["feature"] });
+
+    render(<Issues issues={[bugIssue, featureIssue]} onOpen={onOpen} />);
+
+    const bugButton = screen.getByRole("button", { name: "bug" });
+    await user.click(bugButton);
+    await user.click(bugButton);
+
+    expect(screen.getByText("Bug issue")).toBeInTheDocument();
+    expect(screen.getByText("Feature issue")).toBeInTheDocument();
+  });
+
+  it("should combine repo + label + search + tab filters", async () => {
+    const user = userEvent.setup();
+    const issue1 = makeIssue({ number: 1, title: "Repo1 bug open", state: "open", repoId: "repo-1", labels: ["bug"] });
+    const issue2 = makeIssue({ number: 2, title: "Repo2 bug open", state: "open", repoId: "repo-2", labels: ["bug"] });
+    const issue3 = makeIssue({ number: 3, title: "Repo1 feature open", state: "open", repoId: "repo-1", labels: ["feature"] });
+    const issue4 = makeIssue({ number: 4, title: "Repo1 bug closed", state: "closed", repoId: "repo-1", labels: ["bug"] });
+    mockUseQuery.mockReturnValue({
+      data: [
+        makeRepo(),
+        makeRepo({ id: "repo-2", org: "acme", name: "console", fullName: "acme/console" }),
+      ],
+    });
+
+    render(<Issues issues={[issue1, issue2, issue3, issue4]} onOpen={onOpen} />);
+
+    // Filter by repo-1
+    const select = screen.getByRole("combobox", { name: /filter by repo/i });
+    await userEvent.selectOptions(select, "repo-1");
+
+    // Filter by label "bug"
+    await user.click(screen.getByRole("button", { name: "bug" }));
+
+    // Search for "open"
+    await user.type(screen.getByPlaceholderText("Filter issues..."), "open");
+
+    // Only issue1 matches: repo-1, bug label, "open" in title, open tab
+    expect(screen.getByText("Repo1 bug open")).toBeInTheDocument();
+    expect(screen.queryByText("Repo2 bug open")).not.toBeInTheDocument();
+    expect(screen.queryByText("Repo1 feature open")).not.toBeInTheDocument();
+    expect(screen.queryByText("Repo1 bug closed")).not.toBeInTheDocument();
   });
 
 });

--- a/src/components/Issues/Issues.test.tsx
+++ b/src/components/Issues/Issues.test.tsx
@@ -372,4 +372,56 @@ describe("Issues", () => {
     expect(screen.queryByText("Repo1 bug closed")).not.toBeInTheDocument();
   });
 
+  it("should reset stale repo/label filters after data changes", async () => {
+    const issue1 = makeIssue({ number: 1, title: "Issue repo1", repoId: "repo-1", labels: ["bug"], state: "open" });
+    const issue2 = makeIssue({ number: 2, title: "Issue repo2", repoId: "repo-2", labels: ["feature"], state: "open" });
+    mockUseQuery.mockReturnValue({
+      data: [
+        makeRepo(),
+        makeRepo({ id: "repo-2", org: "acme", name: "console", fullName: "acme/console" }),
+      ],
+    });
+
+    const { rerender } = render(<Issues issues={[issue1, issue2]} onOpen={onOpen} />);
+
+    // Select repo-2 and label "feature"
+    await userEvent.selectOptions(screen.getByRole("combobox", { name: /filter by repo/i }), "repo-2");
+    await userEvent.click(screen.getByRole("button", { name: "feature" }));
+
+    expect(screen.getByText("Issue repo2")).toBeInTheDocument();
+    expect(screen.queryByText("Issue repo1")).not.toBeInTheDocument();
+
+    // Rerender with data that no longer includes repo-2 or "feature" label
+    const issue3 = makeIssue({ number: 3, title: "Issue repo1 new", repoId: "repo-1", labels: ["docs"], state: "open" });
+    mockUseQuery.mockReturnValue({ data: [makeRepo()] });
+    rerender(<Issues issues={[issue1, issue3]} onOpen={onOpen} />);
+
+    // Filters should reset — all items visible again
+    expect(screen.getByText("Issue repo1")).toBeInTheDocument();
+    expect(screen.getByText("Issue repo1 new")).toBeInTheDocument();
+    expect(screen.queryByRole("combobox", { name: /filter by repo/i })).toBeNull();
+  });
+
+  it("should show only labels from the selected repo", async () => {
+    const issue1 = makeIssue({ number: 1, title: "Issue1", repoId: "repo-1", labels: ["bug"], state: "open" });
+    const issue2 = makeIssue({ number: 2, title: "Issue2", repoId: "repo-2", labels: ["feature"], state: "open" });
+    mockUseQuery.mockReturnValue({
+      data: [
+        makeRepo(),
+        makeRepo({ id: "repo-2", org: "acme", name: "console", fullName: "acme/console" }),
+      ],
+    });
+
+    render(<Issues issues={[issue1, issue2]} onOpen={onOpen} />);
+
+    const labelGroup = screen.getByRole("group", { name: /filter by label/i });
+    expect(within(labelGroup).getByRole("button", { name: "bug" })).toBeInTheDocument();
+    expect(within(labelGroup).getByRole("button", { name: "feature" })).toBeInTheDocument();
+
+    // Select repo-1: only "bug" label should remain
+    await userEvent.selectOptions(screen.getByRole("combobox", { name: /filter by repo/i }), "repo-1");
+    expect(within(labelGroup).getByRole("button", { name: "bug" })).toBeInTheDocument();
+    expect(within(labelGroup).queryByRole("button", { name: "feature" })).not.toBeInTheDocument();
+  });
+
 });

--- a/src/components/Issues/Issues.tsx
+++ b/src/components/Issues/Issues.tsx
@@ -48,23 +48,44 @@ function IssuesImpl({ issues, isLoading = false, onOpen }: IssuesProps): ReactEl
     return result.sort((a, b) => a.fullName.localeCompare(b.fullName));
   }, [issues, repoMap]);
 
+  const repoFiltered = useMemo<readonly Issue[]>(
+    () =>
+      repoFilter === ""
+        ? issues
+        : issues.filter((issue) => issue.repoId === repoFilter),
+    [issues, repoFilter],
+  );
+
   const uniqueLabels = useMemo<string[]>(() => {
     const seen = new Set<string>();
-    for (const issue of issues) {
+    for (const issue of repoFiltered) {
       for (const label of issue.labels) {
         seen.add(label);
       }
     }
     return [...seen].sort();
-  }, [issues]);
+  }, [repoFiltered]);
 
-  const preFiltered = useMemo<readonly Issue[]>(() => {
-    return issues.filter((issue) => {
-      if (repoFilter !== "" && issue.repoId !== repoFilter) return false;
-      if (labelFilter !== null && !issue.labels.includes(labelFilter)) return false;
-      return true;
-    });
-  }, [issues, repoFilter, labelFilter]);
+  // Reset stale filters when available options shrink
+  useEffect(() => {
+    if (repoFilter !== "" && !uniqueRepos.some((r) => r.id === repoFilter)) {
+      setRepoFilter("");
+    }
+  }, [uniqueRepos, repoFilter]);
+
+  useEffect(() => {
+    if (labelFilter !== null && !uniqueLabels.includes(labelFilter)) {
+      setLabelFilter(null);
+    }
+  }, [uniqueLabels, labelFilter]);
+
+  const preFiltered = useMemo<readonly Issue[]>(
+    () =>
+      labelFilter === null
+        ? repoFiltered
+        : repoFiltered.filter((issue) => issue.labels.includes(labelFilter)),
+    [repoFiltered, labelFilter],
+  );
 
   const searchPredicate = useCallback(
     (issue: Issue, query: string): boolean => {

--- a/src/components/Issues/Issues.tsx
+++ b/src/components/Issues/Issues.tsx
@@ -82,12 +82,15 @@ function IssuesImpl({ issues, isLoading = false, onOpen }: IssuesProps): ReactEl
     }
   }, [uniqueLabels, labelFilter]);
 
+  const isLabelFilterValid =
+    labelFilter === null || uniqueLabels.includes(labelFilter);
+
   const preFiltered = useMemo<readonly Issue[]>(
     () =>
-      labelFilter === null
+      labelFilter === null || !isLabelFilterValid
         ? repoFiltered
         : repoFiltered.filter((issue) => issue.labels.includes(labelFilter)),
-    [repoFiltered, labelFilter],
+    [repoFiltered, labelFilter, isLabelFilterValid],
   );
 
   const searchPredicate = useCallback(

--- a/src/components/Issues/Issues.tsx
+++ b/src/components/Issues/Issues.tsx
@@ -48,12 +48,15 @@ function IssuesImpl({ issues, isLoading = false, onOpen }: IssuesProps): ReactEl
     return result.sort((a, b) => a.fullName.localeCompare(b.fullName));
   }, [issues, repoMap]);
 
+  const isRepoFilterValid =
+    repoFilter === "" || uniqueRepos.some((r) => r.id === repoFilter);
+
   const repoFiltered = useMemo<readonly Issue[]>(
     () =>
-      repoFilter === ""
+      repoFilter === "" || !isRepoFilterValid
         ? issues
         : issues.filter((issue) => issue.repoId === repoFilter),
-    [issues, repoFilter],
+    [issues, repoFilter, isRepoFilterValid],
   );
 
   const uniqueLabels = useMemo<string[]>(() => {

--- a/src/components/Issues/Issues.tsx
+++ b/src/components/Issues/Issues.tsx
@@ -1,9 +1,9 @@
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { useQuery } from "@tanstack/react-query";
-import { memo, type ReactElement, useCallback, useEffect, useMemo, useRef } from "react";
+import { memo, type ReactElement, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { FOCUS_RING } from "../../lib/a11y";
 import { listRepos } from "../../lib/tauri";
-import { FILTER_BUTTON_CLASS } from "../../lib/uiClasses";
+import { FILTER_BUTTON_CLASS, INLINE_CONTROL_CLASS } from "../../lib/uiClasses";
 import type { Issue } from "../../lib/types/github";
 import { useFilterableList } from "../../hooks/useFilterableList";
 import { useRegisterNavigableItems } from "../../hooks/useRegisterNavigableItems";
@@ -28,11 +28,43 @@ const ISSUE_TABS: Readonly<Record<Tab, (issue: Issue) => boolean>> = {
 function IssuesImpl({ issues, isLoading = false, onOpen }: IssuesProps): ReactElement {
   const parentRef = useRef<HTMLDivElement>(null);
   const { data: repos } = useQuery({ queryKey: ["repos"], queryFn: listRepos });
+  const [repoFilter, setRepoFilter] = useState("");
+  const [labelFilter, setLabelFilter] = useState<string | null>(null);
 
   const repoMap = useMemo<Map<string, string>>(() => {
     if (!repos) return new Map();
     return new Map(repos.map((repo) => [repo.id, repo.fullName]));
   }, [repos]);
+
+  const uniqueRepos = useMemo<{ id: string; fullName: string }[]>(() => {
+    const seen = new Set<string>();
+    const result: { id: string; fullName: string }[] = [];
+    for (const issue of issues) {
+      if (!seen.has(issue.repoId)) {
+        seen.add(issue.repoId);
+        result.push({ id: issue.repoId, fullName: repoMap.get(issue.repoId) ?? issue.repoId });
+      }
+    }
+    return result.sort((a, b) => a.fullName.localeCompare(b.fullName));
+  }, [issues, repoMap]);
+
+  const uniqueLabels = useMemo<string[]>(() => {
+    const seen = new Set<string>();
+    for (const issue of issues) {
+      for (const label of issue.labels) {
+        seen.add(label);
+      }
+    }
+    return [...seen].sort();
+  }, [issues]);
+
+  const preFiltered = useMemo<readonly Issue[]>(() => {
+    return issues.filter((issue) => {
+      if (repoFilter !== "" && issue.repoId !== repoFilter) return false;
+      if (labelFilter !== null && !issue.labels.includes(labelFilter)) return false;
+      return true;
+    });
+  }, [issues, repoFilter, labelFilter]);
 
   const searchPredicate = useCallback(
     (issue: Issue, query: string): boolean => {
@@ -54,7 +86,7 @@ function IssuesImpl({ issues, isLoading = false, onOpen }: IssuesProps): ReactEl
     visibleItems: visible,
     tabCounts,
   } = useFilterableList<Issue, Tab>({
-    items: issues,
+    items: preFiltered,
     tabs: ISSUE_TABS,
     defaultTab: "open",
     searchPredicate,
@@ -62,7 +94,7 @@ function IssuesImpl({ issues, isLoading = false, onOpen }: IssuesProps): ReactEl
 
   useEffect(() => {
     parentRef.current?.scrollTo({ top: 0, behavior: "instant" });
-  }, [tab, normalizedQuery]);
+  }, [tab, normalizedQuery, repoFilter, labelFilter]);
 
   const virtualizer = useVirtualizer({
     count: visible.length,
@@ -139,6 +171,40 @@ function IssuesImpl({ issues, isLoading = false, onOpen }: IssuesProps): ReactEl
               Closed {tabCounts.closed}
             </button>
           </div>
+
+          {uniqueRepos.length > 1 && (
+            <select
+              aria-label="Filter by repo"
+              value={repoFilter}
+              onChange={(e) => setRepoFilter(e.target.value)}
+              className={`cursor-pointer border border-border bg-surface text-foreground hover:border-foreground ${INLINE_CONTROL_CLASS}`}
+            >
+              <option value="">All repos</option>
+              {uniqueRepos.map((r) => (
+                <option key={r.id} value={r.id}>{r.fullName}</option>
+              ))}
+            </select>
+          )}
+
+          {uniqueLabels.length > 0 && (
+            <div className="flex flex-wrap gap-1" role="group" aria-label="Filter by label">
+              {uniqueLabels.map((label) => (
+                <button
+                  key={label}
+                  type="button"
+                  aria-pressed={labelFilter === label}
+                  onClick={() => setLabelFilter(labelFilter === label ? null : label)}
+                  className={`${FILTER_BUTTON_CLASS} ${
+                    labelFilter === label
+                      ? "bg-accent text-bg font-semibold hover:bg-accent/80"
+                      : "text-dim hover:bg-surface-hover hover:text-foreground"
+                  }`}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+          )}
 
           {visible.length === 0 ? (
             <EmptyState icon="◎" message="No issues to display" />

--- a/src/components/MyPRs/MyPRs.test.tsx
+++ b/src/components/MyPRs/MyPRs.test.tsx
@@ -221,4 +221,122 @@ describe("MyPRs", () => {
     expect(onOpen).toHaveBeenCalledWith(openPr1.pullRequest.url);
   });
 
+  it("should show repo dropdown when multiple repos exist", () => {
+    const pr2 = makePr({ number: 6, title: "PR from acme", repoId: "repo-2", state: "open" });
+    mockUseQuery.mockReturnValue({
+      data: [
+        makeRepo(),
+        makeRepo({ id: "repo-2", org: "acme", name: "console", fullName: "acme/console" }),
+      ],
+    });
+
+    render(<MyPRs prs={[openPr1, pr2]} onOpen={onOpen} />);
+
+    const select = screen.getByRole("combobox", { name: /filter by repo/i });
+    expect(select).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "All repos" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "org/repo" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "acme/console" })).toBeInTheDocument();
+  });
+
+  it("should hide repo dropdown when single repo", () => {
+    render(<MyPRs prs={[openPr1, openPr2]} onOpen={onOpen} />);
+
+    expect(screen.queryByRole("combobox", { name: /filter by repo/i })).not.toBeInTheDocument();
+  });
+
+  it("should filter PRs by selected repo", async () => {
+    const pr2 = makePr({ number: 6, title: "PR from acme", repoId: "repo-2", state: "open" });
+    mockUseQuery.mockReturnValue({
+      data: [
+        makeRepo(),
+        makeRepo({ id: "repo-2", org: "acme", name: "console", fullName: "acme/console" }),
+      ],
+    });
+
+    render(<MyPRs prs={[openPr1, pr2]} onOpen={onOpen} />);
+
+    const select = screen.getByRole("combobox", { name: /filter by repo/i });
+    await userEvent.selectOptions(select, "repo-2");
+
+    expect(screen.queryByText("Open PR one")).not.toBeInTheDocument();
+    expect(screen.getByText("PR from acme")).toBeInTheDocument();
+  });
+
+  it("should show label filter buttons when labels exist", () => {
+    const bugPr = makePr({ number: 6, title: "Bug fix", labels: ["bug"], state: "open" });
+    const featurePr = makePr({ number: 7, title: "New feature", labels: ["feature"], state: "open" });
+
+    render(<MyPRs prs={[bugPr, featurePr]} onOpen={onOpen} />);
+
+    const group = screen.getByRole("group", { name: /filter by label/i });
+    expect(within(group).getByRole("button", { name: "bug" })).toBeInTheDocument();
+    expect(within(group).getByRole("button", { name: "feature" })).toBeInTheDocument();
+  });
+
+  it("should hide label filters when no labels", () => {
+    render(<MyPRs prs={[openPr1, openPr2]} onOpen={onOpen} />);
+
+    expect(screen.queryByRole("group", { name: /filter by label/i })).not.toBeInTheDocument();
+  });
+
+  it("should filter PRs by selected label", async () => {
+    const user = userEvent.setup();
+    const bugPr = makePr({ number: 6, title: "Bug fix", labels: ["bug"], state: "open" });
+    const featurePr = makePr({ number: 7, title: "New feature", labels: ["feature"], state: "open" });
+
+    render(<MyPRs prs={[bugPr, featurePr]} onOpen={onOpen} />);
+
+    await user.click(screen.getByRole("button", { name: "bug" }));
+
+    expect(screen.getByText("Bug fix")).toBeInTheDocument();
+    expect(screen.queryByText("New feature")).not.toBeInTheDocument();
+  });
+
+  it("should deselect label filter on second click", async () => {
+    const user = userEvent.setup();
+    const bugPr = makePr({ number: 6, title: "Bug fix", labels: ["bug"], state: "open" });
+    const featurePr = makePr({ number: 7, title: "New feature", labels: ["feature"], state: "open" });
+
+    render(<MyPRs prs={[bugPr, featurePr]} onOpen={onOpen} />);
+
+    const bugButton = screen.getByRole("button", { name: "bug" });
+    await user.click(bugButton);
+    await user.click(bugButton);
+
+    expect(screen.getByText("Bug fix")).toBeInTheDocument();
+    expect(screen.getByText("New feature")).toBeInTheDocument();
+  });
+
+  it("should combine repo + label + search + tab filters", async () => {
+    const user = userEvent.setup();
+    const pr2 = makePr({ number: 6, title: "Acme bug fix", repoId: "repo-2", labels: ["bug"], state: "open" });
+    const pr3 = makePr({ number: 7, title: "Acme feature", repoId: "repo-2", labels: ["feature"], state: "open" });
+    const pr4 = makePr({ number: 8, title: "Acme merged bug", repoId: "repo-2", labels: ["bug"], state: "merged" });
+    mockUseQuery.mockReturnValue({
+      data: [
+        makeRepo(),
+        makeRepo({ id: "repo-2", org: "acme", name: "console", fullName: "acme/console" }),
+      ],
+    });
+
+    render(<MyPRs prs={[openPr1, pr2, pr3, pr4]} onOpen={onOpen} />);
+
+    // Select repo-2
+    const select = screen.getByRole("combobox", { name: /filter by repo/i });
+    await userEvent.selectOptions(select, "repo-2");
+
+    // Select "bug" label
+    await user.click(screen.getByRole("button", { name: "bug" }));
+
+    // Search for "acme"
+    await user.type(screen.getByPlaceholderText("Filter PRs..."), "acme");
+
+    // Tab is still "open" by default
+    expect(screen.getByText("Acme bug fix")).toBeInTheDocument();
+    expect(screen.queryByText("Open PR one")).not.toBeInTheDocument();
+    expect(screen.queryByText("Acme feature")).not.toBeInTheDocument();
+    expect(screen.queryByText("Acme merged bug")).not.toBeInTheDocument();
+  });
+
 });

--- a/src/components/MyPRs/MyPRs.test.tsx
+++ b/src/components/MyPRs/MyPRs.test.tsx
@@ -339,4 +339,58 @@ describe("MyPRs", () => {
     expect(screen.queryByText("Acme merged bug")).not.toBeInTheDocument();
   });
 
+  it("should reset stale repo/label filters after data changes", async () => {
+    const pr1 = makePr({ number: 1, title: "PR repo1", repoId: "repo-1", labels: ["bug"], state: "open" });
+    const pr2 = makePr({ number: 2, title: "PR repo2", repoId: "repo-2", labels: ["feature"], state: "open" });
+    mockUseQuery.mockReturnValue({
+      data: [
+        makeRepo(),
+        makeRepo({ id: "repo-2", org: "acme", name: "console", fullName: "acme/console" }),
+      ],
+    });
+
+    const { rerender } = render(<MyPRs prs={[pr1, pr2]} onOpen={onOpen} />);
+
+    // Select repo-2 and label "feature"
+    await userEvent.selectOptions(screen.getByRole("combobox", { name: /filter by repo/i }), "repo-2");
+    await userEvent.click(screen.getByRole("button", { name: "feature" }));
+
+    expect(screen.getByText("PR repo2")).toBeInTheDocument();
+    expect(screen.queryByText("PR repo1")).not.toBeInTheDocument();
+
+    // Rerender with data that no longer includes repo-2 or "feature" label
+    const pr3 = makePr({ number: 3, title: "PR repo1 new", repoId: "repo-1", labels: ["docs"], state: "open" });
+    mockUseQuery.mockReturnValue({ data: [makeRepo()] });
+    rerender(<MyPRs prs={[pr1, pr3]} onOpen={onOpen} />);
+
+    // Filters should reset — all items visible again
+    expect(screen.getByText("PR repo1")).toBeInTheDocument();
+    expect(screen.getByText("PR repo1 new")).toBeInTheDocument();
+    // Repo dropdown hidden (single repo), label group shows new labels
+    expect(screen.queryByRole("combobox", { name: /filter by repo/i })).not.toBeInTheDocument();
+  });
+
+  it("should show only labels from the selected repo", async () => {
+    const pr1 = makePr({ number: 1, title: "PR1", repoId: "repo-1", labels: ["bug"], state: "open" });
+    const pr2 = makePr({ number: 2, title: "PR2", repoId: "repo-2", labels: ["feature"], state: "open" });
+    mockUseQuery.mockReturnValue({
+      data: [
+        makeRepo(),
+        makeRepo({ id: "repo-2", org: "acme", name: "console", fullName: "acme/console" }),
+      ],
+    });
+
+    render(<MyPRs prs={[pr1, pr2]} onOpen={onOpen} />);
+
+    // Before repo filter: both labels visible
+    const labelGroup = screen.getByRole("group", { name: /filter by label/i });
+    expect(within(labelGroup).getByRole("button", { name: "bug" })).toBeInTheDocument();
+    expect(within(labelGroup).getByRole("button", { name: "feature" })).toBeInTheDocument();
+
+    // Select repo-1: only "bug" label should remain
+    await userEvent.selectOptions(screen.getByRole("combobox", { name: /filter by repo/i }), "repo-1");
+    expect(within(labelGroup).getByRole("button", { name: "bug" })).toBeInTheDocument();
+    expect(within(labelGroup).queryByRole("button", { name: "feature" })).not.toBeInTheDocument();
+  });
+
 });

--- a/src/components/MyPRs/MyPRs.tsx
+++ b/src/components/MyPRs/MyPRs.tsx
@@ -66,12 +66,15 @@ function MyPRsImpl({
     return result.sort((a, b) => a.fullName.localeCompare(b.fullName));
   }, [prs, repoMap]);
 
+  const isRepoFilterValid =
+    repoFilter === "" || uniqueRepos.some((r) => r.id === repoFilter);
+
   const repoFiltered = useMemo(
     () =>
-      repoFilter === ""
+      repoFilter === "" || !isRepoFilterValid
         ? prs
         : prs.filter((pr) => pr.pullRequest.repoId === repoFilter),
-    [prs, repoFilter],
+    [prs, repoFilter, isRepoFilterValid],
   );
 
   const uniqueLabels = useMemo(() => {

--- a/src/components/MyPRs/MyPRs.tsx
+++ b/src/components/MyPRs/MyPRs.tsx
@@ -66,23 +66,44 @@ function MyPRsImpl({
     return result.sort((a, b) => a.fullName.localeCompare(b.fullName));
   }, [prs, repoMap]);
 
+  const repoFiltered = useMemo(
+    () =>
+      repoFilter === ""
+        ? prs
+        : prs.filter((pr) => pr.pullRequest.repoId === repoFilter),
+    [prs, repoFilter],
+  );
+
   const uniqueLabels = useMemo(() => {
     const seen = new Set<string>();
-    for (const pr of prs) {
+    for (const pr of repoFiltered) {
       for (const label of pr.pullRequest.labels) {
         seen.add(label);
       }
     }
     return [...seen].sort();
-  }, [prs]);
+  }, [repoFiltered]);
 
-  const preFiltered = useMemo(() => {
-    return prs.filter((pr) => {
-      if (repoFilter !== "" && pr.pullRequest.repoId !== repoFilter) return false;
-      if (labelFilter !== null && !pr.pullRequest.labels.includes(labelFilter)) return false;
-      return true;
-    });
-  }, [prs, repoFilter, labelFilter]);
+  // Reset stale filters when available options shrink
+  useEffect(() => {
+    if (repoFilter !== "" && !uniqueRepos.some((r) => r.id === repoFilter)) {
+      setRepoFilter("");
+    }
+  }, [uniqueRepos, repoFilter]);
+
+  useEffect(() => {
+    if (labelFilter !== null && !uniqueLabels.includes(labelFilter)) {
+      setLabelFilter(null);
+    }
+  }, [uniqueLabels, labelFilter]);
+
+  const preFiltered = useMemo(
+    () =>
+      labelFilter === null
+        ? repoFiltered
+        : repoFiltered.filter((pr) => pr.pullRequest.labels.includes(labelFilter)),
+    [repoFiltered, labelFilter],
+  );
 
   const searchPredicate = useCallback(
     (pr: PullRequestWithReview, query: string): boolean => {

--- a/src/components/MyPRs/MyPRs.tsx
+++ b/src/components/MyPRs/MyPRs.tsx
@@ -100,12 +100,15 @@ function MyPRsImpl({
     }
   }, [uniqueLabels, labelFilter]);
 
+  const isLabelFilterValid =
+    labelFilter === null || uniqueLabels.includes(labelFilter);
+
   const preFiltered = useMemo(
     () =>
-      labelFilter === null
+      labelFilter === null || !isLabelFilterValid
         ? repoFiltered
         : repoFiltered.filter((pr) => pr.pullRequest.labels.includes(labelFilter)),
-    [repoFiltered, labelFilter],
+    [repoFiltered, labelFilter, isLabelFilterValid],
   );
 
   const searchPredicate = useCallback(

--- a/src/components/MyPRs/MyPRs.tsx
+++ b/src/components/MyPRs/MyPRs.tsx
@@ -1,8 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
-import { memo, type ReactElement, useCallback, useEffect, useMemo, useRef } from "react";
+import { memo, type ReactElement, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { FOCUS_RING } from "../../lib/a11y";
 import { listRepos } from "../../lib/tauri";
-import { FILTER_BUTTON_CLASS } from "../../lib/uiClasses";
+import { FILTER_BUTTON_CLASS, INLINE_CONTROL_CLASS } from "../../lib/uiClasses";
 import type { PullRequestWithReview } from "../../lib/types/dashboard";
 import { useFilterableList } from "../../hooks/useFilterableList";
 import { useRegisterNavigableItems } from "../../hooks/useRegisterNavigableItems";
@@ -45,10 +45,44 @@ function MyPRsImpl({
   const listRef = useRef<HTMLDivElement>(null);
   const { data: repos } = useQuery({ queryKey: ["repos"], queryFn: listRepos });
 
+  const [repoFilter, setRepoFilter] = useState("");
+  const [labelFilter, setLabelFilter] = useState<string | null>(null);
+
   const repoMap = useMemo<Map<string, string>>(() => {
     if (!repos) return new Map();
     return new Map(repos.map((repo) => [repo.id, repo.fullName]));
   }, [repos]);
+
+  const uniqueRepos = useMemo(() => {
+    const seen = new Set<string>();
+    const result: { id: string; fullName: string }[] = [];
+    for (const pr of prs) {
+      const id = pr.pullRequest.repoId;
+      if (!seen.has(id)) {
+        seen.add(id);
+        result.push({ id, fullName: repoMap.get(id) ?? id });
+      }
+    }
+    return result.sort((a, b) => a.fullName.localeCompare(b.fullName));
+  }, [prs, repoMap]);
+
+  const uniqueLabels = useMemo(() => {
+    const seen = new Set<string>();
+    for (const pr of prs) {
+      for (const label of pr.pullRequest.labels) {
+        seen.add(label);
+      }
+    }
+    return [...seen].sort();
+  }, [prs]);
+
+  const preFiltered = useMemo(() => {
+    return prs.filter((pr) => {
+      if (repoFilter !== "" && pr.pullRequest.repoId !== repoFilter) return false;
+      if (labelFilter !== null && !pr.pullRequest.labels.includes(labelFilter)) return false;
+      return true;
+    });
+  }, [prs, repoFilter, labelFilter]);
 
   const searchPredicate = useCallback(
     (pr: PullRequestWithReview, query: string): boolean => {
@@ -69,7 +103,7 @@ function MyPRsImpl({
     visibleItems: visible,
     tabCounts,
   } = useFilterableList<PullRequestWithReview, Tab>({
-    items: prs,
+    items: preFiltered,
     tabs: PR_TABS,
     defaultTab: "open",
     searchPredicate,
@@ -77,7 +111,7 @@ function MyPRsImpl({
 
   useEffect(() => {
     listRef.current?.scrollTo({ top: 0, behavior: "instant" });
-  }, [tab, normalizedQuery]);
+  }, [tab, normalizedQuery, repoFilter, labelFilter]);
 
   const navItems = useMemo(() => visible.map((pr) => ({ url: pr.pullRequest.url })), [visible]);
   useRegisterNavigableItems(navItems);
@@ -152,6 +186,40 @@ function MyPRsImpl({
               Merged {tabCounts.merged}
             </button>
           </div>
+
+          {uniqueRepos.length > 1 && (
+            <select
+              aria-label="Filter by repo"
+              value={repoFilter}
+              onChange={(e) => setRepoFilter(e.target.value)}
+              className={`cursor-pointer border border-border bg-surface text-foreground hover:border-foreground ${INLINE_CONTROL_CLASS}`}
+            >
+              <option value="">All repos</option>
+              {uniqueRepos.map((r) => (
+                <option key={r.id} value={r.id}>{r.fullName}</option>
+              ))}
+            </select>
+          )}
+
+          {uniqueLabels.length > 0 && (
+            <div className="flex flex-wrap gap-1" role="group" aria-label="Filter by label">
+              {uniqueLabels.map((label) => (
+                <button
+                  key={label}
+                  type="button"
+                  aria-pressed={labelFilter === label}
+                  onClick={() => setLabelFilter(labelFilter === label ? null : label)}
+                  className={`${FILTER_BUTTON_CLASS} ${
+                    labelFilter === label
+                      ? "bg-accent text-bg font-semibold hover:bg-accent/80"
+                      : "text-dim hover:bg-surface-hover hover:text-foreground"
+                  }`}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+          )}
 
           {visible.length === 0 ? (
             <EmptyState icon="↗" message="No pull requests to display" />

--- a/src/components/ReviewQueue/ReviewQueue.tsx
+++ b/src/components/ReviewQueue/ReviewQueue.tsx
@@ -1,6 +1,5 @@
 import { memo, type ReactElement, useEffect, useMemo } from "react";
-import { FOCUS_RING } from "../../lib/a11y";
-import { FILTER_BUTTON_CLASS } from "../../lib/uiClasses";
+import { FILTER_BUTTON_CLASS, INLINE_CONTROL_CLASS } from "../../lib/uiClasses";
 import type { Priority } from "../../lib/types/enums";
 import type { PullRequestWithReview } from "../../lib/types/dashboard";
 import { useRegisterNavigableItems } from "../../hooks/useRegisterNavigableItems";
@@ -38,7 +37,6 @@ const FOCUS_PRIORITIES: readonly Priority[] = ["critical", "high"];
 
 const PRIORITY_FILTERS: readonly PriorityFilter[] = ["all", "critical", "high", "medium", "low"];
 
-const INLINE_CONTROL_CLASS = `${FOCUS_RING} min-h-11 rounded px-3 text-xs transition-colors`;
 
 function sortByPriority(
   reviews: readonly PullRequestWithReview[],

--- a/src/lib/uiClasses.ts
+++ b/src/lib/uiClasses.ts
@@ -20,3 +20,10 @@ export const FILTER_BUTTON_CLASS =
  */
 export const ACTION_BUTTON_CLASS =
   `${FOCUS_RING} inline-flex min-h-11 items-center rounded px-3 text-xs transition-colors`;
+
+/**
+ * Inline control (e.g. native `<select>`) used alongside filter buttons in list
+ * headers (ReviewQueue, MyPRs, Issues).
+ */
+export const INLINE_CONTROL_CLASS =
+  `${FOCUS_RING} min-h-11 rounded px-3 text-xs transition-colors`;


### PR DESCRIPTION
## Summary

- Add repo dropdown filter to MyPRs and Issues — only shown when items span multiple repos
- Add label toggle buttons to MyPRs and Issues — only shown when items have labels
- All filters compose with existing tab and search filters (AND logic)
- Extract `INLINE_CONTROL_CLASS` to shared `uiClasses.ts` (previously local to ReviewQueue)
- Scroll resets when any filter changes

## Test plan

- [ ] Verify repo dropdown appears only when PRs/issues span 2+ repos
- [ ] Verify selecting a repo filters the list correctly
- [ ] Verify label buttons appear only when labels exist
- [ ] Verify clicking a label filters, clicking again deselects
- [ ] Verify all filters work together (repo + label + search + tab)
- [ ] Verify 651/651 tests pass (`npx vitest run`)
- [ ] Verify TypeScript compiles clean (`npx tsc --noEmit`)
- [ ] Verify oxlint passes (`npm run lint`)

Closes #196

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added repo and label filters to `MyPRs` and `Issues` to narrow lists faster, per Linear #196. Filters compose with tabs and search, and the list scrolls to top on filter changes.

- **New Features**
  - Repo dropdown, shown only when items span multiple repos.
  - Label toggle buttons, shown only when items have labels.

- **Bug Fixes**
  - Reset stale repo selection on sync; preserve the label filter if it’s still valid.
  - Label options reflect the current repo filter (fallback to all when repo is stale), and stale label selections are ignored during render to prevent transient mis-filtering.

<sup>Written for commit 0076681262886037e32adef0c2b207ea35394e7b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repository dropdown and label-toggle filters added to Issues and PR views (displayed only when applicable); filters combine with search and status tabs and update visible counts.

* **Tests**
  * Comprehensive coverage for conditional rendering, repo/label toggle behavior, multi-filter interactions, reset-on-data-change, and label-list scoping.

* **Style**
  * Unified inline control styling for consistent appearance across list headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->