### PR TITLE
fix(ui): add unread badge for Notifications in sidebar

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -13,6 +13,7 @@ vi.mock("./lib/tauri", async (importOriginal) => {
   return {
     ...actual,
     authGetStatus: vi.fn().mockResolvedValue({ connected: true, username: "test-user", error: null }),
+    listNotifications: vi.fn().mockResolvedValue([]),
   };
 });
 

--- a/src/components/Sidebar/Sidebar.test.tsx
+++ b/src/components/Sidebar/Sidebar.test.tsx
@@ -66,6 +66,38 @@ vi.mock("../../lib/tauri", () => ({
       lastSyncAt: "2026-03-28T10:00:00Z",
     },
   ]),
+  listNotifications: vi.fn().mockResolvedValue([
+    {
+      id: "notif-1",
+      title: "Unread review request",
+      url: "https://github.com/acme/frontend/pull/1",
+      unread: true,
+      updatedAt: "2026-03-28T10:00:00Z",
+      repo: "acme/frontend",
+      reason: "review_requested",
+      notificationType: "pull_request",
+    },
+    {
+      id: "notif-2",
+      title: "Unread issue mention",
+      url: "https://github.com/acme/frontend/issues/2",
+      unread: true,
+      updatedAt: "2026-03-28T11:00:00Z",
+      repo: "acme/frontend",
+      reason: "mention",
+      notificationType: "issue",
+    },
+    {
+      id: "notif-3",
+      title: "Read merge comment",
+      url: "https://github.com/acme/frontend/pull/3",
+      unread: false,
+      updatedAt: "2026-03-28T12:00:00Z",
+      repo: "acme/frontend",
+      reason: "comment",
+      notificationType: "pull_request",
+    },
+  ]),
   setRepoEnabled: vi.fn().mockResolvedValue({}),
   authGetStatus: vi.fn().mockResolvedValue({
     connected: true,
@@ -107,6 +139,11 @@ describe("Sidebar", () => {
   it("should show review count", () => {
     renderSidebar();
     expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("should show unread notification count", async () => {
+    renderSidebar();
+    expect(await screen.findByRole("button", { name: /notifications \(2\)/i })).toBeInTheDocument();
   });
 
   it("should show workspace dots with state colors", () => {

--- a/src/components/Sidebar/Sidebar.test.tsx
+++ b/src/components/Sidebar/Sidebar.test.tsx
@@ -75,7 +75,7 @@ vi.mock("../../lib/tauri", () => ({
       updatedAt: "2026-03-28T10:00:00Z",
       repo: "acme/frontend",
       reason: "review_requested",
-      notificationType: "pull_request",
+      notificationType: "pullRequest",
     },
     {
       id: "notif-2",
@@ -95,7 +95,7 @@ vi.mock("../../lib/tauri", () => ({
       updatedAt: "2026-03-28T12:00:00Z",
       repo: "acme/frontend",
       reason: "comment",
-      notificationType: "pull_request",
+      notificationType: "pullRequest",
     },
   ]),
   setRepoEnabled: vi.fn().mockResolvedValue({}),

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -6,7 +6,7 @@ import type { DashboardView } from "../../stores/dashboard";
 import { useWorkspacesStore } from "../../stores/workspaces";
 import { useGitHubData } from "../../hooks/useGitHubData";
 import { FOCUS_RING } from "../../lib/a11y";
-import { listRepos, setRepoEnabled, authGetStatus } from "../../lib/tauri";
+import { listNotifications, listRepos, setRepoEnabled, authGetStatus } from "../../lib/tauri";
 import { NavItem } from "./NavItem";
 import { WorkspaceList } from "./WorkspaceList";
 import { RepoList } from "./RepoList";
@@ -54,6 +54,12 @@ export function Sidebar(): ReactElement {
     refetchOnWindowFocus: false,
   });
 
+  const notificationsQuery = useQuery({
+    queryKey: ["github", "notifications"],
+    queryFn: listNotifications,
+    staleTime: 60_000,
+  });
+
   const toggleRepoMutation = useMutation({
     mutationFn: ({ repoId, enabled }: { repoId: string; enabled: boolean }) =>
       setRepoEnabled(repoId, enabled),
@@ -87,6 +93,7 @@ export function Sidebar(): ReactElement {
   const repos = reposQuery.data ?? [];
   const enabledRepos = repos.filter((r) => r.enabled);
   const username = authQuery.data?.username ?? null;
+  const unreadNotificationsCount = notificationsQuery.data?.filter((item) => item.unread).length;
 
   useEffect(() => {
     if (typeof document !== "undefined" && navGroupRef.current?.contains(document.activeElement)) {
@@ -173,7 +180,13 @@ export function Sidebar(): ReactElement {
             }}
             label={item.label}
             view={item.view}
-            count={item.countKey && stats ? stats[item.countKey] : undefined}
+            count={
+              item.view === "notifications"
+                ? unreadNotificationsCount
+                : item.countKey && stats
+                  ? stats[item.countKey]
+                  : undefined
+            }
             isActive={currentView === item.view}
             tabIndex={focusedView === item.view ? 0 : -1}
             onClick={handleNavClick}

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -54,10 +54,13 @@ export function Sidebar(): ReactElement {
     refetchOnWindowFocus: false,
   });
 
+  const isGitHubConnected = authQuery.data?.connected === true;
+
   const notificationsQuery = useQuery({
     queryKey: ["github", "notifications"],
     queryFn: listNotifications,
     staleTime: 60_000,
+    enabled: isGitHubConnected,
   });
 
   const toggleRepoMutation = useMutation({
@@ -93,7 +96,8 @@ export function Sidebar(): ReactElement {
   const repos = reposQuery.data ?? [];
   const enabledRepos = repos.filter((r) => r.enabled);
   const username = authQuery.data?.username ?? null;
-  const unreadNotificationsCount = notificationsQuery.data?.filter((item) => item.unread).length;
+  const unreadNotificationsCount =
+    notificationsQuery.data?.filter((item) => item.unread).length ?? 0;
 
   useEffect(() => {
     if (typeof document !== "undefined" && navGroupRef.current?.contains(document.activeElement)) {


### PR DESCRIPTION
## Summary
- load GitHub notifications in the sidebar and count unread items
- show the unread count badge on the Notifications nav item using the existing `NavItem` badge UI
- update sidebar and app tests to cover the new query and badge rendering

## Validation
- `npm run test -- src/components/Sidebar/Sidebar.test.tsx`
- `npm run test -- src/App.test.tsx`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/oxlint src/components/Sidebar/Sidebar.tsx src/components/Sidebar/Sidebar.test.tsx src/App.test.tsx`

Closes #248

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows an unread count badge on the Notifications nav item by fetching GitHub notifications and counting unread items. Adds tests and gates the fetch behind GitHub auth, fixing #248.

- **New Features**
  - Fetch notifications via `listNotifications` with React Query (staleTime: 60s), enabled only when connected to GitHub.
  - Compute unread count and pass it to `NavItem` for the Notifications view.

<sup>Written for commit 3bfee63a102f8933f1571dc4e7d40ef76b8d0a66. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Sidebar now displays a notifications counter showing your unread GitHub notification count in real-time.

* **Tests**
  * Added test coverage for the notifications counter functionality to verify accurate unread count tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->