### PR TITLE
fix(ui): truncate label filters with Show More toggle

### DIFF
--- a/src/components/Issues/Issues.test.tsx
+++ b/src/components/Issues/Issues.test.tsx
@@ -545,7 +545,14 @@ describe("Issues", () => {
 
     // label-10 should still be visible even though list is collapsed
     const group = screen.getByRole("group", { name: /filter by label/i });
+    const visibleLabelButtons = within(group)
+      .getAllByRole("button")
+      .filter((button) => /^label-/.test(button.textContent ?? ""));
+
+    expect(visibleLabelButtons).toHaveLength(LABEL_VISIBLE_LIMIT);
     expect(within(group).getByRole("button", { name: "label-10" })).toBeInTheDocument();
+    expect(within(group).queryByRole("button", { name: "label-08" })).not.toBeInTheDocument();
+    expect(screen.getByTestId("label-filter-toggle")).toHaveTextContent("+4 more");
     expect(screen.getByRole("button", { name: "label-10" })).toHaveAttribute("aria-pressed", "true");
   });
 

--- a/src/components/Issues/Issues.test.tsx
+++ b/src/components/Issues/Issues.test.tsx
@@ -3,7 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { FOCUS_RING } from "../../lib/a11y";
 import type { Issue, Repo } from "../../lib/types/github";
-import { Issues } from "./Issues";
+import { Issues, LABEL_VISIBLE_LIMIT } from "./Issues";
 
 vi.mock("@tanstack/react-virtual", () => ({
   useVirtualizer: (opts: { count: number; estimateSize: (i: number) => number }) => ({
@@ -59,6 +59,10 @@ function makeIssue(overrides: Partial<Issue> = {}): Issue {
     updatedAt: "2026-03-26T12:00:00Z",
     ...overrides,
   };
+}
+
+function makeLabels(count: number): string[] {
+  return Array.from({ length: count }, (_, i) => `label-${String(i + 1).padStart(2, "0")}`);
 }
 
 const openIssue1 = makeIssue({ number: 1, title: "Open issue one", state: "open" });
@@ -428,6 +432,121 @@ describe("Issues", () => {
     await userEvent.selectOptions(screen.getByRole("combobox", { name: /filter by repo/i }), "repo-1");
     expect(within(labelGroup).getByRole("button", { name: "bug" })).toBeInTheDocument();
     expect(within(labelGroup).queryByRole("button", { name: "feature" })).not.toBeInTheDocument();
+  });
+
+  it("should only show LABEL_VISIBLE_LIMIT labels when more exist", () => {
+    const labels = makeLabels(12);
+    const issue = makeIssue({ number: 10, title: "Many labels issue", state: "open", labels });
+
+    render(<Issues issues={[issue]} onOpen={onOpen} />);
+
+    const group = screen.getByRole("group", { name: /filter by label/i });
+
+    for (let i = 1; i <= 8; i++) {
+      expect(within(group).getByRole("button", { name: `label-${String(i).padStart(2, "0")}` })).toBeInTheDocument();
+    }
+    for (let i = 9; i <= 12; i++) {
+      expect(within(group).queryByRole("button", { name: `label-${String(i).padStart(2, "0")}` })).not.toBeInTheDocument();
+    }
+    expect(screen.getByTestId("label-filter-toggle")).toHaveTextContent("+4 more");
+  });
+
+  it("should show all labels when toggle is clicked", async () => {
+    const user = userEvent.setup();
+    const labels = makeLabels(12);
+    const issue = makeIssue({ number: 10, title: "Many labels issue", state: "open", labels });
+
+    render(<Issues issues={[issue]} onOpen={onOpen} />);
+
+    const toggle = screen.getByTestId("label-filter-toggle");
+    await user.click(toggle);
+
+    const group = screen.getByRole("group", { name: /filter by label/i });
+    for (let i = 1; i <= 12; i++) {
+      expect(within(group).getByRole("button", { name: `label-${String(i).padStart(2, "0")}` })).toBeInTheDocument();
+    }
+    expect(toggle).toHaveTextContent("Show less");
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("should collapse labels when Show less is clicked", async () => {
+    const user = userEvent.setup();
+    const labels = makeLabels(12);
+    const issue = makeIssue({ number: 10, title: "Many labels issue", state: "open", labels });
+
+    render(<Issues issues={[issue]} onOpen={onOpen} />);
+
+    const toggle = screen.getByTestId("label-filter-toggle");
+    await user.click(toggle);
+    await user.click(toggle);
+
+    const group = screen.getByRole("group", { name: /filter by label/i });
+    for (let i = 1; i <= 8; i++) {
+      expect(within(group).getByRole("button", { name: `label-${String(i).padStart(2, "0")}` })).toBeInTheDocument();
+    }
+    for (let i = 9; i <= 12; i++) {
+      expect(within(group).queryByRole("button", { name: `label-${String(i).padStart(2, "0")}` })).not.toBeInTheDocument();
+    }
+    expect(toggle).toHaveTextContent("+4 more");
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("should not show toggle when labels are within limit", () => {
+    const labels = makeLabels(LABEL_VISIBLE_LIMIT);
+    const issue = makeIssue({ number: 10, title: "Exact limit issue", state: "open", labels });
+
+    render(<Issues issues={[issue]} onOpen={onOpen} />);
+
+    const group = screen.getByRole("group", { name: /filter by label/i });
+    for (let i = 1; i <= LABEL_VISIBLE_LIMIT; i++) {
+      expect(within(group).getByRole("button", { name: `label-${String(i).padStart(2, "0")}` })).toBeInTheDocument();
+    }
+    expect(screen.queryByTestId("label-filter-toggle")).toBeNull();
+  });
+
+  it("should reset label expansion when repo filter changes", async () => {
+    const user = userEvent.setup();
+    const labels1 = makeLabels(12);
+    const labels2 = makeLabels(10).map((l) => `repo2-${l}`);
+    const issue1 = makeIssue({ number: 1, title: "Repo1 issue", state: "open", repoId: "repo-1", labels: labels1 });
+    const issue2 = makeIssue({ number: 2, title: "Repo2 issue", state: "open", repoId: "repo-2", labels: labels2 });
+    mockUseQuery.mockReturnValue({
+      data: [
+        makeRepo(),
+        makeRepo({ id: "repo-2", org: "acme", name: "console", fullName: "acme/console" }),
+      ],
+    });
+
+    render(<Issues issues={[issue1, issue2]} onOpen={onOpen} />);
+
+    const toggle = screen.getByTestId("label-filter-toggle");
+    await user.click(toggle);
+    expect(toggle).toHaveTextContent("Show less");
+
+    const select = screen.getByRole("combobox", { name: /filter by repo/i });
+    await userEvent.selectOptions(select, "repo-2");
+
+    const newToggle = screen.getByTestId("label-filter-toggle");
+    expect(newToggle).not.toHaveTextContent("Show less");
+    expect(newToggle).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("should keep selected label visible when collapsed beyond limit", async () => {
+    const user = userEvent.setup();
+    const labels = makeLabels(12);
+    const issue = makeIssue({ number: 1, title: "Many labels", state: "open", labels });
+
+    render(<Issues issues={[issue]} onOpen={onOpen} />);
+
+    // Expand, select label-10 (beyond LABEL_VISIBLE_LIMIT), then collapse
+    await user.click(screen.getByTestId("label-filter-toggle"));
+    await user.click(screen.getByRole("button", { name: "label-10" }));
+    await user.click(screen.getByTestId("label-filter-toggle"));
+
+    // label-10 should still be visible even though list is collapsed
+    const group = screen.getByRole("group", { name: /filter by label/i });
+    expect(within(group).getByRole("button", { name: "label-10" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "label-10" })).toHaveAttribute("aria-pressed", "true");
   });
 
 });

--- a/src/components/Issues/Issues.tsx
+++ b/src/components/Issues/Issues.tsx
@@ -74,15 +74,15 @@ function IssuesImpl({ issues, isLoading = false, onOpen, hideTabs = false, hideH
     return [...seen].sort();
   }, [repoFiltered]);
 
-  const hasOverflowLabels = uniqueLabels.length > LABEL_VISIBLE_LIMIT;
   const visibleLabels = useMemo(() => {
     if (showAllLabels) return uniqueLabels;
     const sliced = uniqueLabels.slice(0, LABEL_VISIBLE_LIMIT);
     if (labelFilter !== null && !sliced.includes(labelFilter) && uniqueLabels.includes(labelFilter)) {
-      return [...sliced, labelFilter];
+      return [...sliced.slice(0, -1), labelFilter];
     }
     return sliced;
   }, [uniqueLabels, showAllLabels, labelFilter]);
+  const hiddenLabelsCount = uniqueLabels.length - visibleLabels.length;
 
   // Reset stale filters when available options shrink
   useEffect(() => {
@@ -251,7 +251,7 @@ function IssuesImpl({ issues, isLoading = false, onOpen, hideTabs = false, hideH
                       {label}
                     </button>
                   ))}
-                  {hasOverflowLabels && (
+                  {(showAllLabels || hiddenLabelsCount > 0) && (
                     <button
                       type="button"
                       aria-expanded={showAllLabels}
@@ -259,7 +259,7 @@ function IssuesImpl({ issues, isLoading = false, onOpen, hideTabs = false, hideH
                       onClick={() => setShowAllLabels(!showAllLabels)}
                       className={`${FILTER_BUTTON_CLASS} text-dim hover:bg-surface-hover hover:text-foreground`}
                     >
-                      {showAllLabels ? "Show less" : `+${uniqueLabels.length - LABEL_VISIBLE_LIMIT} more`}
+                      {showAllLabels ? "Show less" : `+${hiddenLabelsCount} more`}
                     </button>
                   )}
                 </div>

--- a/src/components/Issues/Issues.tsx
+++ b/src/components/Issues/Issues.tsx
@@ -27,11 +27,14 @@ const ISSUE_TABS: Readonly<Record<Tab, (issue: Issue) => boolean>> = {
   closed: (issue) => issue.state === "closed",
 };
 
+export const LABEL_VISIBLE_LIMIT = 8;
+
 function IssuesImpl({ issues, isLoading = false, onOpen, hideTabs = false, hideHeader = false }: IssuesProps): ReactElement {
   const parentRef = useRef<HTMLDivElement>(null);
   const { data: repos } = useQuery({ queryKey: ["repos"], queryFn: listRepos });
   const [repoFilter, setRepoFilter] = useState("");
   const [labelFilter, setLabelFilter] = useState<string | null>(null);
+  const [showAllLabels, setShowAllLabels] = useState(false);
 
   const repoMap = useMemo<Map<string, string>>(() => {
     if (!repos) return new Map();
@@ -71,6 +74,16 @@ function IssuesImpl({ issues, isLoading = false, onOpen, hideTabs = false, hideH
     return [...seen].sort();
   }, [repoFiltered]);
 
+  const hasOverflowLabels = uniqueLabels.length > LABEL_VISIBLE_LIMIT;
+  const visibleLabels = useMemo(() => {
+    if (showAllLabels) return uniqueLabels;
+    const sliced = uniqueLabels.slice(0, LABEL_VISIBLE_LIMIT);
+    if (labelFilter !== null && !sliced.includes(labelFilter) && uniqueLabels.includes(labelFilter)) {
+      return [...sliced, labelFilter];
+    }
+    return sliced;
+  }, [uniqueLabels, showAllLabels, labelFilter]);
+
   // Reset stale filters when available options shrink
   useEffect(() => {
     if (repoFilter !== "" && !uniqueRepos.some((r) => r.id === repoFilter)) {
@@ -83,6 +96,10 @@ function IssuesImpl({ issues, isLoading = false, onOpen, hideTabs = false, hideH
       setLabelFilter(null);
     }
   }, [uniqueLabels, labelFilter]);
+
+  useEffect(() => {
+    setShowAllLabels(false);
+  }, [repoFilter]);
 
   const isLabelFilterValid =
     labelFilter === null || uniqueLabels.includes(labelFilter);
@@ -219,7 +236,7 @@ function IssuesImpl({ issues, isLoading = false, onOpen, hideTabs = false, hideH
 
               {uniqueLabels.length > 0 && (
                 <div className="flex flex-wrap gap-1" role="group" aria-label="Filter by label">
-                  {uniqueLabels.map((label) => (
+                  {visibleLabels.map((label) => (
                     <button
                       key={label}
                       type="button"
@@ -234,6 +251,17 @@ function IssuesImpl({ issues, isLoading = false, onOpen, hideTabs = false, hideH
                       {label}
                     </button>
                   ))}
+                  {hasOverflowLabels && (
+                    <button
+                      type="button"
+                      aria-expanded={showAllLabels}
+                      data-testid="label-filter-toggle"
+                      onClick={() => setShowAllLabels(!showAllLabels)}
+                      className={`${FILTER_BUTTON_CLASS} text-dim hover:bg-surface-hover hover:text-foreground`}
+                    >
+                      {showAllLabels ? "Show less" : `+${uniqueLabels.length - LABEL_VISIBLE_LIMIT} more`}
+                    </button>
+                  )}
                 </div>
               )}
             </>


### PR DESCRIPTION
## Summary
- Label filter buttons in the Issues view now display at most 8 labels by default, with a "+N more" / "Show less" toggle button
- The actively selected label always stays visible even when the list is collapsed (prevents invisible active filter bug)
- Label expansion resets when the repo filter changes
- Adds `aria-expanded` on the toggle button for accessibility

## Changes
- `src/components/Issues/Issues.tsx` — Added `LABEL_VISIBLE_LIMIT = 8`, `showAllLabels` state, `visibleLabels` memoized computation that keeps the selected label visible, toggle button with ARIA attributes
- `src/components/Issues/Issues.test.tsx` — 6 new tests covering overflow truncation, expand/collapse, reset on repo change, and selected-label-beyond-limit edge case

## Test plan
- [x] 31/31 Issues tests pass (6 new)
- [x] 672/672 full suite pass — no regressions
- [x] TypeScript compilation clean
- [x] oxlint 0 warnings/errors
- [ ] Manual: verify labels truncate at 8 in Issues view with many labels
- [ ] Manual: verify "+N more" expands and "Show less" collapses
- [ ] Manual: verify selected label stays visible after collapse

Closes #245

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Truncates label filters in Issues to show at most 8 by default, with a "+N more" / "Show less" toggle. The selected label stays visible when collapsed and accessibility is improved.

- **Bug Fixes**
  - Fixes #245: prevents label overflow and ensures the active label remains visible when collapsed.
  - Resets label expansion when the repo filter changes and hides the toggle when labels are within `LABEL_VISIBLE_LIMIT`.
  - Adds `aria-expanded` to the toggle and tests for truncation, expand/collapse, reset, and the no-toggle-at-limit case.

<sup>Written for commit 672cd3a8a4df49e7d34fe4c5b6b7415c5c29f32a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expandable label filters that initially show a limited set with a "+N more" toggle and switch to "Show less" when expanded.
  * Toggle is hidden when label count fits the initial view.
  * Expansion state resets when switching repositories.
  * Selected labels outside the initial view remain visible and active when collapsed.

* **Tests**
  * Added tests covering all label toggle and repo-switch interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->