### PR TITLE
fix(a11y): add DialogTitle to Command Palette

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@fontsource/ibm-plex-mono": "^5.2.7",
         "@fontsource/ibm-plex-sans": "^5.2.8",
+        "@radix-ui/react-dialog": "^1.1.15",
         "@tanstack/react-query": "^5.95.2",
         "@tanstack/react-virtual": "^3.13.23",
         "@tauri-apps/api": "^2.10.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@fontsource/ibm-plex-mono": "^5.2.7",
     "@fontsource/ibm-plex-sans": "^5.2.8",
+    "@radix-ui/react-dialog": "^1.1.15",
     "@tanstack/react-query": "^5.95.2",
     "@tanstack/react-virtual": "^3.13.23",
     "@tauri-apps/api": "^2.10.1",

--- a/src/components/CommandPalette/CommandPalette.test.tsx
+++ b/src/components/CommandPalette/CommandPalette.test.tsx
@@ -155,6 +155,12 @@ describe("CommandPalette", () => {
     expect(screen.getByPlaceholderText(/search/i)).toBeInTheDocument();
   });
 
+  it("should render a visually hidden dialog title for accessibility", () => {
+    renderPalette({ open: true, onOpenChange: () => {} });
+
+    expect(screen.getByRole("heading", { name: "Command palette" })).toHaveClass("sr-only");
+  });
+
   it("should close on Esc", async () => {
     const user = userEvent.setup();
     const onOpenChange = vi.fn();

--- a/src/components/CommandPalette/CommandPalette.tsx
+++ b/src/components/CommandPalette/CommandPalette.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState, type ReactElement } from "react";
 import { Command } from "cmdk";
+import { DialogTitle } from "@radix-ui/react-dialog";
 import { useQuery } from "@tanstack/react-query";
 import { useGitHubData } from "../../hooks/useGitHubData";
 import { FOCUS_RING } from "../../lib/a11y";
@@ -166,6 +167,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
       value={selectedValue}
       onValueChange={setSelectedValue}
     >
+      <DialogTitle className="sr-only">Command palette</DialogTitle>
       <div className="w-full max-w-lg rounded-lg border border-border bg-bg shadow-xl">
         <Command.Input
           placeholder="Search PRs, issues, and actions…"


### PR DESCRIPTION
## Summary
- add a hidden `DialogTitle` inside the command palette dialog to satisfy Radix accessibility requirements
- cover the accessible title with a targeted component test
- declare `@radix-ui/react-dialog` as a direct dependency because it is now imported directly

## Validation
- `npm run test -- src/components/CommandPalette/CommandPalette.test.tsx`
- `npm run build`

Closes #246

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a visually hidden `DialogTitle` to the Command Palette to meet Radix dialog accessibility and improve screen reader support. Include a component test for the title and declare `@radix-ui/react-dialog` as a direct dependency.

<sup>Written for commit 278677eb920dd6e031a425cdc46cf7173acd19d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced Command Palette accessibility with proper dialog title for screen readers and assistive technologies.

* **Tests**
  * Added accessibility test to verify proper dialog structure and semantic markup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->