### PR TITLE
fix(a11y): use a single h1 on overview

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -75,6 +75,17 @@ describe("App layout", () => {
     expect(await screen.findByTestId("overview")).toBeInTheDocument();
   });
 
+  it("should expose a single level-one heading on the overview screen", async () => {
+    renderApp();
+
+    expect(await screen.findByTestId("overview")).toBeInTheDocument();
+    expect(screen.getAllByRole("heading", { level: 1 })).toHaveLength(1);
+    expect(screen.getByRole("heading", { level: 1, name: "PRism" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { level: 2, name: "Review requests come first" }),
+    ).toBeInTheDocument();
+  });
+
   it("should render my-prs view", async () => {
     useDashboardStore.setState({ currentView: "mine" });
     renderApp();

--- a/src/components/Overview/Overview.test.tsx
+++ b/src/components/Overview/Overview.test.tsx
@@ -158,6 +158,20 @@ describe("Overview", () => {
     expect(screen.getByText("PR #2")).toBeInTheDocument();
   });
 
+  it("should use a level-two heading for the priority lane title", () => {
+    setupMock(
+      makeDashboard({
+        reviewRequests: [makePr(1)],
+      }),
+    );
+
+    renderWithProviders(<Overview />);
+
+    expect(
+      screen.getByRole("heading", { name: "Review requests come first", level: 2 }),
+    ).toBeInTheDocument();
+  });
+
   it("should render my PRs section", () => {
     setupMock(
       makeDashboard({

--- a/src/components/Overview/Overview.tsx
+++ b/src/components/Overview/Overview.tsx
@@ -122,7 +122,7 @@ export function Overview(): ReactElement {
               <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-accent">
                 Priority lane
               </p>
-              <h1 className="text-lg font-semibold text-white">Review requests come first</h1>
+              <h2 className="text-lg font-semibold text-white">Review requests come first</h2>
               <p className="max-w-2xl text-sm text-dim">
                 Surface the PRs that need your attention now so approvals and requested changes do
                 not get buried under passive updates.


### PR DESCRIPTION
## Summary
- replace the secondary `Overview` page title with an `h2` so the screen has a single level-one heading
- add a component test for the priority lane heading level
- add an app-level test to assert the Overview screen exposes exactly one `h1`

## Root cause
The Overview screen rendered its own `h1` for the priority lane while the application shell already exposed the product title as the page-level `h1`, creating a heading hierarchy violation.

## Impact
- fixes the a11y issue reported in #249
- improves heading semantics for screen reader navigation
- adds regression coverage at both component and screen level

## Validation
- `npm test -- src/components/Overview/Overview.test.tsx src/App.test.tsx`
- `npm run lint`

Closes #249

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the Overview screen exposes a single h1 by demoting the priority lane title to an h2. Adds app- and component-level tests to enforce the heading hierarchy and prevent regressions (closes #249).

<sup>Written for commit 14a4004fd6ec3882c35fbb5acfbd9441af7a3d97. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test cases verifying app layout structure and heading hierarchy in the priority lane section.

* **Refactor**
  * Updated heading hierarchy in the priority lane section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->