### PR TITLE
fix(ui): resolve count inconsistencies between sidebar and overview headings

### DIFF
--- a/src/components/ActivityFeed/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed/ActivityFeed.test.tsx
@@ -200,6 +200,12 @@ describe("ActivityFeed", () => {
     expect(screen.getByText("6")).toBeInTheDocument();
   });
 
+  it("should hide section header when hideHeader is true", () => {
+    render(<ActivityFeed activities={allActivities} onMarkAllRead={onMarkAllRead} hideHeader />);
+
+    expect(screen.queryByText("Activity")).not.toBeInTheDocument();
+  });
+
   it("should keep filter buttons at the minimum touch target size", () => {
     render(<ActivityFeed activities={allActivities} onMarkAllRead={onMarkAllRead} />);
 

--- a/src/components/ActivityFeed/ActivityFeed.tsx
+++ b/src/components/ActivityFeed/ActivityFeed.tsx
@@ -14,6 +14,7 @@ interface ActivityFeedProps {
   readonly activities: readonly Activity[];
   readonly isLoading?: boolean;
   readonly onMarkAllRead: () => void;
+  readonly hideHeader?: boolean;
 }
 
 type FilterType = "all" | "comment" | "review" | "ci" | "mention" | "other";
@@ -57,6 +58,7 @@ export function ActivityFeed({
   activities,
   isLoading = false,
   onMarkAllRead,
+  hideHeader = false,
 }: ActivityFeedProps): ReactElement {
   const [filter, setFilter] = useState<FilterType>("all");
   const [searchQuery, setSearchQuery] = useState("");
@@ -84,7 +86,7 @@ export function ActivityFeed({
       aria-busy={isLoading ? "true" : undefined}
       className="flex flex-col gap-2"
     >
-      <SectionHead title="Activity" count={isLoading ? undefined : visible.length} />
+      {!hideHeader && <SectionHead title="Activity" count={isLoading ? undefined : visible.length} />}
 
       {isLoading ? (
         <>

--- a/src/components/Issues/Issues.test.tsx
+++ b/src/components/Issues/Issues.test.tsx
@@ -197,6 +197,12 @@ describe("Issues", () => {
     expect(screen.getByText("4")).toBeInTheDocument();
   });
 
+  it("should hide section header when hideHeader is true", () => {
+    render(<Issues issues={allIssues} onOpen={onOpen} hideHeader />);
+
+    expect(screen.queryByText("Issues")).not.toBeInTheDocument();
+  });
+
   it("should pass onOpen to IssueCard", async () => {
     const user = userEvent.setup();
     render(<Issues issues={[openIssue1]} onOpen={onOpen} />);

--- a/src/components/Issues/Issues.tsx
+++ b/src/components/Issues/Issues.tsx
@@ -17,6 +17,7 @@ interface IssuesProps {
   readonly isLoading?: boolean;
   readonly onOpen: (url: string) => void;
   readonly hideTabs?: boolean;
+  readonly hideHeader?: boolean;
 }
 
 type Tab = "open" | "closed";
@@ -26,7 +27,7 @@ const ISSUE_TABS: Readonly<Record<Tab, (issue: Issue) => boolean>> = {
   closed: (issue) => issue.state === "closed",
 };
 
-function IssuesImpl({ issues, isLoading = false, onOpen, hideTabs = false }: IssuesProps): ReactElement {
+function IssuesImpl({ issues, isLoading = false, onOpen, hideTabs = false, hideHeader = false }: IssuesProps): ReactElement {
   const parentRef = useRef<HTMLDivElement>(null);
   const { data: repos } = useQuery({ queryKey: ["repos"], queryFn: listRepos });
   const [repoFilter, setRepoFilter] = useState("");
@@ -143,7 +144,7 @@ function IssuesImpl({ issues, isLoading = false, onOpen, hideTabs = false }: Iss
       aria-busy={isLoading ? "true" : undefined}
       className="flex flex-col gap-2"
     >
-      <SectionHead title="Issues" count={isLoading ? undefined : matchingIssues.length} />
+      {!hideHeader && <SectionHead title="Issues" count={isLoading ? undefined : matchingIssues.length} />}
 
       {isLoading ? (
         <>

--- a/src/components/MyPRs/MyPRs.test.tsx
+++ b/src/components/MyPRs/MyPRs.test.tsx
@@ -203,6 +203,12 @@ describe("MyPRs", () => {
     expect(screen.getByText("5")).toBeInTheDocument();
   });
 
+  it("should hide section header when hideHeader is true", () => {
+    render(<MyPRs prs={allPrs} onOpen={onOpen} hideHeader />);
+
+    expect(screen.queryByText("My PRs")).not.toBeInTheDocument();
+  });
+
   it("should exclude closed PRs from total count", () => {
     const closedPr = makePr({ number: 6, title: "Closed PR", state: "closed" });
     render(<MyPRs prs={[openPr1, closedPr, mergedPr1]} onOpen={onOpen} />);

--- a/src/components/MyPRs/MyPRs.tsx
+++ b/src/components/MyPRs/MyPRs.tsx
@@ -24,6 +24,7 @@ interface MyPRsProps {
   readonly isLoading?: boolean;
   readonly onOpen: (url: string) => void;
   readonly onWorkspaceAction?: (params: WorkspaceActionParams) => void;
+  readonly hideHeader?: boolean;
 }
 
 type Tab = "open" | "merged";
@@ -41,6 +42,7 @@ function MyPRsImpl({
   isLoading = false,
   onOpen,
   onWorkspaceAction,
+  hideHeader = false,
 }: MyPRsProps): ReactElement {
   const listRef = useRef<HTMLDivElement>(null);
   const { data: repos } = useQuery({ queryKey: ["repos"], queryFn: listRepos });
@@ -154,10 +156,12 @@ function MyPRsImpl({
         because `PrState` includes "closed" — a state that is intentionally not
         surfaced in any tab and should not appear in the header total.
       */}
-      <SectionHead
-        title="My PRs"
-        count={isLoading ? undefined : tabCounts.open + tabCounts.merged}
-      />
+      {!hideHeader && (
+        <SectionHead
+          title="My PRs"
+          count={isLoading ? undefined : tabCounts.open + tabCounts.merged}
+        />
+      )}
 
       {isLoading ? (
         <>

--- a/src/components/Overview/Overview.test.tsx
+++ b/src/components/Overview/Overview.test.tsx
@@ -277,6 +277,64 @@ describe("Overview", () => {
     expect(screen.queryByTestId("overview-issues-view-all")).not.toBeInTheDocument();
   });
 
+  it("should show 'View all' button when reviews exceed limit", () => {
+    const reviews = Array.from({ length: 8 }, (_, i) => makePr(i + 1));
+    setupMock(makeDashboard({ reviewRequests: reviews }));
+
+    renderWithProviders(<Overview />);
+
+    expect(screen.getByTestId("overview-reviews-view-all")).toBeInTheDocument();
+    expect(screen.getByTestId("overview-reviews-view-all")).toHaveTextContent("View all 8 reviews");
+  });
+
+  it("should not show reviews 'View all' button when reviews fit within limit", () => {
+    const reviews = Array.from({ length: 3 }, (_, i) => makePr(i + 1));
+    setupMock(makeDashboard({ reviewRequests: reviews }));
+
+    renderWithProviders(<Overview />);
+
+    expect(screen.queryByTestId("overview-reviews-view-all")).not.toBeInTheDocument();
+  });
+
+  it("should show 'View all' button when PRs exceed limit", () => {
+    const prs = Array.from({ length: 8 }, (_, i) => makePr(i + 10));
+    setupMock(makeDashboard({ myPullRequests: prs }));
+
+    renderWithProviders(<Overview />);
+
+    expect(screen.getByTestId("overview-prs-view-all")).toBeInTheDocument();
+    expect(screen.getByTestId("overview-prs-view-all")).toHaveTextContent("View all 8 PRs");
+  });
+
+  it("should not show PRs 'View all' button when PRs fit within limit", () => {
+    const prs = Array.from({ length: 3 }, (_, i) => makePr(i + 10));
+    setupMock(makeDashboard({ myPullRequests: prs }));
+
+    renderWithProviders(<Overview />);
+
+    expect(screen.queryByTestId("overview-prs-view-all")).not.toBeInTheDocument();
+  });
+
+  it("should only show open PRs in overview and exclude merged from count", () => {
+    const openPrs = Array.from({ length: 3 }, (_, i) => makePr(i + 10));
+    const mergedPrs = Array.from({ length: 4 }, (_, i) => ({
+      ...makePr(i + 20),
+      pullRequest: { ...makePr(i + 20).pullRequest, state: "merged" as const },
+    }));
+    setupMock(makeDashboard({ myPullRequests: [...openPrs, ...mergedPrs] }));
+
+    renderWithProviders(<Overview />);
+
+    // Only 3 open PRs shown, merged excluded from preview
+    expect(screen.getByText("PR #10")).toBeInTheDocument();
+    expect(screen.getByText("PR #12")).toBeInTheDocument();
+    expect(screen.queryByText("PR #20")).not.toBeInTheDocument();
+    // "View all" hidden because openPrCount (3) <= MAX_PRS (5)
+    expect(screen.queryByTestId("overview-prs-view-all")).not.toBeInTheDocument();
+    // Badge shows correct open count
+    expect(screen.getByText("3 open")).toBeInTheDocument();
+  });
+
   it("should limit activity to 5 items", () => {
     const activities = Array.from({ length: 8 }, (_, i) => makeActivity(i + 1));
     setupMock(makeDashboard({ recentActivity: activities }));

--- a/src/components/Overview/Overview.tsx
+++ b/src/components/Overview/Overview.tsx
@@ -95,14 +95,15 @@ export function Overview(): ReactElement {
   const recentActivity = dashboard?.recentActivity ?? [];
 
   const reviews = reviewRequests.slice(0, MAX_REVIEWS);
-  const prs = myPullRequests.slice(0, MAX_PRS);
+  const openPrs = myPullRequests.filter(
+    (pr) => pr.pullRequest.state === "open" || pr.pullRequest.state === "draft",
+  );
+  const prs = openPrs.slice(0, MAX_PRS);
+  const openPrCount = openPrs.length;
   const openIssues = assignedIssues.filter((i) => i.state === "open");
   const issues = openIssues.slice(0, MAX_ISSUES);
   const openIssueCount = openIssues.length;
   const activities = recentActivity.slice(0, MAX_ACTIVITIES);
-  const openPrCount = myPullRequests.filter(
-    (pr) => pr.pullRequest.state === "open" || pr.pullRequest.state === "draft",
-  ).length;
   const unreadActivityCount = recentActivity.filter((activity) => !activity.isRead).length;
 
   return (
@@ -145,7 +146,19 @@ export function Overview(): ReactElement {
             isLoading={showLoadingState}
             onOpen={openUrl}
             onWorkspaceAction={handleWorkspaceAction}
+            hideHeader
           />
+
+          {!showLoadingState && reviewRequests.length > MAX_REVIEWS ? (
+            <button
+              type="button"
+              data-testid="overview-reviews-view-all"
+              onClick={() => useDashboardStore.getState().setView("reviews")}
+              className={`${FOCUS_RING} mt-3 w-full rounded-lg border border-border px-3 py-2 text-center text-xs text-dim transition-colors hover:border-foreground hover:text-foreground`}
+            >
+              View all {reviewRequests.length} reviews
+            </button>
+          ) : null}
         </div>
 
         <div data-testid="overview-secondary-grid" className="grid min-w-0 gap-6 lg:grid-cols-2">
@@ -169,7 +182,19 @@ export function Overview(): ReactElement {
               isLoading={showLoadingState}
               onOpen={openUrl}
               onWorkspaceAction={handleWorkspaceAction}
+              hideHeader
             />
+
+            {!showLoadingState && openPrCount > MAX_PRS ? (
+              <button
+                type="button"
+                data-testid="overview-prs-view-all"
+                onClick={() => useDashboardStore.getState().setView("mine")}
+                className={`${FOCUS_RING} mt-3 w-full rounded-lg border border-border px-3 py-2 text-center text-xs text-dim transition-colors hover:border-foreground hover:text-foreground`}
+              >
+                View all {openPrCount} PRs
+              </button>
+            ) : null}
           </div>
 
           <div className="rounded-2xl border border-border bg-surface/70 px-4 py-4">
@@ -187,7 +212,7 @@ export function Overview(): ReactElement {
               </span>
             </div>
 
-            <Issues issues={issues} isLoading={showLoadingState} onOpen={openUrl} hideTabs />
+            <Issues issues={issues} isLoading={showLoadingState} onOpen={openUrl} hideTabs hideHeader />
 
             {!showLoadingState && openIssueCount > MAX_ISSUES ? (
               <button
@@ -241,6 +266,7 @@ export function Overview(): ReactElement {
               activities={activities}
               isLoading={showLoadingState}
               onMarkAllRead={() => markAllRead.mutate()}
+              hideHeader
             />
           </div>
         ) : null}

--- a/src/components/ReviewQueue/ReviewQueue.test.tsx
+++ b/src/components/ReviewQueue/ReviewQueue.test.tsx
@@ -148,6 +148,13 @@ describe("ReviewQueue", () => {
     expect(screen.getByText("4")).toBeInTheDocument();
   });
 
+  it("should hide section header when hideHeader is true", () => {
+    render(<ReviewQueue reviews={allReviews} onOpen={vi.fn()} hideHeader />);
+
+    expect(screen.queryByText("Reviews")).not.toBeInTheDocument();
+    expect(screen.getAllByRole("link")).toHaveLength(4);
+  });
+
   it("should show all PRs when 'all' filter is selected", async () => {
     const user = userEvent.setup();
     render(<ReviewQueue reviews={allReviews} onOpen={vi.fn()} />);

--- a/src/components/ReviewQueue/ReviewQueue.tsx
+++ b/src/components/ReviewQueue/ReviewQueue.tsx
@@ -22,6 +22,7 @@ interface ReviewQueueProps {
   readonly isLoading?: boolean;
   readonly onOpen: (url: string) => void;
   readonly onWorkspaceAction?: (params: WorkspaceActionParams) => void;
+  readonly hideHeader?: boolean;
 }
 
 const PRIORITY_ORDER: Record<Priority, number> = {
@@ -57,6 +58,7 @@ function ReviewQueueImpl({
   isLoading = false,
   onOpen,
   onWorkspaceAction,
+  hideHeader = false,
 }: ReviewQueueProps): ReactElement {
   const storePriority = useDashboardStore((s) => s.activeFilters.priority);
   const storeRepo = useDashboardStore((s) => s.activeFilters.repo);
@@ -102,7 +104,7 @@ function ReviewQueueImpl({
       aria-busy={isLoading ? "true" : undefined}
       className="flex flex-col gap-2"
     >
-      <SectionHead title="Reviews" count={isLoading ? undefined : sorted.length} />
+      {!hideHeader && <SectionHead title="Reviews" count={isLoading ? undefined : sorted.length} />}
 
       {isLoading ? (
         <>


### PR DESCRIPTION
## Summary

Fixes #244 — count inconsistencies between sidebar badges, stats bar, and Overview section headings.

- Sub-components (ReviewQueue, MyPRs, Issues, ActivityFeed) rendered their own `SectionHead` with counts from **sliced** preview arrays when embedded in Overview, conflicting with Overview's correct badges and the sidebar stats
- PRs in Overview were sliced from all states but the badge counted only open+draft, causing mismatches
- No "View all" drill-down existed for Reviews and My PRs sections

## Changes

- Add `hideHeader` prop to ReviewQueue, MyPRs, Issues, and ActivityFeed — suppresses `SectionHead` when embedded in Overview (which has its own card headers with correct counts)
- Fix PR filtering in Overview: filter to open+draft **before** slicing (aligning with the Issues pattern)
- Add "View all N reviews" and "View all N PRs" buttons in Overview when items exceed the 5-item preview limit
- Add tests: `hideHeader` behavior for all 4 components, View All button visibility, mixed-state PR edge case

## Test plan

- [x] `npx tsc --noEmit` — passes
- [x] `npm run lint` — 0 warnings, 0 errors
- [x] `npx vitest run` — 667 tests pass, 0 failures
- [x] Adversarial code review: R1 logic bug found and fixed (filter-then-slice for PRs)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inconsistent counts between the sidebar badges and Overview cards by suppressing duplicate headers and aligning PR filtering. Adds “View all” actions for Reviews and My PRs when items exceed the preview limit.

- **Bug Fixes**
  - Added `hideHeader` to `ReviewQueue`, `MyPRs`, `Issues`, and `ActivityFeed`; Overview now hides sub-headers to avoid mismatched counts.
  - Filtered My PRs to `open` + `draft` before slicing so Overview counts match the sidebar and badges.

- **New Features**
  - Added “View all N reviews” and “View all N PRs” buttons in Overview when more than 5 items are available.

<sup>Written for commit 39bc3a77998f8e1a922406af9c2fcce27bf09e99. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional header visibility control across dashboard components for flexible layout customization.
  * Added "View all" buttons in the overview to navigate to full lists when reviews or pull requests exceed display limits.
  * Overview now displays only open and draft pull requests, excluding merged ones.

* **Tests**
  * Extended test coverage for conditional header visibility and view-all button behavior across components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->