### PR TITLE
fix(a11y): show visible keyboard selection in dashboard lists

### DIFF
--- a/src/components/Issues/IssueCard.test.tsx
+++ b/src/components/Issues/IssueCard.test.tsx
@@ -33,7 +33,13 @@ describe("IssueCard", () => {
     render(<IssueCard issue={makeIssue()} repoName="repo-name" onOpen={vi.fn()} isSelected />);
     const card = screen.getByTestId("issue-card");
     expect(card).toHaveAttribute("data-selected", "true");
+    expect(card).toHaveAttribute("aria-current", "true");
     expect(card).toHaveClass("border-accent", "ring-2", "ring-accent");
+  });
+
+  it("should not set aria-current when not selected", () => {
+    render(<IssueCard issue={makeIssue()} repoName="repo-name" onOpen={vi.fn()} />);
+    expect(screen.getByTestId("issue-card")).not.toHaveAttribute("aria-current");
   });
 
   it("should render issue with labels", () => {

--- a/src/components/Issues/IssueCard.test.tsx
+++ b/src/components/Issues/IssueCard.test.tsx
@@ -29,6 +29,13 @@ describe("IssueCard", () => {
     expect(screen.getByText("#42")).toBeInTheDocument();
   });
 
+  it("should show selected styling when keyboard-selected", () => {
+    render(<IssueCard issue={makeIssue()} repoName="repo-name" onOpen={vi.fn()} isSelected />);
+    const card = screen.getByTestId("issue-card");
+    expect(card).toHaveAttribute("data-selected", "true");
+    expect(card).toHaveClass("border-accent", "ring-2", "ring-accent");
+  });
+
   it("should render issue with labels", () => {
     render(
       <IssueCard
@@ -43,7 +50,9 @@ describe("IssueCard", () => {
   });
 
   it("should show green dot for open issues", () => {
-    render(<IssueCard issue={makeIssue({ state: "open" })} repoName="repo-name" onOpen={vi.fn()} />);
+    render(
+      <IssueCard issue={makeIssue({ state: "open" })} repoName="repo-name" onOpen={vi.fn()} />,
+    );
 
     const dot = screen.getByTestId("issue-state-dot");
     expect(dot.className).toContain("bg-green");
@@ -80,9 +89,7 @@ describe("IssueCard", () => {
 
     await user.click(screen.getByText("Fix login bug"));
 
-    expect(onOpen).toHaveBeenCalledWith(
-      "https://github.com/org/repo/issues/42",
-    );
+    expect(onOpen).toHaveBeenCalledWith("https://github.com/org/repo/issues/42");
   });
 
   it("should have aria-label on link describing the issue", () => {

--- a/src/components/Issues/IssueCard.tsx
+++ b/src/components/Issues/IssueCard.tsx
@@ -1,6 +1,7 @@
 import type { MouseEvent, ReactElement } from "react";
 import { FOCUS_RING } from "../../lib/a11y";
 import { timeAgo } from "../../lib/timeAgo";
+import { SELECTED_ITEM_CLASS } from "../../lib/uiClasses";
 import type { Issue } from "../../lib/types/github";
 import type { IssueState } from "../../lib/types/enums";
 import { Tag } from "../atoms";
@@ -9,6 +10,7 @@ interface IssueCardProps {
   readonly issue: Issue;
   readonly repoName: string;
   readonly onOpen: (url: string) => void;
+  readonly isSelected?: boolean;
 }
 
 const STATE_DOT_COLOR: Record<IssueState, string> = {
@@ -16,7 +18,12 @@ const STATE_DOT_COLOR: Record<IssueState, string> = {
   closed: "bg-purple",
 };
 
-export function IssueCard({ issue, repoName, onOpen }: IssueCardProps): ReactElement {
+export function IssueCard({
+  issue,
+  repoName,
+  onOpen,
+  isSelected = false,
+}: IssueCardProps): ReactElement {
   function handleClick(e: MouseEvent) {
     e.preventDefault();
     onOpen(issue.url);
@@ -25,10 +32,13 @@ export function IssueCard({ issue, repoName, onOpen }: IssueCardProps): ReactEle
   return (
     <a
       data-testid="issue-card"
+      data-selected={isSelected ? "true" : undefined}
       href={issue.url}
       onClick={handleClick}
       aria-label={`Issue #${issue.number}: ${issue.title} (${issue.state})`}
-      className={`${FOCUS_RING} group/card flex min-w-0 cursor-pointer flex-col gap-1 rounded border border-border px-3 py-2 no-underline hover:bg-surface-hover`}
+      className={`${FOCUS_RING} group/card flex min-w-0 cursor-pointer flex-col gap-1 rounded border border-border px-3 py-2 no-underline hover:bg-surface-hover${
+        isSelected ? ` ${SELECTED_ITEM_CLASS}` : ""
+      }`}
     >
       <div className="flex min-w-0 items-center gap-2">
         <span

--- a/src/components/Issues/IssueCard.tsx
+++ b/src/components/Issues/IssueCard.tsx
@@ -33,6 +33,7 @@ export function IssueCard({
     <a
       data-testid="issue-card"
       data-selected={isSelected ? "true" : undefined}
+      aria-current={isSelected ? "true" : undefined}
       href={issue.url}
       onClick={handleClick}
       aria-label={`Issue #${issue.number}: ${issue.title} (${issue.state})`}

--- a/src/components/Issues/Issues.memo.test.tsx
+++ b/src/components/Issues/Issues.memo.test.tsx
@@ -31,6 +31,11 @@ vi.mock("@tanstack/react-query", async () => {
   };
 });
 
+// Memoization tests should isolate child renders from dashboard registration side effects.
+vi.mock("../../hooks/useRegisterNavigableItems", () => ({
+  useRegisterNavigableItems: vi.fn(),
+}));
+
 // Replace IssueCard with a light stub that counts render calls.
 vi.mock("./IssueCard", () => ({
   IssueCard: (props: Record<string, unknown>) => {

--- a/src/components/Issues/Issues.test.tsx
+++ b/src/components/Issues/Issues.test.tsx
@@ -1,9 +1,12 @@
-import { render, screen, within } from "@testing-library/react";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { FOCUS_RING } from "../../lib/a11y";
 import type { Issue, Repo } from "../../lib/types/github";
+import { useDashboardStore } from "../../stores/dashboard";
 import { Issues, LABEL_VISIBLE_LIMIT } from "./Issues";
+
+const { mockScrollToIndex } = vi.hoisted(() => ({ mockScrollToIndex: vi.fn() }));
 
 vi.mock("@tanstack/react-virtual", () => ({
   useVirtualizer: (opts: { count: number; estimateSize: (i: number) => number }) => ({
@@ -15,6 +18,7 @@ vi.mock("@tanstack/react-virtual", () => ({
         size: opts.estimateSize(i),
       })),
     getTotalSize: () => opts.count * opts.estimateSize(0),
+    scrollToIndex: mockScrollToIndex,
   }),
 }));
 
@@ -77,6 +81,13 @@ const onOpen = vi.fn();
 beforeEach(() => {
   onOpen.mockClear();
   mockUseQuery.mockReturnValue({ data: [makeRepo()] });
+  mockScrollToIndex.mockReset();
+  useDashboardStore.setState({
+    activeNavigableSection: null,
+    navigableSectionRegistrations: [],
+    selectedIndex: -1,
+    navigableItems: [],
+  });
 });
 
 describe("Issues", () => {
@@ -107,6 +118,21 @@ describe("Issues", () => {
     expect(screen.getByText("Closed issue two")).toBeInTheDocument();
     expect(screen.queryByText("Open issue one")).not.toBeInTheDocument();
     expect(screen.queryByText("Open issue two")).not.toBeInTheDocument();
+  });
+
+  it("should scroll the virtualizer to the selected issue during keyboard navigation", () => {
+    render(<Issues issues={allIssues} onOpen={onOpen} />);
+
+    act(() => {
+      useDashboardStore.setState({
+        activeNavigableSection: "issues",
+        selectedIndex: 1,
+      });
+    });
+
+    return waitFor(() => {
+      expect(mockScrollToIndex).toHaveBeenCalledWith(1, { align: "auto" });
+    });
   });
 
   it("should show correct counts in tabs", () => {
@@ -262,8 +288,18 @@ describe("Issues", () => {
   });
 
   it("should show repo dropdown when multiple repos exist", () => {
-    const issue1 = makeIssue({ number: 1, title: "Issue in repo 1", state: "open", repoId: "repo-1" });
-    const issue2 = makeIssue({ number: 2, title: "Issue in repo 2", state: "open", repoId: "repo-2" });
+    const issue1 = makeIssue({
+      number: 1,
+      title: "Issue in repo 1",
+      state: "open",
+      repoId: "repo-1",
+    });
+    const issue2 = makeIssue({
+      number: 2,
+      title: "Issue in repo 2",
+      state: "open",
+      repoId: "repo-2",
+    });
     mockUseQuery.mockReturnValue({
       data: [
         makeRepo(),
@@ -306,7 +342,12 @@ describe("Issues", () => {
   });
 
   it("should show label filter buttons when labels exist", () => {
-    const labeledIssue = makeIssue({ number: 5, title: "Bug issue", state: "open", labels: ["bug", "help wanted"] });
+    const labeledIssue = makeIssue({
+      number: 5,
+      title: "Bug issue",
+      state: "open",
+      labels: ["bug", "help wanted"],
+    });
 
     render(<Issues issues={[labeledIssue]} onOpen={onOpen} />);
 
@@ -325,7 +366,12 @@ describe("Issues", () => {
   it("should filter issues by selected label", async () => {
     const user = userEvent.setup();
     const bugIssue = makeIssue({ number: 1, title: "Bug issue", state: "open", labels: ["bug"] });
-    const featureIssue = makeIssue({ number: 2, title: "Feature issue", state: "open", labels: ["feature"] });
+    const featureIssue = makeIssue({
+      number: 2,
+      title: "Feature issue",
+      state: "open",
+      labels: ["feature"],
+    });
 
     render(<Issues issues={[bugIssue, featureIssue]} onOpen={onOpen} />);
 
@@ -338,7 +384,12 @@ describe("Issues", () => {
   it("should deselect label filter on second click", async () => {
     const user = userEvent.setup();
     const bugIssue = makeIssue({ number: 1, title: "Bug issue", state: "open", labels: ["bug"] });
-    const featureIssue = makeIssue({ number: 2, title: "Feature issue", state: "open", labels: ["feature"] });
+    const featureIssue = makeIssue({
+      number: 2,
+      title: "Feature issue",
+      state: "open",
+      labels: ["feature"],
+    });
 
     render(<Issues issues={[bugIssue, featureIssue]} onOpen={onOpen} />);
 
@@ -352,10 +403,34 @@ describe("Issues", () => {
 
   it("should combine repo + label + search + tab filters", async () => {
     const user = userEvent.setup();
-    const issue1 = makeIssue({ number: 1, title: "Repo1 bug open", state: "open", repoId: "repo-1", labels: ["bug"] });
-    const issue2 = makeIssue({ number: 2, title: "Repo2 bug open", state: "open", repoId: "repo-2", labels: ["bug"] });
-    const issue3 = makeIssue({ number: 3, title: "Repo1 feature open", state: "open", repoId: "repo-1", labels: ["feature"] });
-    const issue4 = makeIssue({ number: 4, title: "Repo1 bug closed", state: "closed", repoId: "repo-1", labels: ["bug"] });
+    const issue1 = makeIssue({
+      number: 1,
+      title: "Repo1 bug open",
+      state: "open",
+      repoId: "repo-1",
+      labels: ["bug"],
+    });
+    const issue2 = makeIssue({
+      number: 2,
+      title: "Repo2 bug open",
+      state: "open",
+      repoId: "repo-2",
+      labels: ["bug"],
+    });
+    const issue3 = makeIssue({
+      number: 3,
+      title: "Repo1 feature open",
+      state: "open",
+      repoId: "repo-1",
+      labels: ["feature"],
+    });
+    const issue4 = makeIssue({
+      number: 4,
+      title: "Repo1 bug closed",
+      state: "closed",
+      repoId: "repo-1",
+      labels: ["bug"],
+    });
     mockUseQuery.mockReturnValue({
       data: [
         makeRepo(),
@@ -383,8 +458,20 @@ describe("Issues", () => {
   });
 
   it("should reset stale repo/label filters after data changes", async () => {
-    const issue1 = makeIssue({ number: 1, title: "Issue repo1", repoId: "repo-1", labels: ["bug"], state: "open" });
-    const issue2 = makeIssue({ number: 2, title: "Issue repo2", repoId: "repo-2", labels: ["feature"], state: "open" });
+    const issue1 = makeIssue({
+      number: 1,
+      title: "Issue repo1",
+      repoId: "repo-1",
+      labels: ["bug"],
+      state: "open",
+    });
+    const issue2 = makeIssue({
+      number: 2,
+      title: "Issue repo2",
+      repoId: "repo-2",
+      labels: ["feature"],
+      state: "open",
+    });
     mockUseQuery.mockReturnValue({
       data: [
         makeRepo(),
@@ -395,14 +482,23 @@ describe("Issues", () => {
     const { rerender } = render(<Issues issues={[issue1, issue2]} onOpen={onOpen} />);
 
     // Select repo-2 and label "feature"
-    await userEvent.selectOptions(screen.getByRole("combobox", { name: /filter by repo/i }), "repo-2");
+    await userEvent.selectOptions(
+      screen.getByRole("combobox", { name: /filter by repo/i }),
+      "repo-2",
+    );
     await userEvent.click(screen.getByRole("button", { name: "feature" }));
 
     expect(screen.getByText("Issue repo2")).toBeInTheDocument();
     expect(screen.queryByText("Issue repo1")).not.toBeInTheDocument();
 
     // Rerender with data that no longer includes repo-2 or "feature" label
-    const issue3 = makeIssue({ number: 3, title: "Issue repo1 new", repoId: "repo-1", labels: ["docs"], state: "open" });
+    const issue3 = makeIssue({
+      number: 3,
+      title: "Issue repo1 new",
+      repoId: "repo-1",
+      labels: ["docs"],
+      state: "open",
+    });
     mockUseQuery.mockReturnValue({ data: [makeRepo()] });
     rerender(<Issues issues={[issue1, issue3]} onOpen={onOpen} />);
 
@@ -413,8 +509,20 @@ describe("Issues", () => {
   });
 
   it("should show only labels from the selected repo", async () => {
-    const issue1 = makeIssue({ number: 1, title: "Issue1", repoId: "repo-1", labels: ["bug"], state: "open" });
-    const issue2 = makeIssue({ number: 2, title: "Issue2", repoId: "repo-2", labels: ["feature"], state: "open" });
+    const issue1 = makeIssue({
+      number: 1,
+      title: "Issue1",
+      repoId: "repo-1",
+      labels: ["bug"],
+      state: "open",
+    });
+    const issue2 = makeIssue({
+      number: 2,
+      title: "Issue2",
+      repoId: "repo-2",
+      labels: ["feature"],
+      state: "open",
+    });
     mockUseQuery.mockReturnValue({
       data: [
         makeRepo(),
@@ -429,7 +537,10 @@ describe("Issues", () => {
     expect(within(labelGroup).getByRole("button", { name: "feature" })).toBeInTheDocument();
 
     // Select repo-1: only "bug" label should remain
-    await userEvent.selectOptions(screen.getByRole("combobox", { name: /filter by repo/i }), "repo-1");
+    await userEvent.selectOptions(
+      screen.getByRole("combobox", { name: /filter by repo/i }),
+      "repo-1",
+    );
     expect(within(labelGroup).getByRole("button", { name: "bug" })).toBeInTheDocument();
     expect(within(labelGroup).queryByRole("button", { name: "feature" })).not.toBeInTheDocument();
   });
@@ -443,10 +554,14 @@ describe("Issues", () => {
     const group = screen.getByRole("group", { name: /filter by label/i });
 
     for (let i = 1; i <= 8; i++) {
-      expect(within(group).getByRole("button", { name: `label-${String(i).padStart(2, "0")}` })).toBeInTheDocument();
+      expect(
+        within(group).getByRole("button", { name: `label-${String(i).padStart(2, "0")}` }),
+      ).toBeInTheDocument();
     }
     for (let i = 9; i <= 12; i++) {
-      expect(within(group).queryByRole("button", { name: `label-${String(i).padStart(2, "0")}` })).not.toBeInTheDocument();
+      expect(
+        within(group).queryByRole("button", { name: `label-${String(i).padStart(2, "0")}` }),
+      ).not.toBeInTheDocument();
     }
     expect(screen.getByTestId("label-filter-toggle")).toHaveTextContent("+4 more");
   });
@@ -463,7 +578,9 @@ describe("Issues", () => {
 
     const group = screen.getByRole("group", { name: /filter by label/i });
     for (let i = 1; i <= 12; i++) {
-      expect(within(group).getByRole("button", { name: `label-${String(i).padStart(2, "0")}` })).toBeInTheDocument();
+      expect(
+        within(group).getByRole("button", { name: `label-${String(i).padStart(2, "0")}` }),
+      ).toBeInTheDocument();
     }
     expect(toggle).toHaveTextContent("Show less");
     expect(toggle).toHaveAttribute("aria-expanded", "true");
@@ -482,10 +599,14 @@ describe("Issues", () => {
 
     const group = screen.getByRole("group", { name: /filter by label/i });
     for (let i = 1; i <= 8; i++) {
-      expect(within(group).getByRole("button", { name: `label-${String(i).padStart(2, "0")}` })).toBeInTheDocument();
+      expect(
+        within(group).getByRole("button", { name: `label-${String(i).padStart(2, "0")}` }),
+      ).toBeInTheDocument();
     }
     for (let i = 9; i <= 12; i++) {
-      expect(within(group).queryByRole("button", { name: `label-${String(i).padStart(2, "0")}` })).not.toBeInTheDocument();
+      expect(
+        within(group).queryByRole("button", { name: `label-${String(i).padStart(2, "0")}` }),
+      ).not.toBeInTheDocument();
     }
     expect(toggle).toHaveTextContent("+4 more");
     expect(toggle).toHaveAttribute("aria-expanded", "false");
@@ -499,7 +620,9 @@ describe("Issues", () => {
 
     const group = screen.getByRole("group", { name: /filter by label/i });
     for (let i = 1; i <= LABEL_VISIBLE_LIMIT; i++) {
-      expect(within(group).getByRole("button", { name: `label-${String(i).padStart(2, "0")}` })).toBeInTheDocument();
+      expect(
+        within(group).getByRole("button", { name: `label-${String(i).padStart(2, "0")}` }),
+      ).toBeInTheDocument();
     }
     expect(screen.queryByTestId("label-filter-toggle")).toBeNull();
   });
@@ -508,8 +631,20 @@ describe("Issues", () => {
     const user = userEvent.setup();
     const labels1 = makeLabels(12);
     const labels2 = makeLabels(10).map((l) => `repo2-${l}`);
-    const issue1 = makeIssue({ number: 1, title: "Repo1 issue", state: "open", repoId: "repo-1", labels: labels1 });
-    const issue2 = makeIssue({ number: 2, title: "Repo2 issue", state: "open", repoId: "repo-2", labels: labels2 });
+    const issue1 = makeIssue({
+      number: 1,
+      title: "Repo1 issue",
+      state: "open",
+      repoId: "repo-1",
+      labels: labels1,
+    });
+    const issue2 = makeIssue({
+      number: 2,
+      title: "Repo2 issue",
+      state: "open",
+      repoId: "repo-2",
+      labels: labels2,
+    });
     mockUseQuery.mockReturnValue({
       data: [
         makeRepo(),
@@ -553,7 +688,9 @@ describe("Issues", () => {
     expect(within(group).getByRole("button", { name: "label-10" })).toBeInTheDocument();
     expect(within(group).queryByRole("button", { name: "label-08" })).not.toBeInTheDocument();
     expect(screen.getByTestId("label-filter-toggle")).toHaveTextContent("+4 more");
-    expect(screen.getByRole("button", { name: "label-10" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "label-10" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
   });
-
 });

--- a/src/components/Issues/Issues.tsx
+++ b/src/components/Issues/Issues.tsx
@@ -7,6 +7,7 @@ import { FILTER_BUTTON_CLASS, INLINE_CONTROL_CLASS } from "../../lib/uiClasses";
 import type { Issue } from "../../lib/types/github";
 import { useFilterableList } from "../../hooks/useFilterableList";
 import { useRegisterNavigableItems } from "../../hooks/useRegisterNavigableItems";
+import { useDashboardStore } from "../../stores/dashboard";
 import { EmptyState } from "../atoms/EmptyState";
 import { SectionHead } from "../atoms/SectionHead";
 import { ListItemSkeleton, Skeleton } from "../atoms/Skeleton";
@@ -29,8 +30,15 @@ const ISSUE_TABS: Readonly<Record<Tab, (issue: Issue) => boolean>> = {
 
 export const LABEL_VISIBLE_LIMIT = 8;
 
-function IssuesImpl({ issues, isLoading = false, onOpen, hideTabs = false, hideHeader = false }: IssuesProps): ReactElement {
+function IssuesImpl({
+  issues,
+  isLoading = false,
+  onOpen,
+  hideTabs = false,
+  hideHeader = false,
+}: IssuesProps): ReactElement {
   const parentRef = useRef<HTMLDivElement>(null);
+  const selectedIndex = useDashboardStore((s) => s.selectedIndex);
   const { data: repos } = useQuery({ queryKey: ["repos"], queryFn: listRepos });
   const [repoFilter, setRepoFilter] = useState("");
   const [labelFilter, setLabelFilter] = useState<string | null>(null);
@@ -53,8 +61,7 @@ function IssuesImpl({ issues, isLoading = false, onOpen, hideTabs = false, hideH
     return result.sort((a, b) => a.fullName.localeCompare(b.fullName));
   }, [issues, repoMap]);
 
-  const isRepoFilterValid =
-    repoFilter === "" || uniqueRepos.some((r) => r.id === repoFilter);
+  const isRepoFilterValid = repoFilter === "" || uniqueRepos.some((r) => r.id === repoFilter);
 
   const repoFiltered = useMemo<readonly Issue[]>(
     () =>
@@ -77,7 +84,11 @@ function IssuesImpl({ issues, isLoading = false, onOpen, hideTabs = false, hideH
   const visibleLabels = useMemo(() => {
     if (showAllLabels) return uniqueLabels;
     const sliced = uniqueLabels.slice(0, LABEL_VISIBLE_LIMIT);
-    if (labelFilter !== null && !sliced.includes(labelFilter) && uniqueLabels.includes(labelFilter)) {
+    if (
+      labelFilter !== null &&
+      !sliced.includes(labelFilter) &&
+      uniqueLabels.includes(labelFilter)
+    ) {
       return [...sliced.slice(0, -1), labelFilter];
     }
     return sliced;
@@ -101,8 +112,7 @@ function IssuesImpl({ issues, isLoading = false, onOpen, hideTabs = false, hideH
     setShowAllLabels(false);
   }, [repoFilter]);
 
-  const isLabelFilterValid =
-    labelFilter === null || uniqueLabels.includes(labelFilter);
+  const isLabelFilterValid = labelFilter === null || uniqueLabels.includes(labelFilter);
 
   const preFiltered = useMemo<readonly Issue[]>(
     () =>
@@ -161,7 +171,9 @@ function IssuesImpl({ issues, isLoading = false, onOpen, hideTabs = false, hideH
       aria-busy={isLoading ? "true" : undefined}
       className="flex flex-col gap-2"
     >
-      {!hideHeader && <SectionHead title="Issues" count={isLoading ? undefined : matchingIssues.length} />}
+      {!hideHeader && (
+        <SectionHead title="Issues" count={isLoading ? undefined : matchingIssues.length} />
+      )}
 
       {isLoading ? (
         <>
@@ -229,7 +241,9 @@ function IssuesImpl({ issues, isLoading = false, onOpen, hideTabs = false, hideH
                 >
                   <option value="">All repos</option>
                   {uniqueRepos.map((r) => (
-                    <option key={r.id} value={r.id}>{r.fullName}</option>
+                    <option key={r.id} value={r.id}>
+                      {r.fullName}
+                    </option>
                   ))}
                 </select>
               )}
@@ -292,6 +306,7 @@ function IssuesImpl({ issues, isLoading = false, onOpen, hideTabs = false, hideH
                     >
                       <IssueCard
                         issue={issue}
+                        isSelected={selectedIndex === virtualItem.index}
                         repoName={repoMap.get(issue.repoId) ?? issue.repoId}
                         onOpen={onOpen}
                       />

--- a/src/components/Issues/Issues.tsx
+++ b/src/components/Issues/Issues.tsx
@@ -163,6 +163,11 @@ function IssuesImpl({
     useFlushSync: false,
   });
 
+  useEffect(() => {
+    if (selectedIndex < 0 || activeNavigableSection !== "issues") return;
+    virtualizer.scrollToIndex(selectedIndex, { align: "auto" });
+  }, [activeNavigableSection, selectedIndex, virtualizer]);
+
   const navItems = useMemo(() => visible.map((issue) => ({ url: issue.url })), [visible]);
   useRegisterNavigableItems(navItems, "issues");
 

--- a/src/components/Issues/Issues.tsx
+++ b/src/components/Issues/Issues.tsx
@@ -38,6 +38,7 @@ function IssuesImpl({
   hideHeader = false,
 }: IssuesProps): ReactElement {
   const parentRef = useRef<HTMLDivElement>(null);
+  const activeNavigableSection = useDashboardStore((s) => s.activeNavigableSection);
   const selectedIndex = useDashboardStore((s) => s.selectedIndex);
   const { data: repos } = useQuery({ queryKey: ["repos"], queryFn: listRepos });
   const [repoFilter, setRepoFilter] = useState("");
@@ -163,7 +164,7 @@ function IssuesImpl({
   });
 
   const navItems = useMemo(() => visible.map((issue) => ({ url: issue.url })), [visible]);
-  useRegisterNavigableItems(navItems);
+  useRegisterNavigableItems(navItems, "issues");
 
   return (
     <section
@@ -306,7 +307,9 @@ function IssuesImpl({
                     >
                       <IssueCard
                         issue={issue}
-                        isSelected={selectedIndex === virtualItem.index}
+                        isSelected={
+                          activeNavigableSection === "issues" && selectedIndex === virtualItem.index
+                        }
                         repoName={repoMap.get(issue.repoId) ?? issue.repoId}
                         onOpen={onOpen}
                       />

--- a/src/components/MyPRs/MyPRs.memo.test.tsx
+++ b/src/components/MyPRs/MyPRs.memo.test.tsx
@@ -19,6 +19,11 @@ vi.mock("@tanstack/react-query", async () => {
   };
 });
 
+// Memoization tests should isolate child renders from dashboard registration side effects.
+vi.mock("../../hooks/useRegisterNavigableItems", () => ({
+  useRegisterNavigableItems: vi.fn(),
+}));
+
 // Replace MyPrCard with a light stub that counts render calls.
 vi.mock("./MyPrCard", () => ({
   MyPrCard: (props: Record<string, unknown>) => {

--- a/src/components/MyPRs/MyPRs.test.tsx
+++ b/src/components/MyPRs/MyPRs.test.tsx
@@ -1,9 +1,10 @@
-import { render, screen, within } from "@testing-library/react";
+import { act, render, screen, within, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { FOCUS_RING } from "../../lib/a11y";
 import type { PullRequestWithReview } from "../../lib/types/dashboard";
 import type { Repo } from "../../lib/types/github";
+import { useDashboardStore } from "../../stores/dashboard";
 import { MyPRs } from "./MyPRs";
 
 const { mockUseQuery } = vi.hoisted(() => ({ mockUseQuery: vi.fn() }));
@@ -78,6 +79,12 @@ const onOpen = vi.fn();
 beforeEach(() => {
   onOpen.mockClear();
   mockUseQuery.mockReturnValue({ data: [makeRepo()] });
+  useDashboardStore.setState({
+    activeNavigableSection: null,
+    navigableSectionRegistrations: [],
+    selectedIndex: -1,
+    navigableItems: [],
+  });
 });
 
 describe("MyPRs", () => {
@@ -109,6 +116,24 @@ describe("MyPRs", () => {
     expect(screen.getByText("Merged PR two")).toBeInTheDocument();
     expect(screen.queryByText("Open PR one")).not.toBeInTheDocument();
     expect(screen.queryByText("Draft PR")).not.toBeInTheDocument();
+  });
+
+  it("should scroll the selected item into view during keyboard navigation", () => {
+    const scrollIntoView = vi.fn();
+    vi.spyOn(HTMLElement.prototype, "scrollIntoView").mockImplementation(scrollIntoView);
+
+    render(<MyPRs prs={allPrs} onOpen={onOpen} />);
+
+    act(() => {
+      useDashboardStore.setState({
+        activeNavigableSection: "mine",
+        selectedIndex: 1,
+      });
+    });
+
+    return waitFor(() => {
+      expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest" });
+    });
   });
 
   it("should show correct counts", () => {
@@ -271,7 +296,12 @@ describe("MyPRs", () => {
 
   it("should show label filter buttons when labels exist", () => {
     const bugPr = makePr({ number: 6, title: "Bug fix", labels: ["bug"], state: "open" });
-    const featurePr = makePr({ number: 7, title: "New feature", labels: ["feature"], state: "open" });
+    const featurePr = makePr({
+      number: 7,
+      title: "New feature",
+      labels: ["feature"],
+      state: "open",
+    });
 
     render(<MyPRs prs={[bugPr, featurePr]} onOpen={onOpen} />);
 
@@ -289,7 +319,12 @@ describe("MyPRs", () => {
   it("should filter PRs by selected label", async () => {
     const user = userEvent.setup();
     const bugPr = makePr({ number: 6, title: "Bug fix", labels: ["bug"], state: "open" });
-    const featurePr = makePr({ number: 7, title: "New feature", labels: ["feature"], state: "open" });
+    const featurePr = makePr({
+      number: 7,
+      title: "New feature",
+      labels: ["feature"],
+      state: "open",
+    });
 
     render(<MyPRs prs={[bugPr, featurePr]} onOpen={onOpen} />);
 
@@ -302,7 +337,12 @@ describe("MyPRs", () => {
   it("should deselect label filter on second click", async () => {
     const user = userEvent.setup();
     const bugPr = makePr({ number: 6, title: "Bug fix", labels: ["bug"], state: "open" });
-    const featurePr = makePr({ number: 7, title: "New feature", labels: ["feature"], state: "open" });
+    const featurePr = makePr({
+      number: 7,
+      title: "New feature",
+      labels: ["feature"],
+      state: "open",
+    });
 
     render(<MyPRs prs={[bugPr, featurePr]} onOpen={onOpen} />);
 
@@ -316,9 +356,27 @@ describe("MyPRs", () => {
 
   it("should combine repo + label + search + tab filters", async () => {
     const user = userEvent.setup();
-    const pr2 = makePr({ number: 6, title: "Acme bug fix", repoId: "repo-2", labels: ["bug"], state: "open" });
-    const pr3 = makePr({ number: 7, title: "Acme feature", repoId: "repo-2", labels: ["feature"], state: "open" });
-    const pr4 = makePr({ number: 8, title: "Acme merged bug", repoId: "repo-2", labels: ["bug"], state: "merged" });
+    const pr2 = makePr({
+      number: 6,
+      title: "Acme bug fix",
+      repoId: "repo-2",
+      labels: ["bug"],
+      state: "open",
+    });
+    const pr3 = makePr({
+      number: 7,
+      title: "Acme feature",
+      repoId: "repo-2",
+      labels: ["feature"],
+      state: "open",
+    });
+    const pr4 = makePr({
+      number: 8,
+      title: "Acme merged bug",
+      repoId: "repo-2",
+      labels: ["bug"],
+      state: "merged",
+    });
     mockUseQuery.mockReturnValue({
       data: [
         makeRepo(),
@@ -346,8 +404,20 @@ describe("MyPRs", () => {
   });
 
   it("should reset stale repo/label filters after data changes", async () => {
-    const pr1 = makePr({ number: 1, title: "PR repo1", repoId: "repo-1", labels: ["bug"], state: "open" });
-    const pr2 = makePr({ number: 2, title: "PR repo2", repoId: "repo-2", labels: ["feature"], state: "open" });
+    const pr1 = makePr({
+      number: 1,
+      title: "PR repo1",
+      repoId: "repo-1",
+      labels: ["bug"],
+      state: "open",
+    });
+    const pr2 = makePr({
+      number: 2,
+      title: "PR repo2",
+      repoId: "repo-2",
+      labels: ["feature"],
+      state: "open",
+    });
     mockUseQuery.mockReturnValue({
       data: [
         makeRepo(),
@@ -358,14 +428,23 @@ describe("MyPRs", () => {
     const { rerender } = render(<MyPRs prs={[pr1, pr2]} onOpen={onOpen} />);
 
     // Select repo-2 and label "feature"
-    await userEvent.selectOptions(screen.getByRole("combobox", { name: /filter by repo/i }), "repo-2");
+    await userEvent.selectOptions(
+      screen.getByRole("combobox", { name: /filter by repo/i }),
+      "repo-2",
+    );
     await userEvent.click(screen.getByRole("button", { name: "feature" }));
 
     expect(screen.getByText("PR repo2")).toBeInTheDocument();
     expect(screen.queryByText("PR repo1")).not.toBeInTheDocument();
 
     // Rerender with data that no longer includes repo-2 or "feature" label
-    const pr3 = makePr({ number: 3, title: "PR repo1 new", repoId: "repo-1", labels: ["docs"], state: "open" });
+    const pr3 = makePr({
+      number: 3,
+      title: "PR repo1 new",
+      repoId: "repo-1",
+      labels: ["docs"],
+      state: "open",
+    });
     mockUseQuery.mockReturnValue({ data: [makeRepo()] });
     rerender(<MyPRs prs={[pr1, pr3]} onOpen={onOpen} />);
 
@@ -377,8 +456,20 @@ describe("MyPRs", () => {
   });
 
   it("should show only labels from the selected repo", async () => {
-    const pr1 = makePr({ number: 1, title: "PR1", repoId: "repo-1", labels: ["bug"], state: "open" });
-    const pr2 = makePr({ number: 2, title: "PR2", repoId: "repo-2", labels: ["feature"], state: "open" });
+    const pr1 = makePr({
+      number: 1,
+      title: "PR1",
+      repoId: "repo-1",
+      labels: ["bug"],
+      state: "open",
+    });
+    const pr2 = makePr({
+      number: 2,
+      title: "PR2",
+      repoId: "repo-2",
+      labels: ["feature"],
+      state: "open",
+    });
     mockUseQuery.mockReturnValue({
       data: [
         makeRepo(),
@@ -394,9 +485,11 @@ describe("MyPRs", () => {
     expect(within(labelGroup).getByRole("button", { name: "feature" })).toBeInTheDocument();
 
     // Select repo-1: only "bug" label should remain
-    await userEvent.selectOptions(screen.getByRole("combobox", { name: /filter by repo/i }), "repo-1");
+    await userEvent.selectOptions(
+      screen.getByRole("combobox", { name: /filter by repo/i }),
+      "repo-1",
+    );
     expect(within(labelGroup).getByRole("button", { name: "bug" })).toBeInTheDocument();
     expect(within(labelGroup).queryByRole("button", { name: "feature" })).not.toBeInTheDocument();
   });
-
 });

--- a/src/components/MyPRs/MyPRs.tsx
+++ b/src/components/MyPRs/MyPRs.tsx
@@ -6,6 +6,7 @@ import { FILTER_BUTTON_CLASS, INLINE_CONTROL_CLASS } from "../../lib/uiClasses";
 import type { PullRequestWithReview } from "../../lib/types/dashboard";
 import { useFilterableList } from "../../hooks/useFilterableList";
 import { useRegisterNavigableItems } from "../../hooks/useRegisterNavigableItems";
+import { useDashboardStore } from "../../stores/dashboard";
 import { EmptyState } from "../atoms/EmptyState";
 import { SectionHead } from "../atoms/SectionHead";
 import { CardSkeleton, Skeleton } from "../atoms/Skeleton";
@@ -45,6 +46,7 @@ function MyPRsImpl({
   hideHeader = false,
 }: MyPRsProps): ReactElement {
   const listRef = useRef<HTMLDivElement>(null);
+  const selectedIndex = useDashboardStore((s) => s.selectedIndex);
   const { data: repos } = useQuery({ queryKey: ["repos"], queryFn: listRepos });
 
   const [repoFilter, setRepoFilter] = useState("");
@@ -68,8 +70,7 @@ function MyPRsImpl({
     return result.sort((a, b) => a.fullName.localeCompare(b.fullName));
   }, [prs, repoMap]);
 
-  const isRepoFilterValid =
-    repoFilter === "" || uniqueRepos.some((r) => r.id === repoFilter);
+  const isRepoFilterValid = repoFilter === "" || uniqueRepos.some((r) => r.id === repoFilter);
 
   const repoFiltered = useMemo(
     () =>
@@ -102,8 +103,7 @@ function MyPRsImpl({
     }
   }, [uniqueLabels, labelFilter]);
 
-  const isLabelFilterValid =
-    labelFilter === null || uniqueLabels.includes(labelFilter);
+  const isLabelFilterValid = labelFilter === null || uniqueLabels.includes(labelFilter);
 
   const preFiltered = useMemo(
     () =>
@@ -227,7 +227,9 @@ function MyPRsImpl({
             >
               <option value="">All repos</option>
               {uniqueRepos.map((r) => (
-                <option key={r.id} value={r.id}>{r.fullName}</option>
+                <option key={r.id} value={r.id}>
+                  {r.fullName}
+                </option>
               ))}
             </select>
           )}
@@ -257,10 +259,11 @@ function MyPRsImpl({
           ) : (
             <div ref={listRef} className="max-h-[600px] overflow-y-auto">
               <div className="flex flex-col gap-1">
-                {visible.map((pr) => (
+                {visible.map((pr, index) => (
                   <MyPrCard
                     key={pr.pullRequest.id}
                     data={pr}
+                    isSelected={selectedIndex === index}
                     onOpen={onOpen}
                     onWorkspaceAction={onWorkspaceAction}
                   />

--- a/src/components/MyPRs/MyPRs.tsx
+++ b/src/components/MyPRs/MyPRs.tsx
@@ -46,6 +46,7 @@ function MyPRsImpl({
   hideHeader = false,
 }: MyPRsProps): ReactElement {
   const listRef = useRef<HTMLDivElement>(null);
+  const activeNavigableSection = useDashboardStore((s) => s.activeNavigableSection);
   const selectedIndex = useDashboardStore((s) => s.selectedIndex);
   const { data: repos } = useQuery({ queryKey: ["repos"], queryFn: listRepos });
 
@@ -142,8 +143,14 @@ function MyPRsImpl({
     listRef.current?.scrollTo({ top: 0, behavior: "instant" });
   }, [tab, normalizedQuery, repoFilter, labelFilter]);
 
+  useEffect(() => {
+    if (selectedIndex < 0 || activeNavigableSection !== "mine") return;
+    const selectedCard = listRef.current?.querySelector<HTMLElement>('[data-selected="true"]');
+    selectedCard?.scrollIntoView({ block: "nearest" });
+  }, [activeNavigableSection, selectedIndex, visible]);
+
   const navItems = useMemo(() => visible.map((pr) => ({ url: pr.pullRequest.url })), [visible]);
-  useRegisterNavigableItems(navItems);
+  useRegisterNavigableItems(navItems, "mine");
 
   return (
     <section
@@ -263,7 +270,7 @@ function MyPRsImpl({
                   <MyPrCard
                     key={pr.pullRequest.id}
                     data={pr}
-                    isSelected={selectedIndex === index}
+                    isSelected={activeNavigableSection === "mine" && selectedIndex === index}
                     onOpen={onOpen}
                     onWorkspaceAction={onWorkspaceAction}
                   />

--- a/src/components/MyPRs/MyPrCard.test.tsx
+++ b/src/components/MyPRs/MyPrCard.test.tsx
@@ -47,6 +47,7 @@ describe("MyPrCard", () => {
     render(<MyPrCard data={basePr} onOpen={vi.fn()} isSelected />);
     const card = screen.getByTestId("my-pr-card");
     expect(card).toHaveAttribute("data-selected", "true");
+    expect(card).toHaveAttribute("aria-current", "true");
     expect(card).toHaveClass("border-accent", "ring-2", "ring-accent");
   });
 

--- a/src/components/MyPRs/MyPrCard.test.tsx
+++ b/src/components/MyPRs/MyPrCard.test.tsx
@@ -43,6 +43,13 @@ describe("MyPrCard", () => {
     expect(screen.getByText("#99")).toBeInTheDocument();
   });
 
+  it("should show selected styling when keyboard-selected", () => {
+    render(<MyPrCard data={basePr} onOpen={vi.fn()} isSelected />);
+    const card = screen.getByTestId("my-pr-card");
+    expect(card).toHaveAttribute("data-selected", "true");
+    expect(card).toHaveClass("border-accent", "ring-2", "ring-accent");
+  });
+
   it("should show CI dot", () => {
     render(<MyPrCard data={basePr} onOpen={vi.fn()} />);
     const ciDot = screen.getByTestId("ci-dot");
@@ -149,9 +156,7 @@ describe("MyPrCard", () => {
   });
 
   it("should show workspace badge", () => {
-    render(
-      <MyPrCard data={basePr} onOpen={vi.fn()} onWorkspaceAction={vi.fn()} />,
-    );
+    render(<MyPrCard data={basePr} onOpen={vi.fn()} onWorkspaceAction={vi.fn()} />);
     expect(screen.getByText("resume")).toBeInTheDocument();
   });
 
@@ -172,9 +177,7 @@ describe("MyPrCard", () => {
       ...basePr,
       workspace: null,
     };
-    render(
-      <MyPrCard data={data} onOpen={vi.fn()} onWorkspaceAction={vi.fn()} />,
-    );
+    render(<MyPrCard data={data} onOpen={vi.fn()} onWorkspaceAction={vi.fn()} />);
     expect(screen.getByText("open")).toBeInTheDocument();
   });
 
@@ -182,16 +185,12 @@ describe("MyPrCard", () => {
     const handleOpen = vi.fn();
     render(<MyPrCard data={basePr} onOpen={handleOpen} />);
     await userEvent.click(screen.getByRole("link"));
-    expect(handleOpen).toHaveBeenCalledWith(
-      "https://github.com/org/repo/pull/99",
-    );
+    expect(handleOpen).toHaveBeenCalledWith("https://github.com/org/repo/pull/99");
   });
 
   it("should call onWorkspaceAction when badge clicked", async () => {
     const handleWs = vi.fn();
-    render(
-      <MyPrCard data={basePr} onOpen={vi.fn()} onWorkspaceAction={handleWs} />,
-    );
+    render(<MyPrCard data={basePr} onOpen={vi.fn()} onWorkspaceAction={handleWs} />);
     await userEvent.click(screen.getByRole("button"));
     expect(handleWs).toHaveBeenCalledWith({
       repoId: "repo-1",
@@ -246,9 +245,7 @@ describe("MyPrCard", () => {
       pullRequest: { ...basePr.pullRequest, state: "merged" },
       workspace: { id: "ws-1", state: "suspended", lastNoteContent: null },
     };
-    render(
-      <MyPrCard data={data} onOpen={vi.fn()} onWorkspaceAction={vi.fn()} />,
-    );
+    render(<MyPrCard data={data} onOpen={vi.fn()} onWorkspaceAction={vi.fn()} />);
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
   });
 
@@ -257,9 +254,7 @@ describe("MyPrCard", () => {
       ...basePr,
       workspace: { id: "ws-1", state: "suspended", lastNoteContent: null },
     };
-    render(
-      <MyPrCard data={data} onOpen={vi.fn()} onWorkspaceAction={vi.fn()} />,
-    );
+    render(<MyPrCard data={data} onOpen={vi.fn()} onWorkspaceAction={vi.fn()} />);
     expect(screen.getByRole("button", { name: "Wake workspace for PR #99" })).toBeInTheDocument();
     expect(screen.getByText("wake")).toBeInTheDocument();
   });

--- a/src/components/MyPRs/MyPrCard.tsx
+++ b/src/components/MyPRs/MyPrCard.tsx
@@ -1,6 +1,7 @@
 import { type ReactElement, useState } from "react";
 import { FOCUS_RING } from "../../lib/a11y";
 import { timeAgo } from "../../lib/timeAgo";
+import { SELECTED_ITEM_CLASS } from "../../lib/uiClasses";
 import type { CiStatus } from "../../lib/types/enums";
 import type { PullRequestWithReview } from "../../lib/types/dashboard";
 import { CI } from "../atoms/CI";
@@ -10,6 +11,7 @@ import { WsBadge } from "../atoms/WsBadge";
 interface MyPrCardProps {
   readonly data: PullRequestWithReview;
   readonly onOpen: (url: string) => void;
+  readonly isSelected?: boolean;
   readonly onWorkspaceAction?: (params: {
     readonly repoId: string;
     readonly pullRequestNumber: number;
@@ -55,7 +57,12 @@ function buildReviewDots(
   return dots;
 }
 
-export function MyPrCard({ data, onOpen, onWorkspaceAction }: MyPrCardProps): ReactElement {
+export function MyPrCard({
+  data,
+  onOpen,
+  isSelected = false,
+  onWorkspaceAction,
+}: MyPrCardProps): ReactElement {
   const { pullRequest: pr, workspace } = data;
   const merged = pr.state === "merged";
   const [loading, setLoading] = useState(false);
@@ -83,7 +90,10 @@ export function MyPrCard({ data, onOpen, onWorkspaceAction }: MyPrCardProps): Re
   return (
     <div
       data-testid="my-pr-card"
-      className={`flex items-center gap-3 rounded border border-border px-3 py-2 hover:bg-surface-hover${merged ? " opacity-50" : ""}`}
+      data-selected={isSelected ? "true" : undefined}
+      className={`flex items-center gap-3 rounded border border-border px-3 py-2 hover:bg-surface-hover${
+        merged ? " opacity-50" : ""
+      }${isSelected ? ` ${SELECTED_ITEM_CLASS}` : ""}`}
     >
       <a
         href={pr.url}

--- a/src/components/MyPRs/MyPrCard.tsx
+++ b/src/components/MyPRs/MyPrCard.tsx
@@ -91,6 +91,7 @@ export function MyPrCard({
     <div
       data-testid="my-pr-card"
       data-selected={isSelected ? "true" : undefined}
+      aria-current={isSelected ? "true" : undefined}
       className={`flex items-center gap-3 rounded border border-border px-3 py-2 hover:bg-surface-hover${
         merged ? " opacity-50" : ""
       }${isSelected ? ` ${SELECTED_ITEM_CLASS}` : ""}`}

--- a/src/components/Notifications/NotificationCard.test.tsx
+++ b/src/components/Notifications/NotificationCard.test.tsx
@@ -31,6 +31,7 @@ describe("NotificationCard", () => {
     render(<NotificationCard data={makeNotification()} onOpen={vi.fn()} isSelected />);
     const card = screen.getByTestId("notification-card");
     expect(card).toHaveAttribute("data-selected", "true");
+    expect(card).toHaveAttribute("aria-current", "true");
     expect(card).toHaveClass("border-accent", "ring-2", "ring-accent");
   });
 

--- a/src/components/Notifications/NotificationCard.test.tsx
+++ b/src/components/Notifications/NotificationCard.test.tsx
@@ -27,6 +27,13 @@ describe("NotificationCard", () => {
     expect(screen.getByText(/review requested/i)).toBeInTheDocument();
   });
 
+  it("shows selected styling when keyboard-selected", () => {
+    render(<NotificationCard data={makeNotification()} onOpen={vi.fn()} isSelected />);
+    const card = screen.getByTestId("notification-card");
+    expect(card).toHaveAttribute("data-selected", "true");
+    expect(card).toHaveClass("border-accent", "ring-2", "ring-accent");
+  });
+
   it("shows an unread indicator when unread is true", () => {
     render(<NotificationCard data={makeNotification({ unread: true })} onOpen={vi.fn()} />);
     expect(screen.getByTestId("unread-indicator")).toBeInTheDocument();

--- a/src/components/Notifications/NotificationCard.tsx
+++ b/src/components/Notifications/NotificationCard.tsx
@@ -94,6 +94,7 @@ function NotificationCardImpl({
     <div
       data-testid="notification-card"
       data-selected={isSelected ? "true" : undefined}
+      aria-current={isSelected ? "true" : undefined}
       className={`flex items-center gap-3 rounded border border-border px-3 py-2 hover:bg-surface-hover${
         unread ? "" : " opacity-60"
       }${isSelected ? ` ${SELECTED_ITEM_CLASS}` : ""}`}

--- a/src/components/Notifications/NotificationCard.tsx
+++ b/src/components/Notifications/NotificationCard.tsx
@@ -1,11 +1,13 @@
 import { memo, type ReactElement, useCallback } from "react";
 import { FOCUS_RING } from "../../lib/a11y";
 import { timeAgo } from "../../lib/timeAgo";
+import { SELECTED_ITEM_CLASS } from "../../lib/uiClasses";
 import type { GithubNotification, NotificationSubjectType } from "../../lib/types/github";
 
 interface NotificationCardProps {
   readonly data: GithubNotification;
   readonly onOpen: (url: string) => void;
+  readonly isSelected?: boolean;
 }
 
 const TYPE_ICON: Record<NotificationSubjectType, string> = {
@@ -67,7 +69,11 @@ function isSafeUrl(url: string): boolean {
   }
 }
 
-function NotificationCardImpl({ data, onOpen }: NotificationCardProps): ReactElement {
+function NotificationCardImpl({
+  data,
+  onOpen,
+  isSelected = false,
+}: NotificationCardProps): ReactElement {
   const { url, title, notificationType, unread, reason, repo, updatedAt } = data;
 
   const handleClick = useCallback(
@@ -87,9 +93,10 @@ function NotificationCardImpl({ data, onOpen }: NotificationCardProps): ReactEle
   return (
     <div
       data-testid="notification-card"
+      data-selected={isSelected ? "true" : undefined}
       className={`flex items-center gap-3 rounded border border-border px-3 py-2 hover:bg-surface-hover${
         unread ? "" : " opacity-60"
-      }`}
+      }${isSelected ? ` ${SELECTED_ITEM_CLASS}` : ""}`}
     >
       <a
         href={url}
@@ -117,10 +124,7 @@ function NotificationCardImpl({ data, onOpen }: NotificationCardProps): ReactEle
 
         <div className="flex min-w-0 flex-1 flex-col gap-1">
           <div className="flex min-w-0 items-center gap-2">
-            <span
-              className="min-w-0 truncate text-sm font-medium text-foreground"
-              title={title}
-            >
+            <span className="min-w-0 truncate text-sm font-medium text-foreground" title={title}>
               {title}
             </span>
           </div>

--- a/src/components/Notifications/Notifications.test.tsx
+++ b/src/components/Notifications/Notifications.test.tsx
@@ -1,8 +1,9 @@
-import { render, screen, within } from "@testing-library/react";
+import { act, render, screen, within, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { FOCUS_RING } from "../../lib/a11y";
 import type { GithubNotification } from "../../lib/types/github";
+import { useDashboardStore } from "../../stores/dashboard";
 import { Notifications } from "./Notifications";
 
 const { mockUseQuery } = vi.hoisted(() => ({ mockUseQuery: vi.fn() }));
@@ -72,6 +73,12 @@ function mockQueryError(message: string) {
 beforeEach(() => {
   onOpen.mockClear();
   mockUseQuery.mockReset();
+  useDashboardStore.setState({
+    activeNavigableSection: null,
+    navigableSectionRegistrations: [],
+    selectedIndex: -1,
+    navigableItems: [],
+  });
 });
 
 describe("Notifications", () => {
@@ -103,6 +110,26 @@ describe("Notifications", () => {
     expect(screen.getByText("Unread PR")).toBeInTheDocument();
     expect(screen.getByText("Read PR")).toBeInTheDocument();
     expect(screen.getByText("Crash")).toBeInTheDocument();
+  });
+
+  it("scrolls the selected item into view during keyboard navigation", async () => {
+    const scrollIntoView = vi.fn();
+    vi.spyOn(HTMLElement.prototype, "scrollIntoView").mockImplementation(scrollIntoView);
+
+    mockQuerySuccess([unreadNotif, readNotif, issueNotif]);
+    render(<Notifications onOpen={onOpen} />);
+
+    await userEvent.click(screen.getByRole("button", { name: /^all/i }));
+    act(() => {
+      useDashboardStore.setState({
+        activeNavigableSection: "notifications",
+        selectedIndex: 1,
+      });
+    });
+
+    await waitFor(() => {
+      expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest" });
+    });
   });
 
   it("shows correct counts on each tab", () => {

--- a/src/components/Notifications/Notifications.tsx
+++ b/src/components/Notifications/Notifications.tsx
@@ -6,6 +6,7 @@ import { FOCUS_RING } from "../../lib/a11y";
 import { listNotifications } from "../../lib/tauri";
 import type { GithubNotification } from "../../lib/types/github";
 import { FILTER_BUTTON_CLASS } from "../../lib/uiClasses";
+import { useDashboardStore } from "../../stores/dashboard";
 import { EmptyState } from "../atoms/EmptyState";
 import { SectionHead } from "../atoms/SectionHead";
 import { CardSkeleton, Skeleton } from "../atoms/Skeleton";
@@ -24,6 +25,7 @@ const NOTIFICATION_TABS: Readonly<Record<Tab, (n: GithubNotification) => boolean
 
 function NotificationsImpl({ onOpen }: NotificationsProps): ReactElement {
   const listRef = useRef<HTMLDivElement>(null);
+  const selectedIndex = useDashboardStore((s) => s.selectedIndex);
 
   const notificationsQuery = useQuery<GithubNotification[]>({
     queryKey: ["github", "notifications"],
@@ -81,10 +83,7 @@ function NotificationsImpl({ onOpen }: NotificationsProps): ReactElement {
     >
       {/* Header count shows the full, unfiltered notification total so the
           header number doesn't jitter as the user types in the search box. */}
-      <SectionHead
-        title="Notifications"
-        count={isLoading ? undefined : notifications.length}
-      />
+      <SectionHead title="Notifications" count={isLoading ? undefined : notifications.length} />
 
       {isLoading ? (
         <>
@@ -161,8 +160,13 @@ function NotificationsImpl({ onOpen }: NotificationsProps): ReactElement {
           ) : (
             <div ref={listRef} className="max-h-[600px] overflow-y-auto">
               <div className="flex flex-col gap-1">
-                {visible.map((n) => (
-                  <NotificationCard key={n.id} data={n} onOpen={onOpen} />
+                {visible.map((n, index) => (
+                  <NotificationCard
+                    key={n.id}
+                    data={n}
+                    isSelected={selectedIndex === index}
+                    onOpen={onOpen}
+                  />
                 ))}
               </div>
             </div>

--- a/src/components/Notifications/Notifications.tsx
+++ b/src/components/Notifications/Notifications.tsx
@@ -25,6 +25,7 @@ const NOTIFICATION_TABS: Readonly<Record<Tab, (n: GithubNotification) => boolean
 
 function NotificationsImpl({ onOpen }: NotificationsProps): ReactElement {
   const listRef = useRef<HTMLDivElement>(null);
+  const activeNavigableSection = useDashboardStore((s) => s.activeNavigableSection);
   const selectedIndex = useDashboardStore((s) => s.selectedIndex);
 
   const notificationsQuery = useQuery<GithubNotification[]>({
@@ -61,8 +62,14 @@ function NotificationsImpl({ onOpen }: NotificationsProps): ReactElement {
     listRef.current?.scrollTo({ top: 0, behavior: "instant" });
   }, [tab, normalizedQuery]);
 
+  useEffect(() => {
+    if (selectedIndex < 0 || activeNavigableSection !== "notifications") return;
+    const selectedCard = listRef.current?.querySelector<HTMLElement>('[data-selected="true"]');
+    selectedCard?.scrollIntoView({ block: "nearest" });
+  }, [activeNavigableSection, selectedIndex, visible]);
+
   const navItems = useMemo(() => visible.map((n) => ({ url: n.url })), [visible]);
-  useRegisterNavigableItems(navItems);
+  useRegisterNavigableItems(navItems, "notifications");
 
   const isLoading = notificationsQuery.isLoading;
   const isFetching = notificationsQuery.isFetching;
@@ -164,7 +171,9 @@ function NotificationsImpl({ onOpen }: NotificationsProps): ReactElement {
                   <NotificationCard
                     key={n.id}
                     data={n}
-                    isSelected={selectedIndex === index}
+                    isSelected={
+                      activeNavigableSection === "notifications" && selectedIndex === index
+                    }
                     onOpen={onOpen}
                   />
                 ))}

--- a/src/components/Overview/Overview.test.tsx
+++ b/src/components/Overview/Overview.test.tsx
@@ -227,12 +227,9 @@ describe("Overview", () => {
 
     renderWithProviders(<Overview />);
 
-    const activeSection = useDashboardStore.getState().activeNavigableSection;
-    expect(activeSection).not.toBeNull();
-
     act(() => {
       useDashboardStore.setState({
-        activeNavigableSection: activeSection,
+        activeNavigableSection: "reviews",
         selectedIndex: 0,
       });
     });

--- a/src/components/Overview/Overview.test.tsx
+++ b/src/components/Overview/Overview.test.tsx
@@ -1,5 +1,5 @@
 import { type ReactElement } from "react";
-import { render, screen, within } from "@testing-library/react";
+import { act, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { describe, expect, it, vi, beforeEach } from "vitest";
@@ -35,6 +35,7 @@ vi.mock("../../lib/tauri", () => ({
 
 import { useGitHubData } from "../../hooks/useGitHubData";
 import { markAllActivityRead } from "../../lib/tauri";
+import { useDashboardStore } from "../../stores/dashboard";
 
 const mockedUseGitHubData = vi.mocked(useGitHubData);
 const mockedMarkAllActivityRead = vi.mocked(markAllActivityRead);
@@ -134,6 +135,12 @@ function setupMock(dashboard: DashboardData | null = makeDashboard()) {
 beforeEach(() => {
   vi.restoreAllMocks();
   mockedMarkAllActivityRead.mockResolvedValue(0);
+  useDashboardStore.setState({
+    activeNavigableSection: null,
+    navigableSectionRegistrations: [],
+    selectedIndex: -1,
+    navigableItems: [],
+  });
 });
 
 describe("Overview", () => {
@@ -207,6 +214,30 @@ describe("Overview", () => {
 
     expect(within(secondaryGrid).getByTestId("my-prs")).toBeInTheDocument();
     expect(within(secondaryGrid).getByTestId("issues")).toBeInTheDocument();
+  });
+
+  it("should highlight only the active overview section during keyboard navigation", () => {
+    setupMock(
+      makeDashboard({
+        reviewRequests: [makePr(1)],
+        myPullRequests: [makePr(10)],
+        assignedIssues: [makeIssue(1)],
+      }),
+    );
+
+    renderWithProviders(<Overview />);
+
+    const activeSection = useDashboardStore.getState().activeNavigableSection;
+    expect(activeSection).not.toBeNull();
+
+    act(() => {
+      useDashboardStore.setState({
+        activeNavigableSection: activeSection,
+        selectedIndex: 0,
+      });
+    });
+
+    expect(document.querySelectorAll('[data-selected="true"]')).toHaveLength(1);
   });
 
   it("should limit review queue to 5 items", () => {

--- a/src/components/ReviewQueue/ReviewCard.test.tsx
+++ b/src/components/ReviewQueue/ReviewCard.test.tsx
@@ -43,6 +43,12 @@ describe("ReviewCard", () => {
     expect(screen.getByText("#42")).toBeInTheDocument();
   });
 
+  it("should show selected styling when keyboard-selected", () => {
+    render(<ReviewCard data={mockData} onOpen={vi.fn()} isSelected />);
+    const card = screen.getByText("Fix login bug").closest("div[data-selected='true']");
+    expect(card).toHaveClass("border-accent", "ring-2", "ring-accent");
+  });
+
   it("should render author name", () => {
     render(<ReviewCard data={mockData} onOpen={vi.fn()} />);
     expect(screen.getByText("alice")).toBeInTheDocument();
@@ -60,26 +66,16 @@ describe("ReviewCard", () => {
   });
 
   it("should show workspace badge", () => {
-    render(
-      <ReviewCard
-        data={mockData}
-        onOpen={vi.fn()}
-        onWorkspaceAction={vi.fn()}
-      />,
-    );
+    render(<ReviewCard data={mockData} onOpen={vi.fn()} onWorkspaceAction={vi.fn()} />);
     expect(screen.getByText("resume")).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "Resume workspace for PR #42" }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Resume workspace for PR #42" })).toBeInTheDocument();
   });
 
   it("should call onOpen on click", async () => {
     const handleOpen = vi.fn();
     render(<ReviewCard data={mockData} onOpen={handleOpen} />);
     await userEvent.click(screen.getByRole("link"));
-    expect(handleOpen).toHaveBeenCalledWith(
-      "https://github.com/org/repo/pull/42",
-    );
+    expect(handleOpen).toHaveBeenCalledWith("https://github.com/org/repo/pull/42");
   });
 
   it("should render without optional diff fields", () => {
@@ -99,13 +95,7 @@ describe("ReviewCard", () => {
 
   it("should call onWorkspaceAction when badge is clicked", async () => {
     const handleWs = vi.fn();
-    render(
-      <ReviewCard
-        data={mockData}
-        onOpen={vi.fn()}
-        onWorkspaceAction={handleWs}
-      />,
-    );
+    render(<ReviewCard data={mockData} onOpen={vi.fn()} onWorkspaceAction={handleWs} />);
     await userEvent.click(screen.getByRole("button"));
     expect(handleWs).toHaveBeenCalledWith({
       repoId: "repo-1",
@@ -128,9 +118,7 @@ describe("ReviewCard", () => {
       pullRequest: { ...mockData.pullRequest, state: "closed" },
       workspace: { id: "ws-1", state: "suspended", lastNoteContent: null },
     };
-    render(
-      <ReviewCard data={data} onOpen={vi.fn()} onWorkspaceAction={vi.fn()} />,
-    );
+    render(<ReviewCard data={data} onOpen={vi.fn()} onWorkspaceAction={vi.fn()} />);
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
   });
 

--- a/src/components/ReviewQueue/ReviewCard.test.tsx
+++ b/src/components/ReviewQueue/ReviewCard.test.tsx
@@ -46,6 +46,7 @@ describe("ReviewCard", () => {
   it("should show selected styling when keyboard-selected", () => {
     render(<ReviewCard data={mockData} onOpen={vi.fn()} isSelected />);
     const card = screen.getByText("Fix login bug").closest("div[data-selected='true']");
+    expect(card).toHaveAttribute("aria-current", "true");
     expect(card).toHaveClass("border-accent", "ring-2", "ring-accent");
   });
 

--- a/src/components/ReviewQueue/ReviewCard.tsx
+++ b/src/components/ReviewQueue/ReviewCard.tsx
@@ -52,6 +52,7 @@ export function ReviewCard({
   return (
     <div
       data-selected={isSelected ? "true" : undefined}
+      aria-current={isSelected ? "true" : undefined}
       className={`flex items-center gap-3 rounded border border-border px-3 py-2 hover:bg-surface-hover${
         isSelected ? ` ${SELECTED_ITEM_CLASS}` : ""
       }`}

--- a/src/components/ReviewQueue/ReviewCard.tsx
+++ b/src/components/ReviewQueue/ReviewCard.tsx
@@ -1,6 +1,7 @@
 import { type ReactElement, useState } from "react";
 import { FOCUS_RING } from "../../lib/a11y";
 import { timeAgo } from "../../lib/timeAgo";
+import { SELECTED_ITEM_CLASS } from "../../lib/uiClasses";
 import type { PullRequestWithReview } from "../../lib/types/dashboard";
 import { CI } from "../atoms/CI";
 import { Diff } from "../atoms/Diff";
@@ -10,6 +11,7 @@ import { WsBadge } from "../atoms/WsBadge";
 interface ReviewCardProps {
   readonly data: PullRequestWithReview;
   readonly onOpen: (url: string) => void;
+  readonly isSelected?: boolean;
   readonly onWorkspaceAction?: (params: {
     readonly repoId: string;
     readonly pullRequestNumber: number;
@@ -19,7 +21,12 @@ interface ReviewCardProps {
   }) => void;
 }
 
-export function ReviewCard({ data, onOpen, onWorkspaceAction }: ReviewCardProps): ReactElement {
+export function ReviewCard({
+  data,
+  onOpen,
+  isSelected = false,
+  onWorkspaceAction,
+}: ReviewCardProps): ReactElement {
   const { pullRequest: pr, workspace } = data;
   const [loading, setLoading] = useState(false);
 
@@ -43,7 +50,12 @@ export function ReviewCard({ data, onOpen, onWorkspaceAction }: ReviewCardProps)
   }
 
   return (
-    <div className="flex items-center gap-3 rounded border border-border px-3 py-2 hover:bg-surface-hover">
+    <div
+      data-selected={isSelected ? "true" : undefined}
+      className={`flex items-center gap-3 rounded border border-border px-3 py-2 hover:bg-surface-hover${
+        isSelected ? ` ${SELECTED_ITEM_CLASS}` : ""
+      }`}
+    >
       <a
         href={pr.url}
         onClick={handleClick}

--- a/src/components/ReviewQueue/ReviewQueue.memo.test.tsx
+++ b/src/components/ReviewQueue/ReviewQueue.memo.test.tsx
@@ -6,6 +6,11 @@ import { useDashboardStore } from "../../stores/dashboard";
 // Hoisted spy so the `vi.mock` factory (which is hoisted) can reference it.
 const { reviewCardSpy } = vi.hoisted(() => ({ reviewCardSpy: vi.fn() }));
 
+// Memoization tests should isolate child renders from dashboard registration side effects.
+vi.mock("../../hooks/useRegisterNavigableItems", () => ({
+  useRegisterNavigableItems: vi.fn(),
+}));
+
 // Replace ReviewCard with a light stub that counts render calls.
 vi.mock("./ReviewCard", () => ({
   ReviewCard: (props: Record<string, unknown>) => {

--- a/src/components/ReviewQueue/ReviewQueue.tsx
+++ b/src/components/ReviewQueue/ReviewQueue.tsx
@@ -61,6 +61,7 @@ function ReviewQueueImpl({
 }: ReviewQueueProps): ReactElement {
   const storePriority = useDashboardStore((s) => s.activeFilters.priority);
   const storeRepo = useDashboardStore((s) => s.activeFilters.repo);
+  const activeNavigableSection = useDashboardStore((s) => s.activeNavigableSection);
   const selectedIndex = useDashboardStore((s) => s.selectedIndex);
   const setFilter = useDashboardStore((s) => s.setFilter);
   const focusMode = useDashboardStore((s) => s.focusMode);
@@ -96,7 +97,7 @@ function ReviewQueueImpl({
     () => (isLoading ? [] : sorted.map((r) => ({ url: r.pullRequest.url }))),
     [isLoading, sorted],
   );
-  useRegisterNavigableItems(navItems);
+  useRegisterNavigableItems(navItems, "reviews");
 
   return (
     <section
@@ -184,7 +185,7 @@ function ReviewQueueImpl({
                 <ReviewCard
                   key={review.pullRequest.id}
                   data={review}
-                  isSelected={selectedIndex === index}
+                  isSelected={activeNavigableSection === "reviews" && selectedIndex === index}
                   onOpen={onOpen}
                   onWorkspaceAction={onWorkspaceAction}
                 />

--- a/src/components/ReviewQueue/ReviewQueue.tsx
+++ b/src/components/ReviewQueue/ReviewQueue.tsx
@@ -38,7 +38,6 @@ const FOCUS_PRIORITIES: readonly Priority[] = ["critical", "high"];
 
 const PRIORITY_FILTERS: readonly PriorityFilter[] = ["all", "critical", "high", "medium", "low"];
 
-
 function sortByPriority(
   reviews: readonly PullRequestWithReview[],
 ): readonly PullRequestWithReview[] {
@@ -62,6 +61,7 @@ function ReviewQueueImpl({
 }: ReviewQueueProps): ReactElement {
   const storePriority = useDashboardStore((s) => s.activeFilters.priority);
   const storeRepo = useDashboardStore((s) => s.activeFilters.repo);
+  const selectedIndex = useDashboardStore((s) => s.selectedIndex);
   const setFilter = useDashboardStore((s) => s.setFilter);
   const focusMode = useDashboardStore((s) => s.focusMode);
 
@@ -180,10 +180,11 @@ function ReviewQueueImpl({
             <EmptyState icon="✓" message="No pending reviews — you're all caught up!" />
           ) : (
             <div className="flex flex-col gap-1">
-              {sorted.map((review) => (
+              {sorted.map((review, index) => (
                 <ReviewCard
                   key={review.pullRequest.id}
                   data={review}
+                  isSelected={selectedIndex === index}
                   onOpen={onOpen}
                   onWorkspaceAction={onWorkspaceAction}
                 />

--- a/src/hooks/useRegisterNavigableItems.ts
+++ b/src/hooks/useRegisterNavigableItems.ts
@@ -1,17 +1,19 @@
 import { useEffect } from "react";
 import { useDashboardStore } from "../stores/dashboard";
-import type { NavigableItem } from "../stores/dashboard";
+import type { NavigableItem, NavigableSectionId } from "../stores/dashboard";
 
 export function useRegisterNavigableItems(
   items: readonly NavigableItem[],
+  sectionId: NavigableSectionId,
 ): void {
-  const setNavigableItems = useDashboardStore((s) => s.setNavigableItems);
+  const registerNavigableItems = useDashboardStore((s) => s.registerNavigableItems);
+  const unregisterNavigableSection = useDashboardStore((s) => s.unregisterNavigableSection);
 
   useEffect(() => {
-    setNavigableItems(items);
-  }, [items, setNavigableItems]);
+    registerNavigableItems(sectionId, items);
+  }, [items, registerNavigableItems, sectionId]);
 
   useEffect(() => {
-    return () => setNavigableItems([]);
-  }, [setNavigableItems]);
+    return () => unregisterNavigableSection(sectionId);
+  }, [sectionId, unregisterNavigableSection]);
 }

--- a/src/lib/uiClasses.ts
+++ b/src/lib/uiClasses.ts
@@ -11,19 +11,23 @@ import { FOCUS_RING } from "./a11y";
  * Square-ish filter button used on list headers (Issues, MyPRs, ReviewQueue,
  * ActivityFeed). Sized to the 44px minimum touch target.
  */
-export const FILTER_BUTTON_CLASS =
-  `${FOCUS_RING} inline-flex min-h-11 min-w-11 items-center justify-center rounded px-3 text-xs leading-none transition-colors`;
+export const FILTER_BUTTON_CLASS = `${FOCUS_RING} inline-flex min-h-11 min-w-11 items-center justify-center rounded px-3 text-xs leading-none transition-colors`;
 
 /**
  * Inline action button used alongside filters (e.g. "Mark all read" in the
  * activity feed).
  */
-export const ACTION_BUTTON_CLASS =
-  `${FOCUS_RING} inline-flex min-h-11 items-center rounded px-3 text-xs transition-colors`;
+export const ACTION_BUTTON_CLASS = `${FOCUS_RING} inline-flex min-h-11 items-center rounded px-3 text-xs transition-colors`;
 
 /**
  * Inline control (e.g. native `<select>`) used alongside filter buttons in list
  * headers (ReviewQueue, MyPRs, Issues).
  */
-export const INLINE_CONTROL_CLASS =
-  `${FOCUS_RING} min-h-11 rounded px-3 text-xs transition-colors`;
+export const INLINE_CONTROL_CLASS = `${FOCUS_RING} min-h-11 rounded px-3 text-xs transition-colors`;
+
+/**
+ * Shared visual treatment for the currently keyboard-selected list item.
+ * Matches the accent focus language without moving DOM focus.
+ */
+export const SELECTED_ITEM_CLASS =
+  "border-accent bg-surface-hover ring-2 ring-accent ring-offset-2 ring-offset-transparent";

--- a/src/stores/dashboard.test.ts
+++ b/src/stores/dashboard.test.ts
@@ -3,7 +3,14 @@ import { useDashboardStore } from "./dashboard";
 
 describe("useDashboardStore", () => {
   beforeEach(() => {
-    useDashboardStore.setState({ currentView: "overview", activeFilters: {} });
+    useDashboardStore.setState({
+      currentView: "overview",
+      activeFilters: {},
+      activeNavigableSection: null,
+      navigableSectionRegistrations: [],
+      selectedIndex: -1,
+      navigableItems: [],
+    });
   });
 
   it("should have default view as overview", () => {
@@ -179,17 +186,52 @@ describe("useDashboardStore", () => {
 
     it("should keep selectedIndex when navigable items change but index is in bounds", () => {
       useDashboardStore.setState({ selectedIndex: 1 });
-      useDashboardStore.getState().setNavigableItems([
-        { url: "https://a.com" },
-        { url: "https://b.com" },
-        { url: "https://c.com" },
-      ]);
+      useDashboardStore
+        .getState()
+        .setNavigableItems([
+          { url: "https://a.com" },
+          { url: "https://b.com" },
+          { url: "https://c.com" },
+        ]);
       expect(useDashboardStore.getState().selectedIndex).toBe(1);
     });
 
     it("should reset selectedIndex to -1 when items become empty", () => {
       useDashboardStore.setState({ selectedIndex: 2 });
       useDashboardStore.getState().setNavigableItems([]);
+      expect(useDashboardStore.getState().selectedIndex).toBe(-1);
+    });
+
+    it("should track the active navigable section from the latest registration", () => {
+      useDashboardStore
+        .getState()
+        .registerNavigableItems("reviews", [{ url: "https://example.com/reviews/1" }]);
+      useDashboardStore
+        .getState()
+        .registerNavigableItems("issues", [{ url: "https://example.com/issues/1" }]);
+
+      expect(useDashboardStore.getState().activeNavigableSection).toBe("issues");
+      expect(useDashboardStore.getState().navigableItems).toEqual([
+        { url: "https://example.com/issues/1" },
+      ]);
+      expect(useDashboardStore.getState().selectedIndex).toBe(-1);
+    });
+
+    it("should fall back to the previous registered section when the active one unregisters", () => {
+      useDashboardStore
+        .getState()
+        .registerNavigableItems("reviews", [{ url: "https://example.com/reviews/1" }]);
+      useDashboardStore
+        .getState()
+        .registerNavigableItems("issues", [{ url: "https://example.com/issues/1" }]);
+      useDashboardStore.getState().navigateList("down");
+
+      useDashboardStore.getState().unregisterNavigableSection("issues");
+
+      expect(useDashboardStore.getState().activeNavigableSection).toBe("reviews");
+      expect(useDashboardStore.getState().navigableItems).toEqual([
+        { url: "https://example.com/reviews/1" },
+      ]);
       expect(useDashboardStore.getState().selectedIndex).toBe(-1);
     });
   });

--- a/src/stores/dashboard.test.ts
+++ b/src/stores/dashboard.test.ts
@@ -197,15 +197,37 @@ describe("useDashboardStore", () => {
     });
 
     it("should reset selectedIndex to -1 when items become empty", () => {
-      useDashboardStore.setState({ selectedIndex: 2 });
+      useDashboardStore.setState({
+        selectedIndex: 2,
+        activeNavigableSection: "reviews",
+        navigableSectionRegistrations: [{ sectionId: "reviews", items }],
+      });
       useDashboardStore.getState().setNavigableItems([]);
       expect(useDashboardStore.getState().selectedIndex).toBe(-1);
+      expect(useDashboardStore.getState().activeNavigableSection).toBeNull();
+      expect(useDashboardStore.getState().navigableSectionRegistrations).toEqual([]);
     });
 
-    it("should track the active navigable section from the latest registration", () => {
+    it("should keep the first active section until ownership changes explicitly", () => {
       useDashboardStore
         .getState()
         .registerNavigableItems("reviews", [{ url: "https://example.com/reviews/1" }]);
+      useDashboardStore
+        .getState()
+        .registerNavigableItems("issues", [{ url: "https://example.com/issues/1" }]);
+
+      expect(useDashboardStore.getState().activeNavigableSection).toBe("reviews");
+      expect(useDashboardStore.getState().navigableItems).toEqual([
+        { url: "https://example.com/reviews/1" },
+      ]);
+      expect(useDashboardStore.getState().selectedIndex).toBe(-1);
+    });
+
+    it("should switch to a later section when ownership changes explicitly", () => {
+      useDashboardStore
+        .getState()
+        .registerNavigableItems("reviews", [{ url: "https://example.com/reviews/1" }]);
+      useDashboardStore.setState({ activeNavigableSection: "issues" });
       useDashboardStore
         .getState()
         .registerNavigableItems("issues", [{ url: "https://example.com/issues/1" }]);
@@ -217,14 +239,42 @@ describe("useDashboardStore", () => {
       expect(useDashboardStore.getState().selectedIndex).toBe(-1);
     });
 
-    it("should fall back to the previous registered section when the active one unregisters", () => {
+    it("should keep the active section when another section updates in the background", () => {
       useDashboardStore
         .getState()
         .registerNavigableItems("reviews", [{ url: "https://example.com/reviews/1" }]);
       useDashboardStore
         .getState()
         .registerNavigableItems("issues", [{ url: "https://example.com/issues/1" }]);
-      useDashboardStore.getState().navigateList("down");
+      useDashboardStore.setState({
+        activeNavigableSection: "reviews",
+        navigableItems: [{ url: "https://example.com/reviews/1" }],
+        selectedIndex: 0,
+      });
+
+      useDashboardStore
+        .getState()
+        .registerNavigableItems("issues", [{ url: "https://example.com/issues/2" }]);
+
+      expect(useDashboardStore.getState().activeNavigableSection).toBe("reviews");
+      expect(useDashboardStore.getState().navigableItems).toEqual([
+        { url: "https://example.com/reviews/1" },
+      ]);
+      expect(useDashboardStore.getState().selectedIndex).toBe(0);
+    });
+
+    it("should fall back to the previous registered section when the active one unregisters", () => {
+      useDashboardStore
+        .getState()
+        .registerNavigableItems("reviews", [{ url: "https://example.com/reviews/1" }]);
+      useDashboardStore.setState({
+        activeNavigableSection: "issues",
+        navigableItems: [{ url: "https://example.com/issues/1" }],
+        selectedIndex: 0,
+      });
+      useDashboardStore
+        .getState()
+        .registerNavigableItems("issues", [{ url: "https://example.com/issues/1" }]);
 
       useDashboardStore.getState().unregisterNavigableSection("issues");
 

--- a/src/stores/dashboard.ts
+++ b/src/stores/dashboard.ts
@@ -62,6 +62,14 @@ function pickActiveRegistration(
   return null;
 }
 
+function findRegistrationBySection(
+  registrations: readonly NavigableSectionRegistration[],
+  sectionId: NavigableSectionId | null,
+): NavigableSectionRegistration | null {
+  if (!sectionId) return null;
+  return registrations.find((registration) => registration.sectionId === sectionId) ?? null;
+}
+
 export const useDashboardStore = create<DashboardState>((set) => ({
   currentView: "overview",
   activeFilters: {},
@@ -105,7 +113,14 @@ export const useDashboardStore = create<DashboardState>((set) => ({
     }),
   setNavigableItems: (items) =>
     set((state) => {
-      if (items.length === 0) return { navigableItems: items, selectedIndex: -1 };
+      if (items.length === 0) {
+        return {
+          navigableItems: items,
+          selectedIndex: -1,
+          activeNavigableSection: null,
+          navigableSectionRegistrations: [],
+        };
+      }
       const clamped = state.selectedIndex >= items.length ? items.length - 1 : state.selectedIndex;
       return {
         navigableItems: items,
@@ -116,14 +131,22 @@ export const useDashboardStore = create<DashboardState>((set) => ({
     }),
   registerNavigableItems: (sectionId, items) =>
     set((state) => {
-      const registrations = [
-        ...state.navigableSectionRegistrations.filter(
-          (registration) => registration.sectionId !== sectionId,
-        ),
-      ];
-      if (items.length > 0) registrations.push({ sectionId, items });
+      const registrations = [...state.navigableSectionRegistrations];
+      const existingIndex = registrations.findIndex(
+        (registration) => registration.sectionId === sectionId,
+      );
 
-      const activeRegistration = pickActiveRegistration(registrations);
+      if (items.length === 0) {
+        if (existingIndex >= 0) registrations.splice(existingIndex, 1);
+      } else if (existingIndex >= 0) {
+        registrations[existingIndex] = { sectionId, items };
+      } else {
+        registrations.push({ sectionId, items });
+      }
+
+      const activeRegistration =
+        findRegistrationBySection(registrations, state.activeNavigableSection) ??
+        pickActiveRegistration(registrations);
       if (!activeRegistration) {
         return {
           navigableSectionRegistrations: registrations,

--- a/src/stores/dashboard.ts
+++ b/src/stores/dashboard.ts
@@ -22,11 +22,20 @@ export interface NavigableItem {
   readonly workspaceId?: string;
 }
 
+export type NavigableSectionId = "reviews" | "mine" | "issues" | "notifications";
+
+interface NavigableSectionRegistration {
+  readonly sectionId: NavigableSectionId;
+  readonly items: readonly NavigableItem[];
+}
+
 interface DashboardUiState {
   readonly currentView: DashboardView;
   readonly activeFilters: DashboardFilters;
   readonly selectedIndex: number;
   readonly navigableItems: readonly NavigableItem[];
+  readonly activeNavigableSection: NavigableSectionId | null;
+  readonly navigableSectionRegistrations: readonly NavigableSectionRegistration[];
   readonly focusMode: boolean;
 }
 
@@ -36,19 +45,39 @@ interface DashboardActions {
   clearFilters: () => void;
   navigateList: (direction: "up" | "down") => void;
   setNavigableItems: (items: readonly NavigableItem[]) => void;
+  registerNavigableItems: (sectionId: NavigableSectionId, items: readonly NavigableItem[]) => void;
+  unregisterNavigableSection: (sectionId: NavigableSectionId) => void;
   toggleFocusMode: () => void;
 }
 
 type DashboardState = DashboardUiState & DashboardActions;
+
+function pickActiveRegistration(
+  registrations: readonly NavigableSectionRegistration[],
+): NavigableSectionRegistration | null {
+  for (let index = registrations.length - 1; index >= 0; index -= 1) {
+    const registration = registrations[index];
+    if (registration && registration.items.length > 0) return registration;
+  }
+  return null;
+}
 
 export const useDashboardStore = create<DashboardState>((set) => ({
   currentView: "overview",
   activeFilters: {},
   selectedIndex: -1,
   navigableItems: [],
+  activeNavigableSection: null,
+  navigableSectionRegistrations: [],
   focusMode: false,
   setView: (view) =>
-    set({ currentView: view, selectedIndex: -1, navigableItems: [] }),
+    set({
+      currentView: view,
+      selectedIndex: -1,
+      navigableItems: [],
+      activeNavigableSection: null,
+      navigableSectionRegistrations: [],
+    }),
   setFilter: (filter) =>
     set((state) => {
       const prev = state.activeFilters;
@@ -77,12 +106,67 @@ export const useDashboardStore = create<DashboardState>((set) => ({
   setNavigableItems: (items) =>
     set((state) => {
       if (items.length === 0) return { navigableItems: items, selectedIndex: -1 };
-      const clamped =
-        state.selectedIndex >= items.length
-          ? items.length - 1
-          : state.selectedIndex;
-      return { navigableItems: items, selectedIndex: clamped };
+      const clamped = state.selectedIndex >= items.length ? items.length - 1 : state.selectedIndex;
+      return {
+        navigableItems: items,
+        selectedIndex: clamped,
+        activeNavigableSection: null,
+        navigableSectionRegistrations: [],
+      };
     }),
-  toggleFocusMode: () =>
-    set((state) => ({ focusMode: !state.focusMode })),
+  registerNavigableItems: (sectionId, items) =>
+    set((state) => {
+      const registrations = [
+        ...state.navigableSectionRegistrations.filter(
+          (registration) => registration.sectionId !== sectionId,
+        ),
+      ];
+      if (items.length > 0) registrations.push({ sectionId, items });
+
+      const activeRegistration = pickActiveRegistration(registrations);
+      if (!activeRegistration) {
+        return {
+          navigableSectionRegistrations: registrations,
+          activeNavigableSection: null,
+          navigableItems: [],
+          selectedIndex: -1,
+        };
+      }
+
+      const shouldKeepSelection = state.activeNavigableSection === activeRegistration.sectionId;
+      const clampedSelectedIndex = shouldKeepSelection
+        ? Math.min(state.selectedIndex, activeRegistration.items.length - 1)
+        : -1;
+
+      return {
+        navigableSectionRegistrations: registrations,
+        activeNavigableSection: activeRegistration.sectionId,
+        navigableItems: activeRegistration.items,
+        selectedIndex: clampedSelectedIndex,
+      };
+    }),
+  unregisterNavigableSection: (sectionId) =>
+    set((state) => {
+      const registrations = state.navigableSectionRegistrations.filter(
+        (registration) => registration.sectionId !== sectionId,
+      );
+      const activeRegistration = pickActiveRegistration(registrations);
+      if (!activeRegistration) {
+        return {
+          navigableSectionRegistrations: [],
+          activeNavigableSection: null,
+          navigableItems: [],
+          selectedIndex: -1,
+        };
+      }
+
+      return {
+        navigableSectionRegistrations: registrations,
+        activeNavigableSection: activeRegistration.sectionId,
+        navigableItems: activeRegistration.items,
+        selectedIndex:
+          state.activeNavigableSection === activeRegistration.sectionId ? state.selectedIndex : -1,
+      };
+    }),
+  toggleFocusMode: () => set((state) => ({ focusMode: !state.focusMode })),
 }));


### PR DESCRIPTION
## Summary
- add a shared selected-item style for keyboard navigation in dashboard lists
- pass `selectedIndex` from navigable list containers into review, my PR, issue, and notification cards
- cover the visible selected state with targeted component tests

## Root Cause
The dashboard store updated `selectedIndex` when using `j` / `k`, but the rendered list items did not consume that state to show any visual selection.

## Validation
- `npm test -- src/components/ReviewQueue/ReviewCard.test.tsx src/components/ReviewQueue/ReviewQueue.test.tsx src/components/MyPRs/MyPrCard.test.tsx src/components/MyPRs/MyPRs.test.tsx src/components/Issues/IssueCard.test.tsx src/components/Issues/Issues.test.tsx src/components/Notifications/NotificationCard.test.tsx src/components/Notifications/Notifications.test.tsx`
- `npm run lint`
- `npm run build`

Closes #247

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds visible keyboard selection across dashboard lists and keeps the active item in view during j/k navigation. Fixes #247 by wiring selection into all cards, adding `data-selected`/`aria-current`, and scoping navigation by section.

- **Bug Fixes**
  - Apply `isSelected` to `ReviewCard`, `MyPrCard`, `IssueCard`, and `NotificationCard`; add `data-selected`, `aria-current`, and shared `SELECTED_ITEM_CLASS`.
  - Section‑scoped navigation via `useRegisterNavigableItems(sectionId)` and store `registerNavigableItems`/`unregisterNavigableSection`; highlight only the active section and clamp/reset selection on updates.
  - Auto-scroll selected items: `Issues` virtualizer calls `scrollToIndex`; `MyPRs` and `Notifications` scroll the selected card into view.
  - Tests updated for selection visuals, ARIA state, scrolling, and section registration/ownership; memoization tests mock `useRegisterNavigableItems` to isolate registration side effects.

<sup>Written for commit 4a172ef14c25a04602e1e6ecf08b7ddc6d03e3aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Keyboard-selectable items across Issues, Pull Requests, Notifications, and Review Queue with visible selected styling and ARIA current state.
  * Auto-scroll to the focused/selected item during keyboard navigation.
  * Shared selected-item styling applied across lists.

* **Refactor**
  * Navigation updated to section-scoped keyboard navigation with per-section selection tracking and registration lifecycle.

* **Tests**
  * Added/expanded tests for selection styling, ARIA state, scroll-into-view behavior, and navigable-section logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->